### PR TITLE
Add whisper transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Store translation history in an SQLite database or optional PebbleDB store. The backend can be selected with `--db-backend`.
 - Per component logging with adjustable levels.
 - Extract subtitles from media containers using ffmpeg.
+- Transcribe audio tracks to subtitles via Whisper.
 - Download subtitles from a comprehensive list of providers based on Bazarr,
   including Addic7ed, AnimeKalesi, Animetosho, Assrt, Avistaz, BetaSeries,
   BSplayer, GreekSubs, Podnapisi, Subscene, TVSubtitles, Titlovi, LegendasDivx
@@ -123,6 +124,7 @@ subtitle-manager merge [sub1] [sub2] [output]
 subtitle-manager translate [input] [output] [lang]
 subtitle-manager history
 subtitle-manager extract [media] [output]
+subtitle-manager transcribe [media] [output] [lang]
 subtitle-manager fetch opensubtitles [media] [lang] [output]
 subtitle-manager fetch subscene [media] [lang] [output]
 subtitle-manager search opensubtitles [media] [lang]

--- a/cmd/grpcserver_cmd_test.go
+++ b/cmd/grpcserver_cmd_test.go
@@ -29,7 +29,7 @@ func TestServerTranslate(t *testing.T) {
 	defer translator.SetGoogleAPIURL("https://translation.googleapis.com/language/translate/v2")
 
 	s := grpc.NewServer()
-	pb.RegisterTranslatorServer(s, &server{})
+	pb.RegisterTranslatorServer(s, &server{googleKey: "k"})
 	go s.Serve(lis)
 	defer s.Stop()
 

--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/transcriber"
+)
+
+// transcribeCmd generates subtitles from audio using the Whisper API.
+var transcribeCmd = &cobra.Command{
+	Use:   "transcribe [media] [output] [lang]",
+	Short: "Transcribe media to subtitles",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("transcribe")
+		media, out, lang := args[0], args[1], args[2]
+		key := viper.GetString("openai_api_key")
+		data, err := transcriber.WhisperTranscribe(media, lang, key)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(out, data, 0644); err != nil {
+			return err
+		}
+		logger.Infof("transcribed %s to %s", media, out)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(transcribeCmd)
+}

--- a/pkg/transcriber/transcriber.go
+++ b/pkg/transcriber/transcriber.go
@@ -1,0 +1,46 @@
+package transcriber
+
+import (
+	"context"
+	"fmt"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// whisperModel is the OpenAI model used for transcriptions.
+var whisperModel = openai.Whisper1
+
+// baseURL points to the OpenAI API. Tests may override it.
+var baseURL = "https://api.openai.com/v1"
+
+// SetWhisperModel overrides the default Whisper model for testing purposes.
+func SetWhisperModel(m string) {
+	whisperModel = m
+}
+
+// SetBaseURL overrides the OpenAI API base URL.
+func SetBaseURL(u string) {
+	baseURL = u
+}
+
+// WhisperTranscribe transcribes the media file at path using the Whisper API.
+// The language code may be empty to enable auto detection. The API key is
+// required. It returns the SRT subtitle bytes produced by the service.
+func WhisperTranscribe(path, lang, apiKey string) ([]byte, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("api key required")
+	}
+	cfg := openai.DefaultConfig(apiKey)
+	cfg.BaseURL = baseURL
+	client := openai.NewClientWithConfig(cfg)
+	resp, err := client.CreateTranscription(context.Background(), openai.AudioRequest{
+		Model:    whisperModel,
+		FilePath: path,
+		Language: lang,
+		Format:   openai.AudioResponseFormatSRT,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return []byte(resp.Text), nil
+}

--- a/pkg/transcriber/transcriber_test.go
+++ b/pkg/transcriber/transcriber_test.go
@@ -1,0 +1,42 @@
+package transcriber
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWhisperTranscribe verifies that the request is made to the correct
+// endpoint and the subtitle text is returned.
+func TestWhisperTranscribe(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		fmt.Fprint(w, "1\n00:00:00,000 --> 00:00:01,000\ntext\n")
+	}))
+	defer srv.Close()
+
+	SetBaseURL(srv.URL + "/v1")
+	defer SetBaseURL("https://api.openai.com/v1")
+	SetWhisperModel("whisper-1")
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.wav")
+	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	b, err := WhisperTranscribe(file, "en", "k")
+	if err != nil {
+		t.Fatalf("transcribe: %v", err)
+	}
+	if gotPath != "/v1/audio/transcriptions" {
+		t.Fatalf("unexpected path %s", gotPath)
+	}
+	if len(b) == 0 {
+		t.Fatalf("empty result")
+	}
+}


### PR DESCRIPTION
## Summary
- add a `transcriber` package with Whisper helper
- implement `transcribe` CLI command
- update gRPC server test setup
- document Whisper transcription feature in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b37e4259c8321b0f724902adc4f5e