### PR TITLE
Add Wanted page to web UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ This file tracks remaining work and implementation status for Subtitle Manager. 
 
 - [ ] **History Page**: Display translation and download history with filtering
 - [ ] **System Page**: Log viewer, task status, system information
-- [ ] **Wanted Page**: Search for missing subtitles, manage wanted list
+- [x] **Wanted Page**: Search for missing subtitles, manage wanted list
 - [ ] **File Upload**: Forms for converting/translating uploaded subtitle files
 
 ### 2. Missing REST API Endpoints
@@ -120,7 +120,6 @@ The current React UI includes:
 
 - **History** – Combined view of translation and download history with filtering
 - **System** – Log viewer, task status, and system information
-- **Wanted** – Search interface for missing subtitles
 
 Additional pages such as blacklist management or per-movie editors can be added once core functionality is complete.
 

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -5,6 +5,7 @@ import Extract from "./Extract.jsx";
 import History from "./History.jsx";
 import Settings from "./Settings.jsx";
 import Setup from "./Setup.jsx";
+import Wanted from "./Wanted.jsx";
 
 function App() {
   const [username, setUsername] = useState("");
@@ -65,6 +66,7 @@ function App() {
         <button onClick={() => setPage("settings")}>Settings</button>
         <button onClick={() => setPage("extract")}>Extract</button>
         <button onClick={() => setPage("history")}>History</button>
+        <button onClick={() => setPage("wanted")}>Wanted</button>
       </nav>
       {page === "settings" ? (
         <Settings />
@@ -72,6 +74,8 @@ function App() {
         <Extract />
       ) : page === "history" ? (
         <History />
+      ) : page === "wanted" ? (
+        <Wanted />
       ) : (
         <Dashboard />
       )}

--- a/webui/src/Wanted.jsx
+++ b/webui/src/Wanted.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Wanted provides an interface for searching subtitles and maintaining
+ * a list of wanted items. Results are fetched from `/api/search` and
+ * selections are POSTed to `/api/wanted`.
+ */
+export default function Wanted() {
+  const [provider, setProvider] = useState("generic");
+  const [path, setPath] = useState("");
+  const [lang, setLang] = useState("en");
+  const [results, setResults] = useState([]);
+  const [wanted, setWanted] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/wanted")
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setWanted);
+  }, []);
+
+  const search = async () => {
+    const params = new URLSearchParams({ provider, path, lang });
+    const res = await fetch(`/api/search?${params.toString()}`);
+    if (res.ok) {
+      setResults(await res.json());
+    }
+  };
+
+  const add = async (url) => {
+    const res = await fetch("/api/wanted", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    });
+    if (res.ok) {
+      setWanted([...wanted, url]);
+    }
+  };
+
+  return (
+    <div className="wanted">
+      <h1>Wanted</h1>
+      <div>
+        <input
+          placeholder="Provider"
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+        />
+        <input
+          placeholder="Media path"
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+        />
+        <input
+          placeholder="Language"
+          value={lang}
+          onChange={(e) => setLang(e.target.value)}
+        />
+        <button onClick={search}>Search</button>
+      </div>
+      <ul>
+        {results.map((u) => (
+          <li key={u}>
+            {u} <button onClick={() => add(u)}>Add</button>
+          </li>
+        ))}
+      </ul>
+      <h2>Wanted List</h2>
+      <ul>
+        {wanted.map((u) => (
+          <li key={u}>{u}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/webui/src/__tests__/App.test.jsx
+++ b/webui/src/__tests__/App.test.jsx
@@ -1,7 +1,7 @@
 // file: webui/src/__tests__/App.test.jsx
-import { vi, expect, describe, test, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import App from "../App.jsx";
 
 describe("App component", () => {

--- a/webui/src/__tests__/Dashboard.test.jsx
+++ b/webui/src/__tests__/Dashboard.test.jsx
@@ -1,7 +1,7 @@
 // file: webui/src/__tests__/Dashboard.test.jsx
-import { vi, expect, describe, test, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import Dashboard from "../Dashboard.jsx";
 
 describe("Dashboard component", () => {

--- a/webui/src/__tests__/Extract.test.jsx
+++ b/webui/src/__tests__/Extract.test.jsx
@@ -1,7 +1,7 @@
 // file: webui/src/__tests__/Extract.test.jsx
-import { vi, expect, describe, test, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import Extract from "../Extract.jsx";
 
 describe("Extract component", () => {

--- a/webui/src/__tests__/Settings.test.jsx
+++ b/webui/src/__tests__/Settings.test.jsx
@@ -1,7 +1,7 @@
 // file: webui/src/__tests__/Settings.test.jsx
-import { vi, expect, describe, test, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import Settings from "../Settings.jsx";
 
 describe("Settings component", () => {

--- a/webui/src/__tests__/Wanted.test.jsx
+++ b/webui/src/__tests__/Wanted.test.jsx
@@ -1,0 +1,23 @@
+// file: webui/src/__tests__/Wanted.test.jsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi, expect } from 'vitest'
+import '@testing-library/jest-dom'
+import Wanted from '../Wanted.jsx'
+
+describe('Wanted component', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    global.fetch = vi.fn()
+  })
+
+  test('loads wanted list on mount and searches', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(['a']) })
+    render(<Wanted />)
+    await screen.findByText('a')
+
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(['u']) })
+    fireEvent.change(screen.getByPlaceholderText('Media path'), { target: { value: 'f' } })
+    fireEvent.click(screen.getByText('Search'))
+    await waitFor(() => expect(fetch).toHaveBeenLastCalledWith('/api/search?provider=generic&path=f&lang=en'))
+  })
+})

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -6,5 +6,6 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    globals: true,
   },
 })


### PR DESCRIPTION
## Summary
- mark Wanted page as implemented
- add Wanted page React component
- link Wanted page from navigation
- update Vitest config and tests

## Testing
- `go test ./...`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b3cc9ed348321a064eefcf7a4ad85