### PR TITLE
Add Plex library integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Parse file names and retrieve movie or episode details from TheMovieDB.
 - High performance scanning using concurrent workers.
 - Recursive directory watching with -r flag.
-- Integrate with Sonarr and Radarr using dedicated commands.
+- Integrate with Sonarr, Radarr and Plex using dedicated commands.
 - Run a translation gRPC server.
 - Delete subtitle files and remove history records.
 - Track subtitle download history and list with `downloads` command.

--- a/cmd/plex.go
+++ b/cmd/plex.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/database"
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/plex"
+)
+
+var plexCmd = &cobra.Command{
+	Use:   "plex",
+	Short: "Interact with Plex server",
+}
+
+var plexLibraryCmd = &cobra.Command{
+	Use:   "library",
+	Short: "Sync Plex library into database",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("plex")
+		url := viper.GetString("plex.url")
+		token := viper.GetString("plex.token")
+		if url == "" || token == "" {
+			return cmd.Usage()
+		}
+		c := plex.NewClient(url, token)
+		ctx := context.Background()
+		items, err := c.AllItems(ctx)
+		if err != nil {
+			return err
+		}
+		dbPath := viper.GetString("db_path")
+		backend := viper.GetString("db_backend")
+		store, err := database.OpenStore(dbPath, backend)
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+		for _, it := range items {
+			rec := &database.MediaItem{Path: it.Path, Title: it.Title, Season: it.Season, Episode: it.Episode}
+			if err := store.InsertMediaItem(rec); err != nil {
+				logger.Warnf("insert %s: %v", it.Path, err)
+			}
+		}
+		logger.Infof("synced %d items", len(items))
+		return nil
+	},
+}
+
+var refreshKey string
+
+var plexRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Trigger Plex to refresh the library",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url := viper.GetString("plex.url")
+		token := viper.GetString("plex.token")
+		if url == "" || token == "" {
+			return cmd.Usage()
+		}
+		c := plex.NewClient(url, token)
+		ctx := context.Background()
+		if refreshKey != "" {
+			return c.RefreshItem(ctx, refreshKey)
+		}
+		return c.RefreshLibrary(ctx)
+	},
+}
+
+func init() {
+	plexCmd.PersistentFlags().String("url", "", "Plex base URL")
+	plexCmd.PersistentFlags().String("token", "", "Plex API token")
+	viper.BindPFlag("plex.url", plexCmd.PersistentFlags().Lookup("url"))
+	viper.BindPFlag("plex.token", plexCmd.PersistentFlags().Lookup("token"))
+
+	plexRefreshCmd.Flags().StringVar(&refreshKey, "item", "", "ratingKey of item to refresh")
+	plexCmd.AddCommand(plexLibraryCmd)
+	plexCmd.AddCommand(plexRefreshCmd)
+	rootCmd.AddCommand(plexCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,8 @@ func initConfig() {
 		viper.SetDefault("providers.generic.username", "")
 		viper.SetDefault("providers.generic.password", "")
 		viper.SetDefault("providers.generic.api_key", "")
+		viper.SetDefault("plex.url", "http://localhost:32400")
+		viper.SetDefault("plex.token", "")
 	}
 
 	if err := viper.ReadInConfig(); err == nil {

--- a/pkg/plex/client.go
+++ b/pkg/plex/client.go
@@ -1,0 +1,139 @@
+// file: pkg/plex/client.go
+package plex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Client provides minimal access to the Plex HTTP API.
+// BaseURL should include protocol and host (e.g. http://localhost:32400).
+// Token is the user's Plex API token.
+type Client struct {
+	BaseURL string
+	Token   string
+	client  *http.Client
+}
+
+// NewClient returns a configured Plex API client.
+func NewClient(baseURL, token string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Token:   token,
+		client:  &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) buildURL(path string) string {
+	if strings.Contains(path, "?") {
+		return fmt.Sprintf("%s%s&X-Plex-Token=%s", c.BaseURL, path, url.QueryEscape(c.Token))
+	}
+	return fmt.Sprintf("%s%s?X-Plex-Token=%s", c.BaseURL, path, url.QueryEscape(c.Token))
+}
+
+// LibraryItem represents a single media file in Plex.
+type LibraryItem struct {
+	Path    string // absolute file path
+	Title   string // movie or show title
+	Season  int    // season number if episode
+	Episode int    // episode number if episode
+	Key     string // Plex ratingKey
+}
+
+type mediaContainer struct {
+	MediaContainer struct {
+		Metadata []struct {
+			Type             string `json:"type"`
+			Title            string `json:"title"`
+			RatingKey        string `json:"ratingKey"`
+			GrandparentTitle string `json:"grandparentTitle"`
+			ParentIndex      int    `json:"parentIndex"`
+			Index            int    `json:"index"`
+			Media            []struct {
+				Part []struct {
+					File string `json:"file"`
+				} `json:"Part"`
+			} `json:"Media"`
+		} `json:"Metadata"`
+	} `json:"MediaContainer"`
+}
+
+// AllItems retrieves all movies and episodes from the Plex library.
+func (c *Client) AllItems(ctx context.Context) ([]LibraryItem, error) {
+	u := c.buildURL("/library/sections/all")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var mc mediaContainer
+	if err := json.NewDecoder(resp.Body).Decode(&mc); err != nil {
+		return nil, err
+	}
+	var items []LibraryItem
+	for _, m := range mc.MediaContainer.Metadata {
+		if len(m.Media) == 0 || len(m.Media[0].Part) == 0 {
+			continue
+		}
+		it := LibraryItem{Path: m.Media[0].Part[0].File, Key: m.RatingKey}
+		if m.Type == "episode" {
+			it.Title = m.GrandparentTitle
+			it.Season = m.ParentIndex
+			it.Episode = m.Index
+		} else {
+			it.Title = m.Title
+		}
+		items = append(items, it)
+	}
+	return items, nil
+}
+
+// RefreshLibrary triggers a full Plex library refresh.
+func (c *Client) RefreshLibrary(ctx context.Context) error {
+	u := c.buildURL("/library/sections/all/refresh")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// RefreshItem triggers a scan for a single library item identified by ratingKey.
+func (c *Client) RefreshItem(ctx context.Context, key string) error {
+	path := fmt.Sprintf("/library/metadata/%s/refresh", url.PathEscape(key))
+	u := c.buildURL(path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/plex/client_test.go
+++ b/pkg/plex/client_test.go
@@ -1,0 +1,62 @@
+package plex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/library/sections/all" || r.URL.Query().Get("X-Plex-Token") != "tok" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"MediaContainer":{"Metadata":[{"type":"movie","title":"Movie","ratingKey":"1","Media":[{"Part":[{"file":"/m.mov"}]}]},{"type":"episode","grandparentTitle":"Show","parentIndex":1,"index":2,"ratingKey":"2","Media":[{"Part":[{"file":"/s.mkv"}]}]}]}}`)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, "tok")
+	items, err := c.AllItems(context.Background())
+	if err != nil {
+		t.Fatalf("items: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Title != "Movie" || items[1].Season != 1 || items[1].Episode != 2 {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+}
+
+func TestRefresh(t *testing.T) {
+	calledAll := false
+	calledItem := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/library/sections/all/refresh":
+			calledAll = true
+		case "/library/metadata/5/refresh":
+			calledItem = true
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	if err := c.RefreshLibrary(context.Background()); err != nil {
+		t.Fatalf("refresh all: %v", err)
+	}
+	if !calledAll {
+		t.Fatal("all refresh not called")
+	}
+	if err := c.RefreshItem(context.Background(), "5"); err != nil {
+		t.Fatalf("refresh item: %v", err)
+	}
+	if !calledItem {
+		t.Fatal("item refresh not called")
+	}
+}


### PR DESCRIPTION
## Summary
- integrate with Plex API via new `pkg/plex` package
- add `plex` command with `library` and `refresh` subcommands
- default plex configuration options
- document Plex support in the README
- test Plex client functionality

## Testing
- `go test ./...` *(fails: Get https://storage.googleapis.com/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b172872ac83218acea92dd3585c5d