### PR TITLE
Add RBAC enforcement and role command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ### Added
 - GitHub OAuth2 login support with new web server endpoints.
 
+## [0.3.4] - 2025-06-22
+### Added
+- Role based access control enforced on web routes.
+- `user role` command to modify user permissions.
+
 ## [0.3.2] - 2025-06-20
 ### Added
 - Download history stored in database with new `downloads` command.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ subtitle-manager downloads
 subtitle-manager login [username] [password]
 subtitle-manager user add [username] [email] [password]
 subtitle-manager user apikey [username]
+subtitle-manager user role [username] [role]
 ```
 
 The `extract` command accepts `--ffmpeg` to specify a custom ffmpeg binary.

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ This file tracks planned work, architectural decisions, and implementation statu
    - OAuth2 integration for third party login providers. *(GitHub provider implemented)*
    - API key management allowing multiple keys per user. *(implemented)*
    - Command line and web interfaces share the same user store and sessions.
-   - Role based access control with default `admin`, `user` and `viewer` roles.
+   - Role based access control with default `admin`, `user` and `viewer` roles. *(implemented)*
    - Session data persisted in the database for portability across front ends.
 5. **Subtitle Processing**
    - Merge two subtitles in different languages into one.

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -15,6 +15,21 @@ var userCmd = &cobra.Command{
 	Short: "Manage users",
 }
 
+var userRoleCmd = &cobra.Command{
+	Use:   "role [username] [role]",
+	Args:  cobra.ExactArgs(2),
+	Short: "Set user role",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		username, role := args[0], args[1]
+		db, err := database.Open(viper.GetString("db_path"))
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return auth.SetUserRole(db, username, role)
+	},
+}
+
 var userAddCmd = &cobra.Command{
 	Use:   "add [username] [email] [password]",
 	Args:  cobra.ExactArgs(3),
@@ -83,5 +98,6 @@ func init() {
 	rootCmd.AddCommand(userCmd)
 	userCmd.AddCommand(userAddCmd)
 	userCmd.AddCommand(apiKeyCmd)
+	userCmd.AddCommand(userRoleCmd)
 	rootCmd.AddCommand(loginCmd)
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -80,6 +80,12 @@ func ValidateAPIKey(db *sql.DB, key string) (int64, error) {
 	return userID, nil
 }
 
+// SetUserRole updates the role for the specified username.
+func SetUserRole(db *sql.DB, username, role string) error {
+	_, err := db.Exec(`UPDATE users SET role = ? WHERE username = ?`, role, username)
+	return err
+}
+
 // GetOrCreateUser returns the existing user ID for email or inserts a new user
 // with the provided username, email and role if none exists. The password is
 // left empty for OAuth2 users.

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"subtitle-manager/pkg/database"
+	"testing"
+)
+
+func TestSetUserRole(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := CreateUser(db, "u", "p", "", "user"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := SetUserRole(db, "u", "admin"); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+	ok, err := CheckPermission(db, 1, "all")
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !ok {
+		t.Fatal("permission not granted")
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -24,9 +24,9 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle("/api/login", loginHandler(db))
 	mux.Handle("/api/oauth/github/login", githubLoginHandler(db))
 	mux.Handle("/api/oauth/github/callback", githubCallbackHandler(db))
-	mux.Handle("/api/config", authMiddleware(db, configHandler()))
+	mux.Handle("/api/config", authMiddleware(db, "basic", configHandler()))
 	fsHandler := http.FileServer(http.FS(f))
-	mux.Handle("/", authMiddleware(db, fsHandler))
+	mux.Handle("/", authMiddleware(db, "read", fsHandler))
 	return mux, nil
 }
 

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -42,3 +42,56 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("unexpected status: %d", resp.StatusCode)
 	}
 }
+
+// TestRBAC verifies that permissions are enforced for protected routes.
+func TestRBAC(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// viewer role should not access /api/config
+	if err := auth.CreateUser(db, "viewer", "p", "", "viewer"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	vkey, err := auth.GenerateAPIKey(db, 1)
+	if err != nil {
+		t.Fatalf("viewer key: %v", err)
+	}
+	// admin role can access
+	if err := auth.CreateUser(db, "admin", "p", "", "admin"); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	akey, err := auth.GenerateAPIKey(db, 2)
+	if err != nil {
+		t.Fatalf("admin key: %v", err)
+	}
+
+	h, err := Handler(db)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/config", nil)
+	req.Header.Set("X-API-Key", vkey)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("http get: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("viewer status %d", resp.StatusCode)
+	}
+
+	req2, _ := http.NewRequest("GET", srv.URL+"/api/config", nil)
+	req2.Header.Set("X-API-Key", akey)
+	resp2, err := srv.Client().Do(req2)
+	if err != nil {
+		t.Fatalf("admin get: %v", err)
+	}
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("admin status %d", resp2.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce role-based access control on web routes
- add command to change user roles
- implement helper for updating user role
- add tests for RBAC and SetUserRole
- document new command and mark RBAC implemented
- note RBAC in changelog

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846457cae0c832182ef77db62894ce7