### PR TITLE
Implement gRPC translation client

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ subtitle-manager translate [input] [output] [lang]
 subtitle-manager history
 ```
 
-Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. API keys may be specified via flags `--google-key` and `--openai-key` or in the configuration file. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`.
+Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. API keys may be specified via flags `--google-key` and `--openai-key` or in the configuration file. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`.  Translation can be delegated to a remote gRPC server using the `--grpc` flag and providing an address such as `localhost:50051`.
 
 Example configuration:
 

--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,7 @@ This file tracks planned work, architectural decisions, and implementation statu
    - Test command behaviour with edge cases.
 
 6. **Remote Services**
-   - Expose translation via a gRPC server and client.
+   - Expose translation via a gRPC server and client. *(client implemented)*
    - Document protobuf messages and regeneration steps.
 
 7. **Future Enhancements**

--- a/cmd/grpcserver/main.go
+++ b/cmd/grpcserver/main.go
@@ -18,7 +18,7 @@ type server struct {
 }
 
 func (s *server) Translate(ctx context.Context, req *pb.TranslateRequest) (*pb.TranslateResponse, error) {
-	text, err := translator.Translate("google", req.Text, req.Language, s.googleKey, s.gptKey)
+	text, err := translator.Translate("google", req.Text, req.Language, s.googleKey, s.gptKey, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -22,13 +22,14 @@ var translateCmd = &cobra.Command{
 		service := viper.GetString("translate_service")
 		gKey := viper.GetString("google_api_key")
 		gptKey := viper.GetString("openai_api_key")
+		grpcAddr := viper.GetString("grpc_addr")
 		sub, err := astisub.OpenFile(in)
 		if err != nil {
 			return err
 		}
 		for _, item := range sub.Items {
 			text := item.String()
-			t, err := translator.Translate(service, text, lang, gKey, gptKey)
+			t, err := translator.Translate(service, text, lang, gKey, gptKey, grpcAddr)
 			if err != nil {
 				return err
 			}
@@ -56,10 +57,12 @@ var translateCmd = &cobra.Command{
 }
 
 func init() {
-	translateCmd.Flags().String("service", "google", "translation service: google or gpt")
+	translateCmd.Flags().String("service", "google", "translation service: google, gpt or grpc")
 	viper.BindPFlag("translate_service", translateCmd.Flags().Lookup("service"))
 	translateCmd.Flags().String("google-key", "", "Google Translate API key")
 	viper.BindPFlag("google_api_key", translateCmd.Flags().Lookup("google-key"))
 	translateCmd.Flags().String("openai-key", "", "OpenAI API key")
 	viper.BindPFlag("openai_api_key", translateCmd.Flags().Lookup("openai-key"))
+	translateCmd.Flags().String("grpc", "", "use remote gRPC translator at host:port")
+	viper.BindPFlag("grpc_addr", translateCmd.Flags().Lookup("grpc"))
 }

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -1,12 +1,17 @@
 package translator
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"google.golang.org/grpc"
+	pb "subtitle-manager/pkg/translatorpb/proto"
 )
 
 func TestGoogleTranslate(t *testing.T) {
@@ -49,11 +54,57 @@ func TestTranslate(t *testing.T) {
 	SetGoogleAPIURL(srv.URL)
 	defer SetGoogleAPIURL(origURL)
 
-	got, err := Translate("google", "hello", "es", "test", "")
+	got, err := Translate("google", "hello", "es", "test", "", "")
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
 	if got != "hola" {
 		t.Fatalf("expected hola, got %s", got)
 	}
+}
+
+func TestGRPCTranslate(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := grpc.NewServer()
+	pb.RegisterTranslatorServer(s, &mockServer{})
+	go s.Serve(lis)
+	defer s.Stop()
+
+	got, err := GRPCTranslate("hello", "es", lis.Addr().String())
+	if err != nil {
+		t.Fatalf("grpc translate: %v", err)
+	}
+	if got != "hola" {
+		t.Fatalf("expected hola, got %s", got)
+	}
+}
+
+func TestTranslateGRPCProvider(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := grpc.NewServer()
+	pb.RegisterTranslatorServer(s, &mockServer{})
+	go s.Serve(lis)
+	defer s.Stop()
+
+	got, err := Translate("grpc", "hello", "es", "", "", lis.Addr().String())
+	if err != nil {
+		t.Fatalf("translate grpc: %v", err)
+	}
+	if got != "hola" {
+		t.Fatalf("expected hola, got %s", got)
+	}
+}
+
+type mockServer struct {
+	pb.UnimplementedTranslatorServer
+}
+
+func (mockServer) Translate(ctx context.Context, req *pb.TranslateRequest) (*pb.TranslateResponse, error) {
+	return &pb.TranslateResponse{TranslatedText: "hola"}, nil
 }


### PR DESCRIPTION
## Summary
- implement gRPC-based translation provider
- add --grpc flag to `translate` command
- update README to document remote translation option
- note gRPC client status in TODO
- test gRPC provider

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68438d582fd08321b322e317b21519dc