### PR TITLE
Implement search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - One time login tokens with `user token` and `login-token` commands.
 
+## [0.3.6] - 2025-06-24
+### Added
+- Manual subtitle search command with `search` functionality.
+

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Delete subtitle files and remove history records.
 - Track subtitle download history and list with `downloads` command.
 - GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.
-- Track subtitle download history and list with `downloads` command.
+- Manually search for subtitles with `search` command.
 - Provider registry simplifies adding new sources.
 - Dockerfile and workflow for container builds.
 - Prebuilt images published to GitHub Container Registry.
 - Integrated authentication system with password, token, OAuth2 and API key support.
 - Generate one time login tokens using `user token` and authenticate with `login-token`.
-- GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.
 - Minimal React web UI with login page.
 - Role based access control with sensible defaults and session storage in the database.
 
@@ -114,6 +113,7 @@ subtitle-manager history
 subtitle-manager extract [media] [output]
 subtitle-manager fetch opensubtitles [media] [lang] [output]
 subtitle-manager fetch subscene [media] [lang] [output]
+subtitle-manager search opensubtitles [media] [lang]
 subtitle-manager batch [lang] [files...]
 subtitle-manager scan opensubtitles [directory] [lang] [-u]
 subtitle-manager scan subscene [directory] [lang] [-u]

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@ This file tracks planned work, architectural decisions, and implementation statu
    - Download, manage and upgrade subtitles automatically. *(scan command implemented)*
    - Integrate with media servers (e.g. Plex, Emby, Sonarr, Radarr). *(sonarr/radarr commands added)*
    - Concurrent directory scanning for improved performance.
+   - Manual subtitle search on demand. *(search command implemented)*
 
 2. **Configuration with Cobra & Viper**
    - Centralise configuration using Viper.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+)
+
+// searchCmd lists available subtitles from a provider.
+var searchCmd = &cobra.Command{
+	Use:   "search [provider] [media] [lang]",
+	Short: "Search for subtitles without downloading",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("search")
+		name, media, lang := args[0], args[1], args[2]
+		key := viper.GetString("opensubtitles.api_key")
+		p, err := providers.Get(name, key)
+		if err != nil {
+			return err
+		}
+		s, ok := p.(providers.Searcher)
+		if !ok {
+			return fmt.Errorf("provider %s does not support search", name)
+		}
+		urls, err := s.Search(context.Background(), media, lang)
+		if err != nil {
+			return err
+		}
+		for _, u := range urls {
+			fmt.Println(u)
+		}
+		logger.Infof("found %d results", len(urls))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+}

--- a/pkg/providers/opensubtitles/opensubtitles_test.go
+++ b/pkg/providers/opensubtitles/opensubtitles_test.go
@@ -45,6 +45,26 @@ func TestFetch(t *testing.T) {
 	}
 }
 
+// TestSearch lists download links without downloading.
+func TestSearch(t *testing.T) {
+	srv := httptest.NewServer(mockHandler{})
+	defer srv.Close()
+	c := New("")
+	c.APIURL = srv.URL
+	c.HTTPClient = srv.Client()
+	orig := fileHashFunc
+	fileHashFunc = func(string) (uint64, int64, error) { return 1, 1, nil }
+	defer func() { fileHashFunc = orig }()
+
+	urls, err := c.Search(context.Background(), "dummy.mkv", "en")
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+	if len(urls) != 1 || !strings.Contains(urls[0], "/download") {
+		t.Fatalf("unexpected urls: %v", urls)
+	}
+}
+
 // TestNewUsesConfig verifies that viper settings override defaults.
 func TestNewUsesConfig(t *testing.T) {
 	viper.Set("opensubtitles.api_url", "http://api")

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -8,3 +8,9 @@ type Provider interface {
 	// Fetch returns the subtitle bytes for the specified media file and language.
 	Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error)
 }
+
+// Searcher optionally exposes subtitle search functionality.
+type Searcher interface {
+	// Search returns download URLs for matching subtitles without fetching them.
+	Search(ctx context.Context, mediaPath, lang string) ([]string, error)
+}


### PR DESCRIPTION
## Summary
- enable manual search in provider interface
- support manual subtitle search in OpenSubtitles
- add `search` CLI command
- document new capability
- update changelog and todo

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847636438c88321af6a9ec82db8ba1b