### PR TITLE
Plan Bazarr settings import

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Extensive architectural details and design decisions are documented in
 `docs/TECHNICAL_DESIGN.md`. New contributors should review this document to
 understand package responsibilities and future plans.
 For a detailed list of Bazarr features used as the parity target, see [docs/BAZARR_FEATURES.md](docs/BAZARR_FEATURES.md).
+Instructions for importing an existing Bazarr configuration are documented in [docs/BAZARR_SETTINGS_SYNC.md](docs/BAZARR_SETTINGS_SYNC.md).
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,15 @@ This file tracks remaining work and implementation status for Subtitle Manager. 
 - [ ] Mark completed items in roadmap sections
 - [ ] Document new REST endpoints and web UI pages
 
+### 4. Bazarr Configuration Import
+
+- [ ] Implement `import-bazarr` command that fetches settings from `/api/system/settings`
+  using the user's API key.
+- [ ] Map Bazarr preferences for languages, providers and network options into
+  the Viper configuration.
+- [ ] Document the synchronization process in `docs/BAZARR_SETTINGS_SYNC.md` and
+  expose it through the welcome workflow.
+
 ## ✅ Completed Major Features
 
 ### Core Functionality (100% Complete)

--- a/docs/BAZARR_SETTINGS_SYNC.md
+++ b/docs/BAZARR_SETTINGS_SYNC.md
@@ -1,0 +1,26 @@
+# Importing Settings from Bazarr
+
+Existing Bazarr users can migrate their configuration to Subtitle Manager to avoid re-entering preferences. Bazarr exposes a REST API implemented with Flask. The following endpoints are useful:
+
+- `/api/system/settings` – returns the complete settings object (general options, proxy, authentication, notifier URLs, etc.).
+- `/api/system/languages` – lists all languages with `enabled` flags.
+- `/api/providers` – returns provider status and names.
+- `/api/webhooks/radarr` and `/api/webhooks/sonarr` – trigger subtitle searches from Sonarr/Radarr events.
+
+### Proposed Synchronization
+
+1. **Fetch settings** from `/api/system/settings` using the user-provided Bazarr API key.
+2. **Map fields** to the Viper configuration keys used by Subtitle Manager:
+   - Network options (bind address, port, URL base) → `web.*` configuration.
+   - Authentication and API key → `auth.*` fields.
+   - Enabled providers and languages → `providers.*` and `languages.*` sections.
+3. **Save the mapped configuration** via the `/api/config` endpoint or by writing the YAML file directly.
+4. **Optional CLI command** `import-bazarr` to perform the import and start a migration wizard.
+
+### Benefits
+
+- Quick onboarding for users already running Bazarr.
+- Ensures subtitle provider credentials and language profiles remain consistent.
+- Reduces configuration errors by reusing verified settings.
+
+Further implementation details should consider error handling for unreachable Bazarr instances and partial imports when settings do not have direct equivalents.

--- a/pkg/bazarr/client.go
+++ b/pkg/bazarr/client.go
@@ -1,0 +1,37 @@
+package bazarr
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Settings represents a subset of Bazarr's configuration used for import.
+type Settings map[string]any
+
+// FetchSettings retrieves Bazarr settings from the given baseURL using the provided API key.
+// The baseURL should include scheme and host, for example "http://localhost:6767".
+// A non-200 status code results in an error.
+func FetchSettings(baseURL, apiKey string) (Settings, error) {
+	url := fmt.Sprintf("%s/api/system/settings", baseURL)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-KEY", apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	var cfg Settings
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
## Summary
- document how to import settings from Bazarr
- reference the new doc in README
- note new Bazarr config import tasks in TODO
- add basic Bazarr API client

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_684b17aa888c8321b6426e345c5c1ab4