### PR TITLE
Add env var config and CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,24 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Install dependencies
+        run: go mod download
+      - name: Format
+        run: test -z "$(gofmt -s -l $(git ls-files '*.go'))"
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,8 @@ All notable changes to this project will be documented in this file.
 - Customisable ffmpeg path for subtitle extraction.
 - Recursive directory watching.
 - `delete` command and database deletion helper.
+
+## [0.1.7] - 2025-06-12
+### Added
+- Environment variable configuration via `SM_` prefix.
+- GitHub Actions workflow for continuous integration.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The `extract` command accepts `--ffmpeg` to specify a custom ffmpeg binary.
 
 Run `subtitle-manager web` to start the embedded React interface on `:8080`. The SPA is built via `go generate` in the `webui` directory and embedded using Go 1.16's `embed` package.
 
-Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. API keys may be specified via flags `--google-key` and `--openai-key` or in the configuration file. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`.  Translation can be delegated to a remote gRPC server using the `--grpc` flag and providing an address such as `localhost:50051`.
+Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. Environment variables prefixed with `SM_` override configuration values. API keys may be specified via flags `--google-key` and `--openai-key` or in the configuration file. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`.  Translation can be delegated to a remote gRPC server using the `--grpc` flag and providing an address such as `localhost:50051`.
 
 Example configuration:
 
@@ -65,6 +65,7 @@ translate_service: google
 ## Development
 
 Tests can be run with `go test ./...`.
+Continuous integration is provided via a GitHub Actions workflow that verifies formatting, vets code and runs the test suite on each push.
 
 The project aims to eventually reach feature parity with [Bazarr](https://github.com/morpheus65535/bazarr) while offering improved configuration and logging. See `TODO.md` for the full roadmap and implementation plan.
 Extensive architectural details and design decisions are documented in

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 
 6. **Quality Assurance**
    - Unit tests for all packages.
-   - Continuous integration workflow (future work).
+   - Continuous integration workflow using GitHub Actions.
 
 ## Implementation Plan
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -43,6 +44,9 @@ func init() {
 }
 
 func initConfig() {
+	viper.SetEnvPrefix("SM")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestInitConfigEnv(t *testing.T) {
+	os.Setenv("SM_GOOGLE_API_KEY", "testkey")
+	defer os.Unsetenv("SM_GOOGLE_API_KEY")
+	initConfig()
+	if got := viper.GetString("google_api_key"); got != "testkey" {
+		t.Fatalf("expected google_api_key=%s, got %s", "testkey", got)
+	}
+}


### PR DESCRIPTION
## Summary
- support environment variables for configuration
- provide GitHub Actions workflow for CI
- document new configuration method and CI usage
- mark CI as implemented in TODO
- note new feature in changelog
- add tests for initConfig environment overrides

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684471314558832185cf594a3c6eded1