### PR TITLE
Implement batch translation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - OpenSubtitles provider and `fetch` CLI command.
 - Provider implementation documented in README and TODO.
+
+## [0.1.5] - 2025-06-10
+### Added
+- Batch translation command for concurrent processing of multiple files.
+- Helper functions `TranslateFileToSRT` and `TranslateFilesToSRT` in `pkg/subtitles`.
+- Documentation updates for the new command and concurrency model.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Per component logging with adjustable levels.
 - Extract subtitles from media containers using ffmpeg.
 - Download subtitles from OpenSubtitles.
+- Batch translate multiple files concurrently.
 
 ## Installation
 
@@ -31,6 +32,7 @@ subtitle-manager translate [input] [output] [lang]
 subtitle-manager history
 subtitle-manager extract [media] [output]
 subtitle-manager fetch opensubtitles [media] [lang] [output]
+subtitle-manager batch [lang] [files...]
 ```
 
 ### Web UI

--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 
 7. **Future Enhancements**
    - Replace manual HTTP calls with provider SDKs where available.
-   - Consider asynchronous processing for bulk translations.
+   - Asynchronous processing for bulk translations implemented via the `batch` command.
    - Evaluate performance of subtitle merging and translation.
    - Add optional web interface for managing subtitles.
 

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/subtitles"
+)
+
+var workers int
+
+var batchCmd = &cobra.Command{
+	Use:   "batch [lang] [files...]",
+	Short: "Translate multiple subtitle files concurrently",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("batch")
+		lang := args[0]
+		files := args[1:]
+		service := viper.GetString("translate_service")
+		gKey := viper.GetString("google_api_key")
+		gptKey := viper.GetString("openai_api_key")
+		grpcAddr := viper.GetString("grpc_addr")
+		if err := subtitles.TranslateFilesToSRT(files, lang, service, gKey, gptKey, grpcAddr, workers); err != nil {
+			return err
+		}
+		logger.Infof("translated %d files", len(files))
+		return nil
+	},
+}
+
+func init() {
+	batchCmd.Flags().IntVar(&workers, "workers", 4, "number of concurrent workers")
+	rootCmd.AddCommand(batchCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(mergeCmd)
 	rootCmd.AddCommand(translateCmd)
 	rootCmd.AddCommand(fetchCmd)
+	rootCmd.AddCommand(batchCmd)
 }
 
 func initConfig() {

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -1,15 +1,12 @@
 package cmd
 
 import (
-	"os"
-
-	"github.com/asticode/go-astisub"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"subtitle-manager/pkg/database"
 	"subtitle-manager/pkg/logging"
-	"subtitle-manager/pkg/translator"
+	"subtitle-manager/pkg/subtitles"
 )
 
 var translateCmd = &cobra.Command{
@@ -23,24 +20,7 @@ var translateCmd = &cobra.Command{
 		gKey := viper.GetString("google_api_key")
 		gptKey := viper.GetString("openai_api_key")
 		grpcAddr := viper.GetString("grpc_addr")
-		sub, err := astisub.OpenFile(in)
-		if err != nil {
-			return err
-		}
-		for _, item := range sub.Items {
-			text := item.String()
-			t, err := translator.Translate(service, text, lang, gKey, gptKey, grpcAddr)
-			if err != nil {
-				return err
-			}
-			item.Lines = []astisub.Line{{Items: []astisub.LineItem{{Text: t}}}}
-		}
-		f, err := os.Create(out)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		if err := sub.WriteToSRT(f); err != nil {
+		if err := subtitles.TranslateFileToSRT(in, out, lang, service, gKey, gptKey, grpcAddr); err != nil {
 			return err
 		}
 		if dbPath := viper.GetString("db_path"); dbPath != "" {

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -69,6 +69,14 @@ subtitle-manager translate <input> <output> <language>
 
 Translates a subtitle file to the target language. The translator command uses `translator.Translate` which selects the translation backend (Google or ChatGPT) based on configuration. Translation results are stored in the database via `database.InsertSubtitle`.
 
+#### batch
+
+```
+subtitle-manager batch <language> <files...>
+```
+
+Translates multiple subtitle files concurrently. The command invokes `subtitles.TranslateFilesToSRT` which utilises the `conc` package to limit the number of worker goroutines.
+
 #### history
 
 Displays previously translated files. `database.ListSubtitles` returns rows which are printed in a tabular format.

--- a/pkg/subtitles/translatefile.go
+++ b/pkg/subtitles/translatefile.go
@@ -1,0 +1,52 @@
+package subtitles
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asticode/go-astisub"
+	"github.com/sourcegraph/conc/pool"
+
+	"subtitle-manager/pkg/translator"
+)
+
+// TranslateFileToSRT translates the subtitle file at inPath using the
+// specified translation service and writes an SRT file to outPath.
+// googleKey, gptKey and grpcAddr are passed to the underlying provider
+// depending on the service selected.
+func TranslateFileToSRT(inPath, outPath, lang, service, googleKey, gptKey, grpcAddr string) error {
+	sub, err := astisub.OpenFile(inPath)
+	if err != nil {
+		return err
+	}
+	for _, item := range sub.Items {
+		t, err := translator.Translate(service, item.String(), lang, googleKey, gptKey, grpcAddr)
+		if err != nil {
+			return err
+		}
+		item.Lines = []astisub.Line{{Items: []astisub.LineItem{{Text: t}}}}
+	}
+	buf := &bytes.Buffer{}
+	if err := sub.WriteToSRT(buf); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, buf.Bytes(), 0644)
+}
+
+// TranslateFilesToSRT concurrently translates each file in paths using
+// TranslateFileToSRT. Output files are written next to the inputs with the
+// language code appended before the extension. The number of worker
+// goroutines is limited by workers.
+func TranslateFilesToSRT(paths []string, lang, service, googleKey, gptKey, grpcAddr string, workers int) error {
+	p := pool.New().WithErrors().WithMaxGoroutines(workers)
+	for _, in := range paths {
+		in := in
+		out := strings.TrimSuffix(in, filepath.Ext(in)) + "." + lang + ".srt"
+		p.Go(func() error {
+			return TranslateFileToSRT(in, out, lang, service, googleKey, gptKey, grpcAddr)
+		})
+	}
+	return p.Wait()
+}

--- a/pkg/subtitles/translatefile_test.go
+++ b/pkg/subtitles/translatefile_test.go
@@ -1,0 +1,66 @@
+package subtitles
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"subtitle-manager/pkg/translator"
+)
+
+func TestTranslateFileToSRT(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"translations":[{"translatedText":"hola"}]}}`)
+	}))
+	defer srv.Close()
+	translator.SetGoogleAPIURL(srv.URL)
+	defer translator.SetGoogleAPIURL("https://translation.googleapis.com/language/translate/v2")
+
+	out := filepath.Join(t.TempDir(), "out.srt")
+	err := TranslateFileToSRT("../../testdata/simple.srt", out, "es", "google", "k", "", "")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "hola") {
+		t.Fatalf("expected translated text, got %s", data)
+	}
+}
+
+func TestTranslateFilesToSRT(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"translations":[{"translatedText":"hola"}]}}`)
+	}))
+	defer srv.Close()
+	translator.SetGoogleAPIURL(srv.URL)
+	defer translator.SetGoogleAPIURL("https://translation.googleapis.com/language/translate/v2")
+
+	dir := t.TempDir()
+	inputs := []string{}
+	for i := 0; i < 2; i++ {
+		in := filepath.Join(dir, fmt.Sprintf("in%d.srt", i))
+		b, _ := os.ReadFile("../../testdata/simple.srt")
+		os.WriteFile(in, b, 0644)
+		inputs = append(inputs, in)
+	}
+	if err := TranslateFilesToSRT(inputs, "es", "google", "k", "", "", 2); err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	for _, in := range inputs {
+		out := strings.TrimSuffix(in, filepath.Ext(in)) + ".es.srt"
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read out: %v", err)
+		}
+		if !strings.Contains(string(data), "hola") {
+			t.Fatalf("missing translation in %s", out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `batch` command for translating multiple subtitle files concurrently
- extract translation helpers to `pkg/subtitles`
- document batch translation in README, TODO, design docs, and CHANGELOG
- update translate command to use helper
- add tests for translation helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843abc8b69c8321b155298fcee3d6f1