### PR TITLE
Ensure web UI assets built during compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - Basic scheduler with `autoscan` command for periodic scans
 - Additional REST API endpoints for download, convert, and translate operations
 - File upload functionality for web-based subtitle conversion and translation
+- Build process now runs `go generate ./webui` to embed the latest web assets
+  in the binary and container image.
 
 ## [0.3.9] - 2025-06-26
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+RUN go generate ./webui
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o subtitle-manager ./
 
 FROM gcr.io/distroless/static

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ github_redirect_url: http://localhost:8080/api/oauth/github/callback
 # clone repository
 $ git clone <this repository>
 $ cd subtitle-manager
-# install dependencies and build
+# install dependencies, build web UI and compile
+$ go generate ./webui
 $ go build
 ```
 
@@ -191,6 +192,9 @@ Build a container image using the provided `Dockerfile`:
 ```bash
 $ docker build -t subtitle-manager .
 ```
+
+The Docker build runs `go generate ./webui` so the final image contains the latest
+compiled web assets.
 
 Run commands inside the container:
 

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -415,9 +415,9 @@ The project follows the Go community style guide in addition to rules in `AGENTS
 
 ## 22. Future Enhancements
 
-Additional features under consideration:
+-Additional features under consideration:
 
-- **Web Interface** – Provide a lightweight web UI for managing translations and history. Implementation uses a React app built with Vite in `webui`. `go generate` builds the frontend and embeds it using the `embed` package for serving via the `web` command.
+- **Web Interface** – Provide a lightweight web UI for managing translations and history. Implementation uses a React app built with Vite in `webui`. `go generate` builds the frontend and embeds it using the `embed` package for serving via the `web` command. Run `go generate ./webui` before compiling the binary to ensure the latest assets are included.
 - **Asynchronous Queue** – Use a worker queue for heavy translation tasks.
 - **Cloud Storage** – Allow storing subtitles and history in cloud buckets.
 - **Internationalisation** – Localise CLI messages and documentation.


### PR DESCRIPTION
## Summary
- document running `go generate ./webui` before `go build`
- run webui generation in the Dockerfile
- update technical design notes and changelog

## Testing
- `go test ./...` *(fails: translate test needs Google credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684b3763518483219a135896263cb167