### PR TITLE
Implement cron-based scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Monitor directories and automatically download subtitles.
 - Scan existing libraries and fetch missing or upgraded subtitles.
 - Download individual subtitles through the web API at `/api/download`.
-- Schedule periodic scans with the `autoscan` command.
+- Schedule scans with the `autoscan` command using intervals or cron expressions.
 - Parse file names and retrieve movie or episode details from TheMovieDB.
 - High performance scanning using concurrent workers.
 - Recursive directory watching with -r flag.
@@ -121,8 +121,8 @@ services are available:
 ### 🔄 Optional Remaining Features
 
 - PostgreSQL database backend (SQLite and PebbleDB fully implemented)
-- Advanced scheduler with webhook support
-- Anti-captcha service integration for providers requiring captcha solving
+- Advanced scheduler with cron-based scanning and webhook support
+- Anti-captcha service integration
 - Reverse proxy base URL support
 
 The project is fully functional for production use and provides feature parity with Bazarr for all core subtitle management operations.
@@ -187,7 +187,7 @@ subtitle-manager search opensubtitles [media] [lang]
 subtitle-manager batch [lang] [files...]
 subtitle-manager scan opensubtitles [directory] [lang] [-u]
 subtitle-manager scan subscene [directory] [lang] [-u]
-subtitle-manager autoscan [provider] [directory] [lang] [-i duration] [-u]
+subtitle-manager autoscan [provider] [directory] [lang] [-i duration] [-s cron] [-u]
 subtitle-manager scanlib [directory]
 subtitle-manager watch opensubtitles [directory] [lang] [-r]
 subtitle-manager watch subscene [directory] [lang] [-r]

--- a/STATUS.md
+++ b/STATUS.md
@@ -85,7 +85,7 @@ Subtitle Manager has achieved **production-ready status** with full Bazarr featu
 - [ ] Advanced webhook system for Plex events
 - [x] Anti-captcha service integration for challenging providers
 - [ ] Reverse proxy base URL support for complex networks
-- [ ] Enhanced scheduler with granular controls
+- [x] Enhanced scheduler with granular controls
 
 ### Optional Migration Tools
 - [ ] Bazarr configuration import command

--- a/TODO.md
+++ b/TODO.md
@@ -215,8 +215,8 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
    - Reference: [docs/BAZARR_SETTINGS_SYNC.md](docs/BAZARR_SETTINGS_SYNC.md)
 
 2. **Advanced Scheduling** - Granular scan controls
-   - Status: 🔶 Basic autoscan exists
-   - Current: Simple periodic scanning available
+   - Status: ✅ Cron-based scheduler implemented
+   - Current: Supports interval or cron expression
    - Reference: [Scheduler](https://wiki.bazarr.media/Additional-Configuration/Settings/#scheduler)
 
 3. **Reverse Proxy Enhancement** - Base URL configuration
@@ -249,8 +249,8 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 - [ ] **Reverse proxy support**: Base URL configuration for proxy deployments
   - Location: `pkg/webserver/server.go` (enhance existing)
   - Reference: [Reverse Proxy Help](https://wiki.bazarr.media/Additional-Configuration/Reverse-Proxy-Help/)
-- [ ] **Advanced scheduler**: Enhanced periodic scanning with more granular controls
-  - Location: `pkg/scheduler/` (enhance existing)
+- [x] **Advanced scheduler**: Enhanced periodic scanning with more granular controls
+  - Location: `pkg/scheduler/` (cron support added)
 
 ### 3. Bazarr Configuration Import (Optional)
 

--- a/cmd/autoscan.go
+++ b/cmd/autoscan.go
@@ -14,6 +14,7 @@ import (
 )
 
 var interval time.Duration
+var scheduleSpec string
 
 // autoscanCmd periodically scans a directory for subtitles using a provider.
 var autoscanCmd = &cobra.Command{
@@ -40,12 +41,16 @@ var autoscanCmd = &cobra.Command{
 			}
 		}
 		workers := viper.GetInt("scan_workers")
+		if scheduleSpec != "" {
+			return scheduler.ScheduleScanDirectoryCron(ctx, scheduleSpec, dir, lang, name, p, upgrade, workers, store)
+		}
 		return scheduler.ScheduleScanDirectory(ctx, interval, dir, lang, name, p, upgrade, workers, store)
 	},
 }
 
 func init() {
 	autoscanCmd.Flags().DurationVarP(&interval, "interval", "i", time.Hour, "scan interval")
+	autoscanCmd.Flags().StringVarP(&scheduleSpec, "schedule", "s", "", "cron schedule expression")
 	autoscanCmd.Flags().BoolVarP(&upgrade, "upgrade", "u", false, "replace existing subtitles")
 	rootCmd.AddCommand(autoscanCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.21
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sashabaranov/go-openai v1.40.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/sourcegraph/conc v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=

--- a/pkg/scheduler/cron.go
+++ b/pkg/scheduler/cron.go
@@ -1,0 +1,45 @@
+// file: pkg/scheduler/cron.go
+package scheduler
+
+import (
+	"context"
+
+	"github.com/robfig/cron/v3"
+
+	"subtitle-manager/pkg/database"
+	"subtitle-manager/pkg/logging"
+	"subtitle-manager/pkg/providers"
+	"subtitle-manager/pkg/scanner"
+)
+
+// RunCron executes fn immediately and then according to spec until ctx is canceled.
+// Spec may be a standard cron expression or an "@every" duration. Errors after the
+// first run are logged and do not stop subsequent executions. The error from the
+// first run is returned to the caller.
+func RunCron(ctx context.Context, spec string, fn func(context.Context) error) error {
+	logger := logging.GetLogger("scheduler")
+	if err := fn(ctx); err != nil {
+		return err
+	}
+	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	c := cron.New(cron.WithParser(parser))
+	if _, err := c.AddFunc(spec, func() {
+		if err := fn(ctx); err != nil && ctx.Err() == nil {
+			logger.Warnf("scheduled run: %v", err)
+		}
+	}); err != nil {
+		return err
+	}
+	c.Start()
+	<-ctx.Done()
+	c.Stop()
+	return ctx.Err()
+}
+
+// ScheduleScanDirectoryCron schedules a directory scan using spec until ctx is canceled.
+// The scan runs immediately and then on the cron schedule.
+func ScheduleScanDirectoryCron(ctx context.Context, spec, dir, lang, providerName string, p providers.Provider, upgrade bool, workers int, store database.SubtitleStore) error {
+	return RunCron(ctx, spec, func(ctx context.Context) error {
+		return scanner.ScanDirectory(ctx, dir, lang, providerName, p, upgrade, workers, store)
+	})
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -59,3 +59,23 @@ func TestRunWithSkipFirst(t *testing.T) {
 		t.Fatalf("expected 1 run, got %d", n)
 	}
 }
+
+// TestRunCron verifies that RunCron executes according to the provided schedule.
+func TestRunCron(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var n int32
+	go func() {
+		time.Sleep(220 * time.Millisecond)
+		cancel()
+	}()
+	err := RunCron(ctx, "@every 50ms", func(context.Context) error {
+		atomic.AddInt32(&n, 1)
+		return nil
+	})
+	if err != context.Canceled {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if n < 2 {
+		t.Fatalf("expected at least 2 executions, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary
- add cron support to scheduling
- expose new `--schedule` flag in `autoscan`
- document cron usage and mark scheduler feature complete
- update TODO and STATUS
- add tests for new scheduler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c7fd2b8808321b43c363f915cde85