### PR TITLE
Add web UI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The `extract` command accepts `--ffmpeg` to specify a custom ffmpeg binary.
 
 Run `subtitle-manager web` to start the embedded React interface on `:8080`. The SPA is built via `go generate` in the `webui` directory and embedded using Go 1.16's `embed` package.
 
+The interface now exposes a **Settings** page that mirrors Bazarr's options. Configuration values are retrieved from `/api/config` and saved back via a `POST` to the same endpoint. Any changes are written to the active YAML configuration file.
+
 Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. Environment variables prefixed with `SM_` override configuration values. API keys may be specified via flags `--google-key`, `--openai-key` and `--opensubtitles-key` or in the configuration file. Additional flags include `--ffmpeg-path` for a custom ffmpeg binary, `--batch-workers` and `--scan-workers` to control concurrency. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`. Use `--db-backend` to switch between the `sqlite` and `pebble` engines. When using PebbleDB a directory path may be supplied instead of a file. Translation can be delegated to a remote gRPC server using the `--grpc` flag and providing an address such as `localhost:50051`. Generic provider options may also be set with variables like `SM_PROVIDERS_GENERIC_API_URL`.
 Run `subtitle-manager migrate old.db newdir` to copy existing subtitle history from SQLite to PebbleDB.
 

--- a/webui/package.json
+++ b/webui/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,30 +1,52 @@
-import { useState } from 'react'
-import './App.css'
+import { useEffect, useState } from "react";
+import Settings from "./Settings.jsx";
+import "./App.css";
 
 function App() {
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [status, setStatus] = useState('')
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState("");
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/config").then((res) => {
+      if (res.ok) setAuthed(true);
+    });
+  }, []);
 
   const login = async () => {
-    const form = new URLSearchParams({ username, password })
-    const res = await fetch('/api/login', { method: 'POST', body: form })
+    const form = new URLSearchParams({ username, password });
+    const res = await fetch("/api/login", { method: "POST", body: form });
     if (res.ok) {
-      setStatus('logged in')
+      setStatus("logged in");
+      setAuthed(true);
     } else {
-      setStatus('login failed')
+      setStatus("login failed");
     }
+  };
+
+  if (!authed) {
+    return (
+      <div className="login">
+        <h1>Subtitle Manager</h1>
+        <input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button onClick={login}>Login</button>
+        <p>{status}</p>
+      </div>
+    );
   }
 
-  return (
-    <div className="login">
-      <h1>Subtitle Manager</h1>
-      <input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
-      <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-      <button onClick={login}>Login</button>
-      <p>{status}</p>
-    </div>
-  )
+  return <Settings />;
 }
 
-export default App
+export default App;

--- a/webui/src/Settings.jsx
+++ b/webui/src/Settings.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Settings renders a simple configuration form. Values are loaded from
+ * `/api/config` and submitted back via POST to the same endpoint.
+ */
+export default function Settings() {
+  const [config, setConfig] = useState(null);
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    fetch("/api/config")
+      .then((r) => r.json())
+      .then(setConfig);
+  }, []);
+
+  const handleChange = (key, value) => {
+    setConfig({ ...config, [key]: value });
+  };
+
+  const save = async () => {
+    const res = await fetch("/api/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    });
+    setStatus(res.ok ? "saved" : "error");
+  };
+
+  if (!config) return <p>Loading...</p>;
+
+  return (
+    <div className="settings">
+      <h1>Settings</h1>
+      <table>
+        <tbody>
+          {Object.entries(config).map(([k, v]) => (
+            <tr key={k}>
+              <td>{k}</td>
+              <td>
+                <input
+                  value={v}
+                  onChange={(e) => handleChange(k, e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button onClick={save}>Save</button>
+      <p>{status}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support POST updates to /api/config
- add settings page to web UI
- describe settings endpoint in README
- test config update API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847618ead208321a98b969c0d6137e4