### PR TITLE
Implement /api/translate REST endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ All notable changes to this project will be documented in this file.
 
 - Complete web UI with History, System, and Wanted pages
 - Basic scheduler with `autoscan` command for periodic scans
-- Additional REST API endpoints for download, convert, and translate operations
+- Additional REST API endpoints for download operations
 - File upload functionality for web-based subtitle conversion and translation
 
 ### Added
 
 - REST endpoint `/api/convert` for subtitle file conversion
+- REST endpoint `/api/translate` for translating uploaded subtitle files
 - Build process now runs `go generate ./webui` to embed the latest web assets
   in the binary and container image.
 - Automated workflow closes duplicate issues by title

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Recursive directory watching with -r flag.
 - Integrate with Sonarr, Radarr and Plex using dedicated commands.
 - Run a translation gRPC server.
+- Translate uploaded subtitles through `/api/translate` endpoint.
 - Delete subtitle files and remove history records.
 - Track subtitle download history and list with `downloads` command or `/api/history`.
 - GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ This file tracks remaining work and implementation status for Subtitle Manager. 
 
 - [ ] **`/api/download`**: Download subtitles for specific media files
 - [x] **`/api/convert`**: Convert uploaded subtitle files between formats
-- [ ] **`/api/translate`**: Translate uploaded subtitle files
+- [x] **`/api/translate`**: Translate uploaded subtitle files
 - [x] **`/api/history`**: Retrieve translation and download history as JSON
 
 ### 3. Documentation Updates

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -113,6 +113,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle("/api/logs", authMiddleware(db, "basic", logsHandler()))
 	mux.Handle("/api/system", authMiddleware(db, "basic", systemHandler()))
 	mux.Handle("/api/tasks", authMiddleware(db, "basic", tasksHandler()))
+	mux.Handle("/api/translate", authMiddleware(db, "basic", translateHandler()))
 	fsHandler := http.FileServer(http.FS(f))
 	mux.Handle("/", authMiddleware(db, "read", fsHandler))
 	return mux, nil

--- a/pkg/webserver/translate.go
+++ b/pkg/webserver/translate.go
@@ -1,0 +1,89 @@
+// file: pkg/webserver/translate.go
+package webserver
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/subtitles"
+)
+
+// translateHandler handles translating an uploaded subtitle file.
+//
+// POST requests must use multipart/form-data containing a "file" part and
+// a "lang" field specifying the target language. Optional fields "service"
+// and "grpc" override the configured translation service and gRPC address.
+// The translated SRT data is returned with content type "application/x-subrip".
+func translateHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		file, hdr, err := r.FormFile("file")
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		lang := r.FormValue("lang")
+		if lang == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		service := r.FormValue("service")
+		if service == "" {
+			service = viper.GetString("translate_service")
+			if service == "" {
+				service = "google"
+			}
+		}
+		grpcAddr := r.FormValue("grpc")
+		if grpcAddr == "" {
+			grpcAddr = viper.GetString("grpc_addr")
+		}
+		gKey := viper.GetString("google_api_key")
+		gptKey := viper.GetString("openai_api_key")
+
+		in, err := os.CreateTemp("", "in-*"+filepath.Ext(hdr.Filename))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer os.Remove(in.Name())
+		if _, err := io.Copy(in, file); err != nil {
+			in.Close()
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		in.Close()
+
+		out, err := os.CreateTemp("", "out-*.srt")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		out.Close()
+		defer os.Remove(out.Name())
+
+		if err := subtitles.TranslateFileToSRT(in.Name(), out.Name(), lang, service, gKey, gptKey, grpcAddr); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		data, err := os.ReadFile(out.Name())
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-subrip")
+		_, _ = w.Write(data)
+	})
+}


### PR DESCRIPTION
## Summary
- add `/api/translate` endpoint for translating uploaded subtitle files
- update handler registration
- document the new endpoint in README, TODO and CHANGELOG
- test translation via web server

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b3d6929ac8321b146f252343325d7