### PR TITLE
Implement basic subtitle provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,8 @@ All notable changes to this project will be documented in this file.
 - React based web UI built with Vite under `webui/`.
 - `web` command to serve the embedded single page application.
 - Technical design and TODO updated with web front end plan.
+
+## [0.1.4] - 2025-06-09
+### Added
+- OpenSubtitles provider and `fetch` CLI command.
+- Provider implementation documented in README and TODO.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Store translation history in an SQLite database.
 - Per component logging with adjustable levels.
 - Extract subtitles from media containers using ffmpeg.
+- Download subtitles from OpenSubtitles.
 
 ## Installation
 
@@ -29,6 +30,7 @@ subtitle-manager merge [sub1] [sub2] [output]
 subtitle-manager translate [input] [output] [lang]
 subtitle-manager history
 subtitle-manager extract [media] [output]
+subtitle-manager fetch opensubtitles [media] [lang] [output]
 ```
 
 ### Web UI

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 
 1. **Feature Parity with Bazarr**
    - Monitor media libraries for new subtitles.
-   - Support multiple subtitle providers.
+   - Support multiple subtitle providers. *(OpenSubtitles implemented)*
    - Download, manage and upgrade subtitles automatically.
    - Integrate with media servers (e.g. Plex, Emby).
 

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -22,11 +22,7 @@ var extractCmd = &cobra.Command{
 			return err
 		}
 		sub := astisub.NewSubtitles()
-		var convertedItems []astisub.Item
-		for _, item := range items {
-			convertedItems = append(convertedItems, *item)
-		}
-		sub.Items = convertedItems
+		sub.Items = items
 		f, err := os.Create(out)
 		if err != nil {
 			return err

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,47 @@
+// file: cmd/fetch.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/providers/opensubtitles"
+)
+
+// fetchCmd downloads subtitles for a media file using a provider.
+var fetchCmd = &cobra.Command{
+	Use:   "fetch [provider] [media] [lang] [output]",
+	Short: "Download subtitles using a provider",
+	Args:  cobra.ExactArgs(4),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("fetch")
+		name, media, lang, out := args[0], args[1], args[2], args[3]
+		var p providers.Provider
+		switch name {
+		case "opensubtitles":
+			key := viper.GetString("opensubtitles.api_key")
+			p = opensubtitles.New(key)
+		default:
+			return fmt.Errorf("unknown provider %s", name)
+		}
+		data, err := p.Fetch(context.Background(), media, lang)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(out, data, 0644); err != nil {
+			return err
+		}
+		logger.Infof("downloaded subtitle to %s", out)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(convertCmd)
 	rootCmd.AddCommand(mergeCmd)
 	rootCmd.AddCommand(translateCmd)
+	rootCmd.AddCommand(fetchCmd)
 }
 
 func initConfig() {

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -202,6 +202,8 @@ type Provider interface {
 ```
 
 Providers share common configuration such as API keys or user credentials via Viper. Future work includes supporting services used by Bazarr (OpenSubtitles, Addic7ed, Subscene, etc.).
+An initial provider based on the OpenSubtitles REST API has been implemented
+under `pkg/providers/opensubtitles` and exposed through the `fetch` command.
 
 ## 10. Concurrency Model
 

--- a/pkg/providers/opensubtitles/hash.go
+++ b/pkg/providers/opensubtitles/hash.go
@@ -1,0 +1,50 @@
+// file: pkg/providers/opensubtitles/hash.go
+package opensubtitles
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+)
+
+// fileHash calculates the OpenSubtitles file hash.
+// fileHashFunc is used internally to compute the movie hash.
+// It is defined as a variable to allow tests to replace it.
+var fileHashFunc = realFileHash
+
+// realFileHash calculates the OpenSubtitles file hash.
+func realFileHash(path string) (uint64, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return 0, 0, err
+	}
+	size := fi.Size()
+	const chunk = 64 * 1024
+	buf := make([]byte, chunk)
+	var h uint64
+	h += uint64(size)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return 0, 0, err
+	}
+	for i := 0; i < chunk/8; i++ {
+		h += binary.LittleEndian.Uint64(buf[i*8:])
+	}
+	if size > chunk {
+		if _, err := f.Seek(-chunk, io.SeekEnd); err != nil {
+			return 0, 0, err
+		}
+		if _, err := io.ReadFull(f, buf); err != nil {
+			return 0, 0, err
+		}
+		for i := 0; i < chunk/8; i++ {
+			h += binary.LittleEndian.Uint64(buf[i*8:])
+		}
+	}
+	return h, size, nil
+}

