### PR TITLE
Fix update-issues workflow duplication

### DIFF
--- a/.github/workflows/update-issues.yml
+++ b/.github/workflows/update-issues.yml
@@ -13,20 +13,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update GitHub issues
+        id: issues
         if: ${{ hashFiles('issue_updates.json') != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
+          processed=0
           jq -c '.[]' issue_updates.json | while read -r item; do
             action=$(echo "$item" | jq -r '.action')
             if [ "$action" = "create" ]; then
-              echo "Creating issue"
-              curl -s -X POST \
-                -H "Authorization: Bearer $GH_TOKEN" \
+              title=$(echo "$item" | jq -r '.title')
+              encoded_title=$(printf '%s' "$title" | jq -sRr @uri)
+              count=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${REPO}/issues" \
-                -d "$(echo "$item" | jq 'del(.action)')"
+                "https://api.github.com/search/issues?q=repo:${REPO}+is:issue+in:title+${encoded_title}" | jq '.total_count')
+              if [ "$count" -eq 0 ]; then
+                echo "Creating issue '$title'"
+                curl -s -X POST \
+                  -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/${REPO}/issues" \
+                  -d "$(echo "$item" | jq 'del(.action)')"
+              else
+                echo "Issue '$title' already exists, skipping"
+              fi
             elif [ "$action" = "update" ]; then
               num=$(echo "$item" | jq -r '.number')
               echo "Updating issue $num"
@@ -49,4 +60,17 @@ jobs:
                 https://api.github.com/graphql \
                 -d "$mutation"
             fi
+            processed=1
           done
+          echo "processed=$processed" >> "$GITHUB_OUTPUT"
+      - name: Remove issue_updates.json
+        if: steps.issues.outputs.processed == '1'
+        run: rm issue_updates.json
+      - name: Create pull request for cleanup
+        if: steps.issues.outputs.processed == '1'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: issue-updates-${{ github.run_id }}
+          commit-message: 'Remove processed issue updates'
+          title: 'Remove processed issue updates'
+          body: 'Remove processed entries from issue_updates.json.'

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Continuous integration is provided via a GitHub Actions workflow that verifies f
 
 ### Issue updates
 
-Pushing an `issue_updates.json` file to the repository root allows the `update-issues` workflow to create, update or delete GitHub issues using the repository `GITHUB_TOKEN`. The file contains a JSON array where each object specifies an `action` and any supported issue fields. Example:
+Pushing an `issue_updates.json` file to the repository root allows the `update-issues` workflow to create, update or delete GitHub issues using the repository `GITHUB_TOKEN`. The file contains a JSON array where each object specifies an `action` and any supported issue fields. Duplicate issues are avoided by checking for an existing issue with the same title before creation. Example:
 
 ```json
 [
@@ -228,7 +228,7 @@ Pushing an `issue_updates.json` file to the repository root allows the `update-i
 ]
 ```
 
-The workflow runs on every push to `main` and processes the listed operations.
+The workflow runs on every push to `main` and processes the listed operations. After all entries are handled the file is removed on a new branch and a pull request is opened so that the cleanup can be merged back to `main`.
 
 The project aims to eventually reach feature parity with [Bazarr](https://github.com/morpheus65535/bazarr) while offering improved configuration and logging. See `TODO.md` for the full roadmap and implementation plan.
 Extensive architectural details and design decisions are documented in


### PR DESCRIPTION
## Summary
- prevent duplicate issues by checking existing issues before creation
- clean up processed `issue_updates.json` via PR
- document new behaviour in README

## Testing
- `go vet ./...`
- `go test ./...` *(fails: rpc error: could not find default credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684b3a395594832199add839c16eb38c