### PR TITLE
Implement directory watcher and add watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Extract subtitles from media containers using ffmpeg.
 - Download subtitles from OpenSubtitles.
 - Batch translate multiple files concurrently.
+- Monitor directories and automatically download subtitles.
 
 ## Installation
 
@@ -33,6 +34,7 @@ subtitle-manager history
 subtitle-manager extract [media] [output]
 subtitle-manager fetch opensubtitles [media] [lang] [output]
 subtitle-manager batch [lang] [files...]
+subtitle-manager watch opensubtitles [directory] [lang]
 ```
 
 ### Web UI

--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@ This file tracks planned work, architectural decisions, and implementation statu
 ## Roadmap
 
 1. **Feature Parity with Bazarr**
-   - Monitor media libraries for new subtitles.
-   - Support multiple subtitle providers. *(OpenSubtitles implemented)*
+   - Monitor media libraries for new subtitles. *(watch command implemented)*
+   - Support multiple subtitle providers. *(OpenSubtitles implemented; others pending)*
    - Download, manage and upgrade subtitles automatically.
-   - Integrate with media servers (e.g. Plex, Emby).
+   - Integrate with media servers (e.g. Plex, Emby, Sonarr, Radarr).
 
 2. **Configuration with Cobra & Viper**
    - Centralise configuration using Viper.
@@ -56,7 +56,11 @@ This file tracks planned work, architectural decisions, and implementation statu
    - Expose translation via a gRPC server and client. *(client implemented)*
    - Document protobuf messages and regeneration steps.
 
-7. **Future Enhancements**
+7. **Media Library Monitoring**
+   - Implement filesystem watchers to detect new video files.
+   - Automatically fetch subtitles when media appears.
+
+8. **Future Enhancements**
    - Replace manual HTTP calls with provider SDKs where available.
    - Asynchronous processing for bulk translations implemented via the `batch` command.
    - Evaluate performance of subtitle merging and translation.

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/providers/opensubtitles"
+	"subtitle-manager/pkg/watcher"
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch [provider] [directory] [lang]",
+	Short: "Watch directory and auto-download subtitles",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("watch")
+		name, dir, lang := args[0], args[1], args[2]
+		var p providers.Provider
+		switch name {
+		case "opensubtitles":
+			key := viper.GetString("opensubtitles.api_key")
+			p = opensubtitles.New(key)
+		default:
+			return fmt.Errorf("unknown provider %s", name)
+		}
+		logger.Infof("watching %s", dir)
+		ctx := context.Background()
+		return watcher.WatchDirectory(ctx, dir, lang, p)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(watchCmd)
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,67 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+)
+
+var videoExtensions = []string{".mkv", ".mp4", ".avi", ".mov"}
+
+func isVideoFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, e := range videoExtensions {
+		if ext == e {
+			return true
+		}
+	}
+	return false
+}
+
+// WatchDirectory monitors dir for new video files and downloads subtitles using
+// provider p for the given language. Subtitles are written next to the media
+// file with the language code appended before the extension.
+func WatchDirectory(ctx context.Context, dir, lang string, p providers.Provider) error {
+	logger := logging.GetLogger("watcher")
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if err := w.Add(dir); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-w.Errors:
+			logger.Warnf("watch error: %v", err)
+		case ev := <-w.Events:
+			if ev.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write) != 0 && isVideoFile(ev.Name) {
+				out := strings.TrimSuffix(ev.Name, filepath.Ext(ev.Name)) + "." + lang + ".srt"
+				if _, err := os.Stat(out); err == nil {
+					continue
+				}
+				data, err := p.Fetch(ctx, ev.Name, lang)
+				if err != nil {
+					logger.Warnf("fetch %s: %v", ev.Name, err)
+					continue
+				}
+				if err := os.WriteFile(out, data, 0644); err != nil {
+					logger.Warnf("write %s: %v", out, err)
+					continue
+				}
+				logger.Infof("downloaded subtitle %s", out)
+			}
+		}
+	}
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,45 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type fakeProvider struct{}
+
+func (fakeProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return []byte("sub"), nil
+}
+
+func TestWatchDirectory(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		if err := WatchDirectory(ctx, dir, "en", fakeProvider{}); err != context.Canceled {
+			t.Errorf("watch: %v", err)
+		}
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	f := filepath.Join(dir, "video.mkv")
+	if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	out := filepath.Join(dir, "video.en.srt")
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(out); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("subtitle not downloaded: %v", err)
+	}
+	cancel()
+	<-done
+}


### PR DESCRIPTION
## Summary
- document implemented and remaining features in TODO
- add ability to monitor a directory for new media files
- create `watch` CLI command to start a watcher
- document the watcher in README
- tests for the new watcher package

## Testing
- `go test ./pkg/watcher -run TestWatchDirectory -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684457168c78832185c95db9d4261fa7