### PR TITLE
Implement library scanning command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.0] - 2025-06-16
+### Added
+- Library scanning command to automatically download and upgrade subtitles.
+- Updated README and TODO for new feature.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
   and many more.
 - Batch translate multiple files concurrently.
 - Monitor directories and automatically download subtitles.
+- Scan existing libraries and fetch missing or upgraded subtitles.
 - Recursive directory watching with -r flag.
 - Run a translation gRPC server.
 - Delete subtitle files and remove history records.
@@ -100,6 +101,8 @@ subtitle-manager extract [media] [output]
 subtitle-manager fetch opensubtitles [media] [lang] [output]
 subtitle-manager fetch subscene [media] [lang] [output]
 subtitle-manager batch [lang] [files...]
+subtitle-manager scan opensubtitles [directory] [lang] [-u]
+subtitle-manager scan subscene [directory] [lang] [-u]
 subtitle-manager watch opensubtitles [directory] [lang] [-r]
 subtitle-manager watch subscene [directory] [lang] [-r]
 subtitle-manager grpc-server --addr :50051

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 1. **Feature Parity with Bazarr**
    - Monitor media libraries for new subtitles. *(watch command implemented)*
    - Support multiple subtitle providers. *(Full Bazarr provider list implemented)*
-   - Download, manage and upgrade subtitles automatically.
+   - Download, manage and upgrade subtitles automatically. *(scan command implemented)*
    - Integrate with media servers (e.g. Plex, Emby, Sonarr, Radarr).
 
 2. **Configuration with Cobra & Viper**

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/scanner"
+)
+
+var upgrade bool
+
+// scanCmd scans a directory for video files and downloads subtitles.
+var scanCmd = &cobra.Command{
+	Use:   "scan [provider] [directory] [lang]",
+	Short: "Scan directory and download subtitles",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("scan")
+		name, dir, lang := args[0], args[1], args[2]
+		key := viper.GetString("opensubtitles.api_key")
+		p, err := providers.Get(name, key)
+		if err != nil {
+			return err
+		}
+		logger.Infof("scanning %s", dir)
+		ctx := context.Background()
+		return scanner.ScanDirectory(ctx, dir, lang, p, upgrade)
+	},
+}
+
+func init() {
+	scanCmd.Flags().BoolVarP(&upgrade, "upgrade", "u", false, "replace existing subtitles")
+	rootCmd.AddCommand(scanCmd)
+}

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -267,8 +267,9 @@ The following steps outline the order of implementation to achieve the project g
 6. **History Command** – allow users to view past translation actions.
 7. **Provider Integrations** – add subtitle download modules for popular services.
 8. **Media Library Monitoring** – implement watchers to detect new media and automatically download subtitles.
-9. **gRPC API (Optional)** – provide remote translation capabilities.
-10. **Testing and CI** – expand unit tests and add CI workflows.
+9. **Library Scanning** – add command to scan existing directories and fetch missing or improved subtitles.
+10. **gRPC API (Optional)** – provide remote translation capabilities.
+11. **Testing and CI** – expand unit tests and add CI workflows.
 
 This plan aligns with the tasks listed in `TODO.md`.
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,0 +1,59 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+)
+
+// ScanDirectory traverses dir looking for video files and downloads subtitles
+// using provider p for the given language. If upgrade is false existing
+// subtitle files are skipped. Subtitles are saved next to the video with the
+// language code appended before the extension.
+func ScanDirectory(ctx context.Context, dir, lang string, p providers.Provider, upgrade bool) error {
+	logger := logging.GetLogger("scanner")
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !isVideoFile(path) {
+			return nil
+		}
+		out := strings.TrimSuffix(path, filepath.Ext(path)) + "." + lang + ".srt"
+		if !upgrade {
+			if _, err := os.Stat(out); err == nil {
+				return nil
+			}
+		}
+		data, err := p.Fetch(ctx, path, lang)
+		if err != nil {
+			logger.Warnf("fetch %s: %v", path, err)
+			return nil
+		}
+		if err := os.WriteFile(out, data, 0644); err != nil {
+			logger.Warnf("write %s: %v", out, err)
+			return nil
+		}
+		logger.Infof("downloaded subtitle %s", out)
+		return nil
+	})
+}
+
+var videoExtensions = []string{".mkv", ".mp4", ".avi", ".mov"}
+
+func isVideoFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, e := range videoExtensions {
+		if ext == e {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -1,0 +1,50 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeProvider struct{ data []byte }
+
+func (f fakeProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return f.data, nil
+}
+
+func TestScanDirectory(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	// first scan creates subtitle
+	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("a")}, false); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sub := filepath.Join(dir, "movie.en.srt")
+	data, err := os.ReadFile(sub)
+	if err != nil {
+		t.Fatalf("read subtitle: %v", err)
+	}
+	if string(data) != "a" {
+		t.Fatalf("unexpected subtitle %q", data)
+	}
+	// second scan without upgrade should keep existing subtitle
+	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("b")}, false); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	data, _ = os.ReadFile(sub)
+	if string(data) != "a" {
+		t.Fatalf("subtitle overwritten without upgrade")
+	}
+	// scan with upgrade should replace subtitle
+	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("c")}, true); err != nil {
+		t.Fatalf("scan upgrade: %v", err)
+	}
+	data, _ = os.ReadFile(sub)
+	if string(data) != "c" {
+		t.Fatalf("subtitle not upgraded: %q", data)
+	}
+}


### PR DESCRIPTION
## Summary
- add new `scan` CLI command for library scanning
- implement `ScanDirectory` helper with tests
- document the feature in README, TODO, CHANGELOG and design docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844c2d6942483219b9cc5e3007810da