### PR TITLE
Add autoscan scheduler and document missing Bazarr features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - In Progress
 ### Planned
 - Complete web UI with History, System, and Wanted pages
+- Basic scheduler with `autoscan` command for periodic scans
 - Additional REST API endpoints for download, convert, and translate operations
 - File upload functionality for web-based subtitle conversion and translation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Subtitle Manager
 
-Subtitle Manager is a comprehensive subtitle management application written in Go that provides both CLI and web interfaces for converting, translating, and managing subtitle files. **The project has achieved feature parity with Bazarr and is production-ready.**
+Subtitle Manager is a comprehensive subtitle management application written in Go that provides both CLI and web interfaces for converting, translating, and managing subtitle files. The project aims to reach feature parity with Bazarr. Some advanced features such as scheduling and webhooks are still in progress.
 
 ## ✨ Key Highlights
 
@@ -25,6 +25,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Batch translate multiple files concurrently.
 - Monitor directories and automatically download subtitles.
 - Scan existing libraries and fetch missing or upgraded subtitles.
+- Schedule periodic scans with the `autoscan` command.
 - Parse file names and retrieve movie or episode details from TheMovieDB.
 - High performance scanning using concurrent workers.
 - Recursive directory watching with -r flag.
@@ -127,6 +128,7 @@ subtitle-manager search opensubtitles [media] [lang]
 subtitle-manager batch [lang] [files...]
 subtitle-manager scan opensubtitles [directory] [lang] [-u]
 subtitle-manager scan subscene [directory] [lang] [-u]
+subtitle-manager autoscan [provider] [directory] [lang] [-i duration] [-u]
 subtitle-manager scanlib [directory]
 subtitle-manager watch opensubtitles [directory] [lang] [-r]
 subtitle-manager watch subscene [directory] [lang] [-r]

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,14 @@ This file tracks remaining work and implementation status for Subtitle Manager. 
 - [ ] Mark completed items in roadmap sections
 - [ ] Document new REST endpoints and web UI pages
 
-### 4. Bazarr Configuration Import
+### 4. Remaining Bazarr Features
+- [ ] PostgreSQL database backend
+- [ ] Reverse proxy base URL support
+- [ ] Webhook endpoint for Plex events
+- [ ] Anti-captcha service integration
+- [ ] Scheduler for Sonarr/Radarr sync and subtitle upgrades
+
+### 5. Bazarr Configuration Import
 
 - [ ] Implement `import-bazarr` command that fetches settings from `/api/system/settings`
   using the user's API key.

--- a/cmd/autoscan.go
+++ b/cmd/autoscan.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/database"
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/scheduler"
+)
+
+var interval time.Duration
+
+// autoscanCmd periodically scans a directory for subtitles using a provider.
+var autoscanCmd = &cobra.Command{
+	Use:   "autoscan [provider] [directory] [lang]",
+	Short: "Periodically scan directory and download subtitles",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("autoscan")
+		name, dir, lang := args[0], args[1], args[2]
+		key := viper.GetString("opensubtitles.api_key")
+		p, err := providers.Get(name, key)
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		var store database.SubtitleStore
+		if dbPath := viper.GetString("db_path"); dbPath != "" {
+			backend := viper.GetString("db_backend")
+			if s, err := database.OpenStore(dbPath, backend); err == nil {
+				store = s
+				defer s.Close()
+			} else {
+				logger.Warnf("db open: %v", err)
+			}
+		}
+		workers := viper.GetInt("scan_workers")
+		return scheduler.ScheduleScanDirectory(ctx, interval, dir, lang, name, p, upgrade, workers, store)
+	},
+}
+
+func init() {
+	autoscanCmd.Flags().DurationVarP(&interval, "interval", "i", time.Hour, "scan interval")
+	autoscanCmd.Flags().BoolVarP(&upgrade, "upgrade", "u", false, "replace existing subtitles")
+	rootCmd.AddCommand(autoscanCmd)
+}

--- a/pkg/scheduler/scan.go
+++ b/pkg/scheduler/scan.go
@@ -1,0 +1,19 @@
+// file: pkg/scheduler/scan.go
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"subtitle-manager/pkg/database"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/scanner"
+)
+
+// ScheduleScanDirectory periodically scans dir for subtitles using provider p.
+// The scan runs immediately and then every interval until ctx is canceled.
+func ScheduleScanDirectory(ctx context.Context, interval time.Duration, dir, lang, providerName string, p providers.Provider, upgrade bool, workers int, store database.SubtitleStore) error {
+	return Run(ctx, interval, func(ctx context.Context) error {
+		return scanner.ScanDirectory(ctx, dir, lang, providerName, p, upgrade, workers, store)
+	})
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,31 @@
+// file: pkg/scheduler/scheduler.go
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"subtitle-manager/pkg/logging"
+)
+
+// Run executes fn immediately and then at each interval until ctx is canceled.
+// Errors returned by fn after the first execution are logged and do not stop
+// subsequent runs. The initial error is returned to the caller.
+func Run(ctx context.Context, interval time.Duration, fn func(context.Context) error) error {
+	logger := logging.GetLogger("scheduler")
+	if err := fn(ctx); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := fn(ctx); err != nil && ctx.Err() == nil {
+				logger.Warnf("scheduled run: %v", err)
+			}
+		}
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,28 @@
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRun verifies that Run invokes the task repeatedly until the context is cancelled.
+func TestRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var n int32
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		cancel()
+	}()
+	err := Run(ctx, 50*time.Millisecond, func(context.Context) error {
+		atomic.AddInt32(&n, 1)
+		return nil
+	})
+	if err != context.Canceled {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if n < 2 {
+		t.Fatalf("expected at least 2 executions, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary
- note outstanding Bazarr features in README, TODO and CHANGELOG
- implement scheduler package and autoscan command
- document autoscan command and update usage instructions

## Testing
- `go test ./...` *(fails: Forbidden while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_684b18b646dc8321becd62de9ce5859b