--- a/pkg/providers/opensubtitles/hash_test.go
+++ b/pkg/providers/opensubtitles/hash_test.go
@@ -1,0 +1,33 @@
+package opensubtitles
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFileHash(t *testing.T) {
+	f, err := os.CreateTemp("", "hash-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 200000)
+	for i := range data {
+		data[i] = byte(i % 255)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	h, size, err := realFileHash(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != int64(len(data)) {
+		t.Fatalf("size mismatch: %d != %d", size, len(data))
+	}
+	if h == 0 {
+		t.Fatal("hash should not be zero")
+	}
+}

--- a/pkg/providers/opensubtitles/opensubtitles.go
+++ b/pkg/providers/opensubtitles/opensubtitles.go
@@ -1,0 +1,79 @@
+// file: pkg/providers/opensubtitles/opensubtitles.go
+package opensubtitles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client implements the providers.Provider interface for OpenSubtitles.
+type Client struct {
+	// APIURL allows overriding the REST endpoint, mainly for testing.
+	APIURL string
+	// UserAgent identifies this application to the OpenSubtitles API.
+	UserAgent  string
+	HTTPClient *http.Client
+	APIKey     string
+}
+
+// New returns a new Client with the provided API key.
+func New(apiKey string) *Client {
+	return &Client{
+		APIURL:     "https://rest.opensubtitles.org",
+		UserAgent:  "subtitle-manager/0.1",
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		APIKey:     apiKey,
+	}
+}
+
+// Fetch downloads the first matching subtitle for mediaPath in lang.
+func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	hash, size, err := fileHashFunc(mediaPath)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/search/moviehash-%x/moviebytesize-%d/sublanguageid-%s", c.APIURL, hash, size, lang)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	if c.APIKey != "" {
+		req.Header.Set("Api-Key", c.APIKey)
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search status %d", resp.StatusCode)
+	}
+	var results []struct {
+		SubDownloadLink string `json:"SubDownloadLink"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no subtitles found")
+	}
+	dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, results[0].SubDownloadLink, nil)
+	if err != nil {
+		return nil, err
+	}
+	dlReq.Header.Set("User-Agent", c.UserAgent)
+	dlResp, err := c.HTTPClient.Do(dlReq)
+	if err != nil {
+		return nil, err
+	}
+	defer dlResp.Body.Close()
+	if dlResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download status %d", dlResp.StatusCode)
+	}
+	return io.ReadAll(dlResp.Body)
+}

--- a/pkg/providers/opensubtitles/opensubtitles_test.go
+++ b/pkg/providers/opensubtitles/opensubtitles_test.go
@@ -1,0 +1,44 @@
+package opensubtitles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockHandler struct{}
+
+func (mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/search") {
+		fmt.Fprintf(w, `[{"SubDownloadLink":"http://%s/download"}]`, r.Host)
+		return
+	}
+	if r.URL.Path == "/download" {
+		fmt.Fprint(w, "sub data")
+		return
+	}
+	w.WriteHeader(404)
+}
+
+func TestFetch(t *testing.T) {
+	srv := httptest.NewServer(mockHandler{})
+	defer srv.Close()
+	c := New("")
+	c.APIURL = srv.URL
+	c.HTTPClient = srv.Client()
+	// override fileHash to avoid reading a real file
+	orig := fileHashFunc
+	fileHashFunc = func(string) (uint64, int64, error) { return 1, 1, nil }
+	defer func() { fileHashFunc = orig }()
+
+	data, err := c.Fetch(context.Background(), "dummy.mkv", "en")
+	if err != nil {
+		t.Fatalf("fetch error: %v", err)
+	}
+	if string(data) != "sub data" {
+		t.Fatalf("unexpected data: %s", data)
+	}
+}

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -1,0 +1,10 @@
+// file: pkg/providers/provider.go
+package providers
+
+import "context"
+
+// Provider downloads subtitles for a media file in the given language.
+type Provider interface {
+	// Fetch returns the subtitle bytes for the specified media file and language.
+	Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error)
+}

--- a/pkg/subtitles/extract.go
+++ b/pkg/subtitles/extract.go
@@ -12,7 +12,7 @@ import (
 // ExtractFromMedia extracts the first subtitle stream from the given media
 // container using the `ffmpeg` command line tool. The resulting subtitle items
 // are returned. The `ffmpeg` binary must be available in $PATH.
-func ExtractFromMedia(mediaPath string) ([]astisub.Item, error) {
+func ExtractFromMedia(mediaPath string) ([]*astisub.Item, error) {
 	tmp, err := os.CreateTemp("", "subextract-*.srt")
 	if err != nil {
 		return nil, err
@@ -30,8 +30,6 @@ func ExtractFromMedia(mediaPath string) ([]astisub.Item, error) {
 		return nil, err
 	}
 	items := make([]*astisub.Item, len(sub.Items))
-	for i := range sub.Items {
-		items[i] = &sub.Items[i]
-	}
+	copy(items, sub.Items)
 	return items, nil
 }


### PR DESCRIPTION
## Summary
- add `fetch` command to download subtitles using providers
- implement initial OpenSubtitles provider
- document provider usage in README, CHANGELOG, TODO and design docs
- fix extraction helper to return pointer items

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68439c07520c8321b785bccf5ba447e4