### PR TITLE
Refactor Google Translate provider to use SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,7 @@ All notable changes to this project will be documented in this file.
 - `media_items` table to store video metadata for library scanning.
 - Library scan command `scanlib` populating the `media_items` table.
 - REST endpoint `/api/extract` exposing subtitle extraction from media.
+
+## [0.3.9] - 2025-06-26
+### Changed
+- `GoogleTranslate` now uses the official Google Cloud SDK instead of manual HTTP requests.

--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@ This file tracks planned work, architectural decisions, and implementation statu
    - Automatically fetch subtitles when media appears. *(recursive watching implemented)*
 
 8. **Future Enhancements**
-   - Replace manual HTTP calls with provider SDKs where available.
+   - Replace manual HTTP calls with provider SDKs where available. *(Google Translate now uses the official SDK)*
    - Asynchronous processing for bulk translations implemented via the `batch` command.
    - Evaluate performance of subtitle merging and translation.
    - Add optional web interface for managing subtitles. *(initial login page implemented)*

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -181,7 +181,7 @@ type TranslateFunc func(ctx context.Context, text, lang string) (string, error)
 
 ### 7.1 Google Translate
 
-`GoogleTranslate(text, lang, apiKey string) (string, error)` issues a POST request to the Google Translate API endpoint. The result is parsed from JSON and returned. API keys are read from configuration.
+`GoogleTranslate(text, lang, apiKey string) (string, error)` uses the official Google Cloud client library. A client is created with `option.WithAPIKey` and the endpoint can be overridden for tests. The translation result is returned from the SDK response.
 
 ### 7.2 ChatGPT
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.21
-	github.com/sashabaranov/go-openai v1.40.1
-	github.com/sirupsen/logrus v1.9.3
-	github.com/sourcegraph/conc v0.3.0
+        github.com/sashabaranov/go-openai v1.40.1
+        github.com/sirupsen/logrus v1.9.3
+        cloud.google.com/go/translate v1.12.5
+        github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	golang.org/x/crypto v0.39.0

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -16,11 +16,9 @@ import (
 
 func TestGoogleTranslate(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		r.Body.Close()
-		s := string(body)
-		if !(strings.Contains(s, "q=hello") && strings.Contains(s, "target=es") && strings.Contains(s, "key=test")) {
-			t.Fatalf("unexpected request body: %s", s)
+		q := r.URL.RawQuery
+		if !(strings.Contains(q, "q=hello") && strings.Contains(q, "target=es") && strings.Contains(q, "key=test")) {
+			t.Fatalf("unexpected query: %s", q)
 		}
 		fmt.Fprint(w, `{"data":{"translations":[{"translatedText":"hola"}]}}`)
 	}))


### PR DESCRIPTION
## Summary
- refactor `GoogleTranslate` to use the official Google Cloud SDK
- note the new approach in the technical design docs
- update TODO and changelog
- adjust tests for new HTTP request pattern
- add dependency to `go.mod`

## Testing
- `go mod tidy` *(fails: Forbidden when fetching modules)*
- `go test ./...` *(fails: missing go.sum entry for cloud.google.com/go/translate)*

------
https://chatgpt.com/codex/tasks/task_e_684a40d917d88321bdb37a92dc7e5877