### PR TITLE
Add issue deduplication workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,10 @@ All notable changes to this project will be documented in this file.
 
 - REST endpoint `/api/convert` for subtitle file conversion
 - REST endpoint `/api/translate` for translating uploaded subtitle files
+- REST endpoint `/api/download` for on-demand subtitle fetching
 - Build process now runs `go generate ./webui` to embed the latest web assets
   in the binary and container image.
 - Automated workflow closes duplicate issues by title
-
-### Added
-- REST endpoint `/api/download` for on-demand subtitle fetching
 
 ## [0.3.9] - 2025-06-26
 


### PR DESCRIPTION
## Summary
- automate closing duplicate issues via a new workflow
- document the workflow in the README
- note the new feature in the changelog
- improve the script to sort issues before grouping

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b3c16a0788321b089c228b42d0086