### PR TITLE
Implement one-time login tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Role based access control enforced on web routes.
 - `user role` command to modify user permissions.
 
+## [0.3.5] - 2025-06-23
+### Added
+- One time login tokens with `user token` and `login-token` commands.
+
 ## [0.3.2] - 2025-06-20
 ### Added
 - Download history stored in database with new `downloads` command.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Dockerfile and workflow for container builds.
 - Prebuilt images published to GitHub Container Registry.
 - Integrated authentication system with password, token, OAuth2 and API key support.
+- Generate one time login tokens using `user token` and authenticate with `login-token`.
 - GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.
 - Minimal React web UI with login page.
 - Role based access control with sensible defaults and session storage in the database.
@@ -122,8 +123,10 @@ subtitle-manager grpc-server --addr :50051
 subtitle-manager delete [file]
 subtitle-manager downloads
 subtitle-manager login [username] [password]
+subtitle-manager login-token [token]
 subtitle-manager user add [username] [email] [password]
 subtitle-manager user apikey [username]
+subtitle-manager user token [email]
 subtitle-manager user role [username] [role]
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ This file tracks planned work, architectural decisions, and implementation statu
 
 4. **Authentication & Authorization**
    - Password authentication with hashed credentials stored in the database. *(implemented)*
-   - One time token generation for email logins. *(initial support implemented)*
+  - One time token generation for email logins. *(implemented in v0.3.5)*
    - OAuth2 integration for third party login providers. *(GitHub provider implemented)*
    - API key management allowing multiple keys per user. *(implemented)*
    - Command line and web interfaces share the same user store and sessions.

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
-	"subtitle-manager/pkg/database"
 	"testing"
+	"time"
+
+	"subtitle-manager/pkg/database"
 )
 
 func TestSetUserRole(t *testing.T) {
@@ -23,5 +25,30 @@ func TestSetUserRole(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("permission not granted")
+	}
+}
+
+func TestOneTimeToken(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := CreateUser(db, "u", "p", "e@example.com", "user"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	token, err := GenerateOneTimeToken(db, 1, time.Minute)
+	if err != nil {
+		t.Fatalf("gen token: %v", err)
+	}
+	id, err := ConsumeOneTimeToken(db, token)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if id != 1 {
+		t.Fatalf("unexpected user id %d", id)
+	}
+	if _, err := ConsumeOneTimeToken(db, token); err == nil {
+		t.Fatal("expected second consume to fail")
 	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -116,6 +116,17 @@ func initSchema(db *sql.DB) error {
 		return err
 	}
 
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS login_tokens (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        token TEXT UNIQUE NOT NULL,
+        expires_at TIMESTAMP NOT NULL,
+        used INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMP NOT NULL
+    )`); err != nil {
+		return err
+	}
+
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS permissions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         role TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- implement single-use login token generation and consumption
- add `user token` and `login-token` CLI commands
- document new commands and features
- record feature status in TODO and CHANGELOG
- test one-time token logic

## Testing
- `go test ./pkg/auth ./pkg/database`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684760c7ab288321a6e75fff432edccf