### PR TITLE
Add issue deduplication workflow

### DIFF
--- a/.github/scripts/close-duplicates.sh
+++ b/.github/scripts/close-duplicates.sh
@@ -1,0 +1,43 @@
+# file: .github/scripts/close-duplicates.sh
+#!/bin/bash
+
+# Close duplicate GitHub issues by title, keeping the lowest numbered issue open.
+# Parameters are provided via environment variables:
+#   GH_TOKEN - GitHub token with repo permissions
+#   REPO     - owner/repo name, e.g. "user/project"
+# The script fetches all open issues, groups them by title, and closes
+# duplicates while commenting with a reference to the canonical issue.
+
+set -euo pipefail
+
+if [[ -z "${GH_TOKEN:-}" || -z "${REPO:-}" ]]; then
+  echo "GH_TOKEN and REPO must be set" >&2
+  exit 1
+fi
+
+issues=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${REPO}/issues?state=open&per_page=100")
+
+echo "$issues" | jq -c '.[] | {number, title}' | \
+  jq -s 'group_by(.title)[] | select(length>1)' | while read -r group; do
+    canonical=$(echo "$group" | jq 'min_by(.number)')
+    canonical_num=$(echo "$canonical" | jq -r '.number')
+
+    echo "$group" | jq -c '.[]' | while read -r issue; do
+        num=$(echo "$issue" | jq -r '.number')
+        if [[ "$num" != "$canonical_num" ]]; then
+            echo "Closing #$num as duplicate of #$canonical_num"
+            curl -s -X PATCH \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/issues/$num" \
+              -d '{"state":"closed"}' > /dev/null
+            curl -s -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/issues/$num/comments" \
+              -d "{\"body\":\"Duplicate of #$canonical_num\"}" > /dev/null
+        fi
+    done
+  done

--- a/.github/workflows/close-duplicates.yml
+++ b/.github/workflows/close-duplicates.yml
@@ -1,0 +1,21 @@
+# file: .github/workflows/close-duplicates.yml
+name: Close Duplicate Issues
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  deduplicate:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Close duplicates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/close-duplicates.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - File upload functionality for web-based subtitle conversion and translation
 - Build process now runs `go generate ./webui` to embed the latest web assets
   in the binary and container image.
+- Automated workflow closes duplicate issues by title
 
 ## [0.3.9] - 2025-06-26
 ### Changed

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Pushing an `issue_updates.json` file to the repository root allows the `update-i
 
 The workflow runs on every push to `main` and processes the listed operations. After all entries are handled the file is removed on a new branch and a pull request is opened so that the cleanup can be merged back to `main`.
 
+### Duplicate ticket cleanup
+
+The `close-duplicates` workflow runs daily and on demand to detect open issues
+with the same title. The script chooses the lowest numbered ticket as the
+canonical reference and automatically closes the rest with a comment noting the
+duplicate. This keeps the issue tracker focused on a single discussion for each
+problem.
+
 The project aims to eventually reach feature parity with [Bazarr](https://github.com/morpheus65535/bazarr) while offering improved configuration and logging. See `TODO.md` for the full roadmap and implementation plan.
 Extensive architectural details and design decisions are documented in
 `docs/TECHNICAL_DESIGN.md`. New contributors should review this document to


### PR DESCRIPTION
## Summary
- automate closing duplicate issues via a new workflow
- document the workflow in the README
- note the new feature in the changelog

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b3c16a0788321b089c228b42d0086