### PR TITLE
Implement download history feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.2] - 2025-06-20
+### Added
+- Download history stored in database with new `downloads` command.
+
 ## [0.3.1] - 2025-06-19
 ### Added
 - PebbleDB backend with migration command.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Integrate with Sonarr and Radarr using dedicated commands.
 - Run a translation gRPC server.
 - Delete subtitle files and remove history records.
+- Track subtitle download history and list with `downloads` command.
 - Provider registry simplifies adding new sources.
 - Dockerfile and workflow for container builds.
 - Prebuilt images published to GitHub Container Registry.
@@ -112,6 +113,7 @@ subtitle-manager watch opensubtitles [directory] [lang] [-r]
 subtitle-manager watch subscene [directory] [lang] [-r]
 subtitle-manager grpc-server --addr :50051
 subtitle-manager delete [file]
+subtitle-manager downloads
 subtitle-manager login [username] [password]
 subtitle-manager user add [username] [email] [password]
 subtitle-manager user apikey [username]

--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 5. **Database Schema**
    - Design an efficient schema to store subtitle metadata and history.
   - PebbleDB backend implemented with migration from SQLite.
+  - Download history table and command implemented.
 
 6. **Quality Assurance**
    - Unit tests for all packages.

--- a/cmd/downloads.go
+++ b/cmd/downloads.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/database"
+	"subtitle-manager/pkg/logging"
+)
+
+// downloadsCmd shows subtitle download history.
+var downloadsCmd = &cobra.Command{
+	Use:   "downloads",
+	Short: "Show subtitle download history",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("downloads")
+		dbPath := viper.GetString("db_path")
+		backend := viper.GetString("db_backend")
+		store, err := database.OpenStore(dbPath, backend)
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+
+		recs, err := store.ListDownloads()
+		if err != nil {
+			return err
+		}
+		for _, r := range recs {
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\n", r.ID, r.VideoFile, r.Language, r.Provider, r.CreatedAt.Format(time.RFC3339))
+		}
+		logger.Infof("listed %d records", len(recs))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(downloadsCmd)
+}

--- a/cmd/radarr.go
+++ b/cmd/radarr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"subtitle-manager/pkg/database"
 	"subtitle-manager/pkg/logging"
 	"subtitle-manager/pkg/providers"
 	"subtitle-manager/pkg/scanner"
@@ -33,7 +34,17 @@ var radarrCmd = &cobra.Command{
 		}
 		ctx := context.Background()
 		logger.Infof("processing %s", path)
-		return scanner.ProcessFile(ctx, path, lang, p, true)
+		var store database.SubtitleStore
+		if dbPath := viper.GetString("db_path"); dbPath != "" {
+			backend := viper.GetString("db_backend")
+			if s, err := database.OpenStore(dbPath, backend); err == nil {
+				store = s
+				defer s.Close()
+			} else {
+				logger.Warnf("db open: %v", err)
+			}
+		}
+		return scanner.ProcessFile(ctx, path, lang, providerName, p, true, store)
 	},
 }
 

--- a/cmd/sonarr.go
+++ b/cmd/sonarr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"subtitle-manager/pkg/database"
 	"subtitle-manager/pkg/logging"
 	"subtitle-manager/pkg/providers"
 	"subtitle-manager/pkg/scanner"
@@ -33,7 +34,17 @@ var sonarrCmd = &cobra.Command{
 		}
 		ctx := context.Background()
 		logger.Infof("processing %s", path)
-		return scanner.ProcessFile(ctx, path, lang, p, true)
+		var store database.SubtitleStore
+		if dbPath := viper.GetString("db_path"); dbPath != "" {
+			backend := viper.GetString("db_backend")
+			if s, err := database.OpenStore(dbPath, backend); err == nil {
+				store = s
+				defer s.Close()
+			} else {
+				logger.Warnf("db open: %v", err)
+			}
+		}
+		return scanner.ProcessFile(ctx, path, lang, providerName, p, true, store)
 	},
 }
 

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -375,7 +375,7 @@ To support additional features such as subtitle provider history and media libra
 
 - `providers` – list of configured subtitle providers, credentials and status.
 - `media_items` – records of movies or episodes by unique hash.
-- `downloads` – history of downloaded subtitles with provider references.
+- `downloads` – history of downloaded subtitles with provider references. *Implemented in v0.3.2*
 
 Each migration file is numbered sequentially and includes both `up` and `down` SQL scripts.
 

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -47,3 +47,31 @@ func TestDeleteSubtitle(t *testing.T) {
 		t.Fatalf("expected 0 records, got %d", len(recs))
 	}
 }
+
+func TestDownloadHistory(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := InsertDownload(db, "file.srt", "video.mkv", "opensubtitles", "en"); err != nil {
+		t.Fatalf("insert download: %v", err)
+	}
+	recs, err := ListDownloads(db)
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(recs) != 1 || recs[0].Provider != "opensubtitles" {
+		t.Fatalf("unexpected records %+v", recs)
+	}
+	if err := DeleteDownload(db, "file.srt"); err != nil {
+		t.Fatalf("delete download: %v", err)
+	}
+	recs, err = ListDownloads(db)
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(recs))
+	}
+}

