### PR TITLE
Add GitHub OAuth2 login support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.3] - 2025-06-21
+### Added
+- GitHub OAuth2 login support with new web server endpoints.
+
 ## [0.3.2] - 2025-06-20
 ### Added
 - Download history stored in database with new `downloads` command.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Dockerfile and workflow for container builds.
 - Prebuilt images published to GitHub Container Registry.
 - Integrated authentication system with password, token, OAuth2 and API key support.
+- GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.
 - Minimal React web UI with login page.
 - Role based access control with sensible defaults and session storage in the database.
 
@@ -141,6 +142,9 @@ providers:
     username: myuser
     password: secret
     api_key: token123
+github_client_id: yourClientID
+github_client_secret: yourClientSecret
+github_redirect_url: http://localhost:8080/api/oauth/github/callback
 ```
 
 ### Docker

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 4. **Authentication & Authorization**
    - Password authentication with hashed credentials stored in the database. *(implemented)*
    - One time token generation for email logins. *(initial support implemented)*
-   - OAuth2 integration for third party login providers. *(planned)*
+   - OAuth2 integration for third party login providers. *(GitHub provider implemented)*
    - API key management allowing multiple keys per user. *(implemented)*
    - Command line and web interfaces share the same user store and sessions.
    - Role based access control with default `admin`, `user` and `viewer` roles.

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,12 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	golang.org/x/crypto v0.39.0
+	golang.org/x/oauth2 v0.25.0
 	google.golang.org/grpc v1.67.3
 	google.golang.org/protobuf v1.36.1
 )
+
+require github.com/klauspost/compress v1.16.0 // indirect
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect
@@ -26,7 +29,7 @@ require (
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
-        github.com/cockroachdb/pebble v1.1.5
+	github.com/cockroachdb/pebble v1.1.5
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
@@ -57,6 +60,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241223144023-3abc09e42ca8 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
+golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/webserver/oauth.go
+++ b/pkg/webserver/oauth.go
@@ -1,0 +1,95 @@
+package webserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/viper"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+
+	"subtitle-manager/pkg/auth"
+)
+
+var githubAPIURL = "https://api.github.com/user"
+
+// SetGitHubAPIURL overrides the GitHub API URL for testing purposes.
+func SetGitHubAPIURL(u string) { githubAPIURL = u }
+
+var oauthCfg *oauth2.Config
+
+func initOAuthConfig() {
+	oauthCfg = &oauth2.Config{
+		ClientID:     viper.GetString("github_client_id"),
+		ClientSecret: viper.GetString("github_client_secret"),
+		RedirectURL:  viper.GetString("github_redirect_url"),
+		Endpoint:     github.Endpoint,
+		Scopes:       []string{"user:email"},
+	}
+}
+
+// githubLoginHandler starts the GitHub OAuth2 flow.
+func githubLoginHandler(db *sql.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if oauthCfg == nil {
+			initOAuthConfig()
+		}
+		state := uuid.NewString()
+		url := oauthCfg.AuthCodeURL(state)
+		http.Redirect(w, r, url, http.StatusFound)
+	})
+}
+
+// githubCallbackHandler handles the OAuth2 callback and creates a session.
+func githubCallbackHandler(db *sql.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if oauthCfg == nil {
+			initOAuthConfig()
+		}
+		code := r.FormValue("code")
+		if code == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		token, err := oauthCfg.Exchange(context.Background(), code)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		client := oauthCfg.Client(context.Background(), token)
+		resp, err := client.Get(githubAPIURL)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		defer resp.Body.Close()
+		var u struct {
+			Email string `json:"email"`
+			Login string `json:"login"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if u.Email == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		id, err := auth.GetOrCreateUser(db, u.Login, u.Email, "user")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		tokenStr, err := auth.GenerateSession(db, id, 24*time.Hour)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: tokenStr, Path: "/", HttpOnly: true})
+		http.Redirect(w, r, "/", http.StatusFound)
+	})
+}

--- a/pkg/webserver/oauth_test.go
+++ b/pkg/webserver/oauth_test.go
@@ -1,0 +1,57 @@
+package webserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"subtitle-manager/pkg/database"
+)
+
+// TestGitHubCallbackHandler verifies OAuth2 callback creates a session cookie.
+func TestGitHubCallbackHandler(t *testing.T) {
+	tokenResp := `{"access_token":"t","token_type":"bearer"}`
+	apiResp := `{"login":"tester","email":"tester@example.com"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, tokenResp)
+		case "/user":
+			fmt.Fprint(w, apiResp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	oauthCfg = &oauth2.Config{
+		ClientID:     "id",
+		ClientSecret: "sec",
+		RedirectURL:  "",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  srv.URL + "/auth",
+			TokenURL: srv.URL + "/token",
+		},
+	}
+	SetGitHubAPIURL(srv.URL + "/user")
+	defer func() { oauthCfg = nil; SetGitHubAPIURL("https://api.github.com/user") }()
+
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	h := githubCallbackHandler(db)
+	r := httptest.NewRequest("GET", "/callback?code=c", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusFound {
+		t.Fatalf("status %d", w.Code)
+	}
+	if len(w.Result().Cookies()) == 0 {
+		t.Fatalf("session cookie missing")
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -22,6 +22,8 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/api/login", loginHandler(db))
+	mux.Handle("/api/oauth/github/login", githubLoginHandler(db))
+	mux.Handle("/api/oauth/github/callback", githubCallbackHandler(db))
 	mux.Handle("/api/config", authMiddleware(db, configHandler()))
 	fsHandler := http.FileServer(http.FS(f))
 	mux.Handle("/", authMiddleware(db, fsHandler))


### PR DESCRIPTION
## Summary
- implement GitHub OAuth2 login and session creation
- document OAuth2 configuration options in README
- mark OAuth2 work as implemented in TODO
- update changelog for v0.3.3
- add tests for OAuth handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68463d2728fc83219782c4d94b567573