### PR TITLE
Implement metadata package with TMDB lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Subtitle Manager is a command line application written in Go for converting, mer
 - Batch translate multiple files concurrently.
 - Monitor directories and automatically download subtitles.
 - Scan existing libraries and fetch missing or upgraded subtitles.
+- Parse file names and retrieve movie or episode details from TheMovieDB.
 - High performance scanning using concurrent workers.
 - Recursive directory watching with -r flag.
 - Integrate with Sonarr and Radarr using dedicated commands.

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,0 +1,174 @@
+// file: pkg/metadata/metadata.go
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var tmdbAPIBase = "https://api.themoviedb.org/3"
+
+// SetTMDBAPIBase overrides the default TMDB API base URL. Primarily used for testing.
+func SetTMDBAPIBase(u string) { tmdbAPIBase = u }
+
+// MediaType differentiates between movie and TV episode metadata.
+type MediaType int
+
+const (
+	// TypeMovie represents a movie file.
+	TypeMovie MediaType = iota
+	// TypeEpisode represents an episode of a TV show.
+	TypeEpisode
+)
+
+// MediaInfo stores basic metadata for a movie or episode.
+type MediaInfo struct {
+	Type         MediaType // movie or episode
+	Title        string    // movie title or show name
+	Year         int       // release year for movies
+	TMDBID       int       // TMDB identifier
+	EpisodeTitle string    // title of the episode (if any)
+	Season       int       // season number for episodes
+	Episode      int       // episode number for episodes
+}
+
+var (
+	tvRegex    = regexp.MustCompile(`(?i)^(.*?)[ ._-]+s(\d{1,2})e(\d{1,2})`)
+	movieRegex = regexp.MustCompile(`(?i)^(.*?)[ ._\(](\d{4})`)
+)
+
+// ParseFileName attempts to derive metadata from a media file name.
+// It recognises common patterns such as "Show.Name.S01E02" for episodes
+// and "Movie Title (2020)" for movies.
+func ParseFileName(path string) (*MediaInfo, error) {
+	name := filepath.Base(path)
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+
+	if m := tvRegex.FindStringSubmatch(name); m != nil {
+		season, _ := strconv.Atoi(m[2])
+		episode, _ := strconv.Atoi(m[3])
+		title := cleanTitle(m[1])
+		return &MediaInfo{Type: TypeEpisode, Title: title, Season: season, Episode: episode}, nil
+	}
+	if m := movieRegex.FindStringSubmatch(name); m != nil {
+		year, _ := strconv.Atoi(m[2])
+		title := cleanTitle(m[1])
+		return &MediaInfo{Type: TypeMovie, Title: title, Year: year}, nil
+	}
+	return nil, fmt.Errorf("unrecognised file name")
+}
+
+func cleanTitle(s string) string {
+	s = strings.ReplaceAll(s, ".", " ")
+	s = strings.ReplaceAll(s, "_", " ")
+	return strings.TrimSpace(s)
+}
+
+// QueryMovie searches TMDB for a movie matching the title and optional year.
+// It returns the first result's metadata.
+func QueryMovie(ctx context.Context, title string, year int, apiKey string) (*MediaInfo, error) {
+	q := url.Values{}
+	q.Set("api_key", apiKey)
+	q.Set("query", title)
+	if year > 0 {
+		q.Set("year", strconv.Itoa(year))
+	}
+	u := fmt.Sprintf("%s/search/movie?%s", tmdbAPIBase, q.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var mr struct {
+		Results []struct {
+			ID          int    `json:"id"`
+			Title       string `json:"title"`
+			Overview    string `json:"overview"`
+			ReleaseDate string `json:"release_date"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+		return nil, err
+	}
+	if len(mr.Results) == 0 {
+		return nil, fmt.Errorf("movie not found")
+	}
+	r := mr.Results[0]
+	y := year
+	if y == 0 && len(r.ReleaseDate) >= 4 {
+		y, _ = strconv.Atoi(r.ReleaseDate[:4])
+	}
+	return &MediaInfo{Type: TypeMovie, Title: r.Title, Year: y, TMDBID: r.ID}, nil
+}
+
+// QueryEpisode retrieves episode details from TMDB. The function searches for
+// the show by title then requests the specific season and episode metadata.
+func QueryEpisode(ctx context.Context, show string, season, episode int, apiKey string) (*MediaInfo, error) {
+	q := url.Values{}
+	q.Set("api_key", apiKey)
+	q.Set("query", show)
+	u := fmt.Sprintf("%s/search/tv?%s", tmdbAPIBase, q.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var sr struct {
+		Results []struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return nil, err
+	}
+	if len(sr.Results) == 0 {
+		return nil, fmt.Errorf("show not found")
+	}
+	sid := sr.Results[0].ID
+	showName := sr.Results[0].Name
+
+	u = fmt.Sprintf("%s/tv/%d/season/%d/episode/%d?api_key=%s", tmdbAPIBase, sid, season, episode, url.QueryEscape(apiKey))
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var er struct {
+		ID      int    `json:"id"`
+		Name    string `json:"name"`
+		AirDate string `json:"air_date"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return nil, err
+	}
+	return &MediaInfo{Type: TypeEpisode, Title: showName, Season: season, Episode: episode, EpisodeTitle: er.Name, TMDBID: er.ID}, nil
+}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,69 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseFileName(t *testing.T) {
+	m, err := ParseFileName("Show.Name.S01E02.mkv")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Type != TypeEpisode || m.Title != "Show Name" || m.Season != 1 || m.Episode != 2 {
+		t.Fatalf("unexpected result: %+v", m)
+	}
+	m, err = ParseFileName("Movie Title (2020).mp4")
+	if err != nil {
+		t.Fatalf("parse movie: %v", err)
+	}
+	if m.Type != TypeMovie || m.Title != "Movie Title" || m.Year != 2020 {
+		t.Fatalf("unexpected movie: %+v", m)
+	}
+}
+
+func TestQueryMovie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search/movie" {
+			fmt.Fprint(w, `{"results":[{"id":1,"title":"Test","release_date":"2020-01-01"}]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	SetTMDBAPIBase(srv.URL)
+
+	m, err := QueryMovie(context.Background(), "Test", 0, "key")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if m.TMDBID != 1 || m.Title != "Test" || m.Year != 2020 {
+		t.Fatalf("unexpected movie: %+v", m)
+	}
+}
+
+func TestQueryEpisode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/tv":
+			fmt.Fprint(w, `{"results":[{"id":2,"name":"Show"}]}`)
+		case "/tv/2/season/1/episode/3":
+			fmt.Fprint(w, `{"id":5,"name":"Episode"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	SetTMDBAPIBase(srv.URL)
+
+	m, err := QueryEpisode(context.Background(), "Show", 1, 3, "key")
+	if err != nil {
+		t.Fatalf("query ep: %v", err)
+	}
+	if m.TMDBID != 5 || m.Title != "Show" || m.EpisodeTitle != "Episode" || m.Season != 1 || m.Episode != 3 {
+		t.Fatalf("unexpected episode: %+v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- add `pkg/metadata` package
- implement filename parsing and TheMovieDB API queries
- document new capability in README
- test metadata parsing and lookup functionality

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684770c8a878832187a8ddb4771a4295