--- a/pkg/database/migrate.go
+++ b/pkg/database/migrate.go
@@ -12,6 +12,10 @@ func MigrateToPebble(sqlitePath, pebblePath string) error {
 	if err != nil {
 		return err
 	}
+	downloads, err := sqlStore.ListDownloads()
+	if err != nil {
+		return err
+	}
 
 	pebbleStore, err := OpenPebble(pebblePath)
 	if err != nil {
@@ -22,6 +26,12 @@ func MigrateToPebble(sqlitePath, pebblePath string) error {
 	for _, r := range recs {
 		rec := r
 		if err := pebbleStore.InsertSubtitle(&rec); err != nil {
+			return err
+		}
+	}
+	for _, d := range downloads {
+		dr := d
+		if err := pebbleStore.InsertDownload(&dr); err != nil {
 			return err
 		}
 	}

--- a/pkg/database/migrate_test.go
+++ b/pkg/database/migrate_test.go
@@ -13,6 +13,9 @@ func TestMigrateToPebble(t *testing.T) {
 	if err := s.InsertSubtitle(&SubtitleRecord{File: "a.srt", VideoFile: "a.mkv", Language: "en", Service: "g"}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
+	if err := s.InsertDownload(&DownloadRecord{File: "b.srt", VideoFile: "b.mkv", Provider: "p", Language: "en"}); err != nil {
+		t.Fatalf("insert download: %v", err)
+	}
 	s.Close()
 
 	if err := MigrateToPebble(sqlitePath, pebblePath); err != nil {
@@ -31,5 +34,12 @@ func TestMigrateToPebble(t *testing.T) {
 	}
 	if len(recs) != 1 || recs[0].File != "a.srt" {
 		t.Fatalf("unexpected records %+v", recs)
+	}
+	dRecs, err := p.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(dRecs) != 1 || dRecs[0].File != "b.srt" {
+		t.Fatalf("unexpected download records %+v", dRecs)
 	}
 }

--- a/pkg/database/pebble_test.go
+++ b/pkg/database/pebble_test.go
@@ -47,3 +47,38 @@ func TestPebbleDeleteSubtitle(t *testing.T) {
 		t.Fatalf("expected 0 records, got %d", len(recs))
 	}
 }
+
+func TestPebbleDownloadRecords(t *testing.T) {
+	db, err := OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	rec := &DownloadRecord{File: "f.srt", VideoFile: "v.mkv", Language: "es", Provider: "test"}
+	if err := db.InsertDownload(rec); err != nil {
+		t.Fatalf("insert download: %v", err)
+	}
+
+	recs, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	if recs[0].Provider != "test" || recs[0].Language != "es" {
+		t.Fatalf("unexpected record %+v", recs[0])
+	}
+
+	if err := db.DeleteDownload("f.srt"); err != nil {
+		t.Fatalf("delete download: %v", err)
+	}
+	recs, err = db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(recs))
+	}
+}

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -8,6 +8,12 @@ type SubtitleStore interface {
 	ListSubtitles() ([]SubtitleRecord, error)
 	// DeleteSubtitle removes all records for the specified file.
 	DeleteSubtitle(file string) error
+	// InsertDownload stores a download record.
+	InsertDownload(rec *DownloadRecord) error
+	// ListDownloads retrieves all download records sorted by creation time.
+	ListDownloads() ([]DownloadRecord, error)
+	// DeleteDownload removes download records for the specified subtitle file.
+	DeleteDownload(file string) error
 	// Close releases any resources held by the store.
 	Close() error
 }

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -20,7 +20,7 @@ func TestScanDirectory(t *testing.T) {
 		t.Fatalf("create video: %v", err)
 	}
 	// first scan creates subtitle
-	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("a")}, false, 2); err != nil {
+	if err := ScanDirectory(context.Background(), dir, "en", "test", fakeProvider{[]byte("a")}, false, 2, nil); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 	sub := filepath.Join(dir, "movie.en.srt")
@@ -32,7 +32,7 @@ func TestScanDirectory(t *testing.T) {
 		t.Fatalf("unexpected subtitle %q", data)
 	}
 	// second scan without upgrade should keep existing subtitle
-	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("b")}, false, 2); err != nil {
+	if err := ScanDirectory(context.Background(), dir, "en", "test", fakeProvider{[]byte("b")}, false, 2, nil); err != nil {
 		t.Fatalf("scan 2: %v", err)
 	}
 	data, _ = os.ReadFile(sub)
@@ -40,7 +40,7 @@ func TestScanDirectory(t *testing.T) {
 		t.Fatalf("subtitle overwritten without upgrade")
 	}
 	// scan with upgrade should replace subtitle
-	if err := ScanDirectory(context.Background(), dir, "en", fakeProvider{[]byte("c")}, true, 2); err != nil {
+	if err := ScanDirectory(context.Background(), dir, "en", "test", fakeProvider{[]byte("c")}, true, 2, nil); err != nil {
 		t.Fatalf("scan upgrade: %v", err)
 	}
 	data, _ = os.ReadFile(sub)

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -19,7 +19,7 @@ func TestWatchDirectory(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		if err := WatchDirectory(ctx, dir, "en", fakeProvider{}); err != context.Canceled {
+		if err := WatchDirectory(ctx, dir, "en", "test", fakeProvider{}, nil); err != context.Canceled {
 			t.Errorf("watch: %v", err)
 		}
 		close(done)
@@ -53,7 +53,7 @@ func TestWatchDirectoryRecursive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		if err := WatchDirectoryRecursive(ctx, dir, "en", fakeProvider{}); err != context.Canceled {
+		if err := WatchDirectoryRecursive(ctx, dir, "en", "test", fakeProvider{}, nil); err != context.Canceled {
 			t.Errorf("watch recursive: %v", err)
 		}
 		close(done)


### PR DESCRIPTION
## Summary
- track subtitle download history in both SQL and Pebble stores
- migrate download records when moving from SQLite to Pebble
- log downloads when fetching or scanning subtitles
- support recording history in watch/sonarr/radarr commands
- add `downloads` command and document it

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684635c7b2c883219534ba51430529d2