### PR TITLE
Implement notification services

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | Library scanning   | ✅ Complete            | [cmd/scan.go](cmd/scan.go)                         |
 | Directory watching | ✅ Complete            | [cmd/watch.go](cmd/watch.go)                       |
 | Webhooks           | 🔶 Basic (Plex only)   | [TODO] Advanced webhook system                     |
-| Notifications      | 🔶 Planned             | [TODO] Discord/Telegram/Email                      |
+| Notifications      | ✅ Basic               | [pkg/notifications/](pkg/notifications/)           |
 
 #### 6. Advanced Features 🔶 80% Complete
 
@@ -181,7 +181,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | **Post-Processing**          | ✅ Complete            | UTF-8 encoding                   | [Post-Processing](https://wiki.bazarr.media/Additional-Configuration/Settings/#post-processing)                                       |
 | **Languages**                | ✅ Complete            | 180+ languages                   | [Languages](https://wiki.bazarr.media/Additional-Configuration/Settings/#languages)                                                   |
 | **Providers**                | ✅ Complete            | Full registry                    | [Providers](https://wiki.bazarr.media/Additional-Configuration/Settings/#providers)                                                   |
-| **Notifications**            | 🔶 Planned             | Infrastructure ready             | [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)                                           |
+| **Notifications**            | ✅ Basic               | Infrastructure ready             | [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)                                           |
 | **Scheduler**                | ✅ Basic               | Auto-scan available              | [Scheduler](https://wiki.bazarr.media/Additional-Configuration/Settings/#scheduler)                                                   |
 
 ### Missing Features Analysis
@@ -199,10 +199,9 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
    - Reference: [Webhooks](https://wiki.bazarr.media/Additional-Configuration/Webhooks/)
 
 3. **Notification Services** - Discord, Telegram, Email alerts
-   - Status: 🔶 Infrastructure ready, providers needed
-   - Current: Basic notification framework exists
+   - Status: ✅ Basic support implemented
+   - Current: Discord, Telegram and SMTP notifiers available
    - Reference: [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)
-
 4. **Anti-Captcha Integration** - For challenging providers
    - Status: ✅ Basic captcha solving available
    - Current: Most providers work without captcha
@@ -280,8 +279,8 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | **Configuration**            | INI files                    | ✅ YAML + Environment vars          | ✅ **Modern config**                |
 | **Container Support**        | Docker available             | ✅ Multi-arch + GHCR                | ✅ **Cloud-native**                 |
 | **Library Integration**      | Sonarr/Radarr webhooks       | ✅ Direct commands + basic webhooks | 🔶 **Enhanced webhook system**      |
-| **Notifications**            | Apprise integration          | 🔶 Infrastructure ready             | 🔶 **Multi-provider notifications** |
-| **Anti-Captcha**             | Anti-captcha.com             | ✅ Basic implementation            | 🔶 **Optional enhancement**         |
+| **Notifications**            | Apprise integration          | ✅ Basic providers                  | 🔶 **Multi-provider notifications** |
+| **Anti-Captcha**             | Anti-captcha.com             | ✅ Basic implementation             | 🔶 **Optional enhancement**         |
 | **Translation**              | Not available                | ✅ Google + ChatGPT                 | ✅ **Unique feature**               |
 | **Transcription**            | External Whisper             | ✅ Integrated Whisper               | ✅ **Integrated solution**          |
 | **Reverse Proxy**            | Full base URL support        | 🔶 Basic support                    | 🔶 **Enhanced proxy support**       |

--- a/pkg/notifications/discord.go
+++ b/pkg/notifications/discord.go
@@ -1,0 +1,44 @@
+// file: pkg/notifications/discord.go
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// DiscordNotifier sends messages to a Discord webhook.
+type DiscordNotifier struct {
+	// WebhookURL is the Discord webhook endpoint.
+	WebhookURL string
+	// Client is used to make HTTP requests. Defaults to http.DefaultClient.
+	Client *http.Client
+}
+
+// Notify posts msg to the Discord webhook.
+func (d DiscordNotifier) Notify(ctx context.Context, msg string) error {
+	if d.WebhookURL == "" {
+		return fmt.Errorf("webhook URL required")
+	}
+	c := d.Client
+	if c == nil {
+		c = http.DefaultClient
+	}
+	body, _ := json.Marshal(map[string]string{"content": msg})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -1,0 +1,35 @@
+// file: pkg/notifications/email.go
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"net/smtp"
+)
+
+// SMTPNotifier sends email using an SMTP server.
+type SMTPNotifier struct {
+	// Addr is the SMTP server address.
+	Addr string
+	// Auth provides optional authentication.
+	Auth smtp.Auth
+	// From is the sender address.
+	From string
+	// To holds destination email addresses.
+	To []string
+	// Send overrides the send function for testing.
+	Send func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+}
+
+// Notify sends msg via SMTP.
+func (s SMTPNotifier) Notify(ctx context.Context, msg string) error {
+	send := s.Send
+	if send == nil {
+		send = smtp.SendMail
+	}
+	if s.Addr == "" || s.From == "" || len(s.To) == 0 {
+		return fmt.Errorf("smtp configuration incomplete")
+	}
+	data := []byte("Subject: Subtitle Manager\r\n\r\n" + msg)
+	return send(s.Addr, s.Auth, s.From, s.To, data)
+}

--- a/pkg/notifications/notifications_test.go
+++ b/pkg/notifications/notifications_test.go
@@ -1,0 +1,75 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/smtp"
+	"testing"
+)
+
+func TestDiscordNotifier(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var m map[string]string
+		json.NewDecoder(r.Body).Decode(&m)
+		got = m["content"]
+	}))
+	defer srv.Close()
+
+	n := DiscordNotifier{WebhookURL: srv.URL, Client: srv.Client()}
+	if err := n.Notify(context.Background(), "hello"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("unexpected message: %s", got)
+	}
+}
+
+func TestTelegramNotifier(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var m map[string]string
+		json.NewDecoder(r.Body).Decode(&m)
+		got = m["text"]
+	}))
+	defer srv.Close()
+
+	n := TelegramNotifier{BotToken: "t", ChatID: "1", Client: srv.Client(), APIBase: srv.URL}
+	if err := n.Notify(context.Background(), "hi"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if got != "hi" {
+		t.Fatalf("unexpected message: %s", got)
+	}
+}
+
+func TestSMTPNotifier(t *testing.T) {
+	var addr, from string
+	var to []string
+	var body []byte
+	n := SMTPNotifier{
+		Addr: "smtp:25",
+		From: "a@example.com",
+		To:   []string{"b@example.com"},
+		Send: func(a string, _ smtp.Auth, f string, t []string, msg []byte) error {
+			addr = a
+			from = f
+			to = t
+			body = msg
+			return nil
+		},
+	}
+	if err := n.Notify(context.Background(), "hi there"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if addr != "smtp:25" || from != "a@example.com" || len(to) != 1 || to[0] != "b@example.com" {
+		t.Fatalf("unexpected params")
+	}
+	if string(body) != "Subject: Subtitle Manager\r\n\r\nhi there" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -1,0 +1,23 @@
+// file: pkg/notifications/notifier.go
+package notifications
+
+import "context"
+
+// Notifier sends messages to a notification service.
+type Notifier interface {
+	// Notify sends msg to the underlying service.
+	// It returns an error if delivery fails.
+	Notify(ctx context.Context, msg string) error
+}
+
+// Func adapts a function to the Notifier interface.
+type Func func(ctx context.Context, msg string) error
+
+// Notify calls f(ctx, msg).
+func (f Func) Notify(ctx context.Context, msg string) error { return f(ctx, msg) }
+
+// Nop is a Notifier that performs no action.
+type Nop struct{}
+
+// Notify implements Notifier for Nop.
+func (Nop) Notify(context.Context, string) error { return nil }

--- a/pkg/notifications/telegram.go
+++ b/pkg/notifications/telegram.go
@@ -1,0 +1,53 @@
+// file: pkg/notifications/telegram.go
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// TelegramNotifier sends messages to a Telegram chat.
+type TelegramNotifier struct {
+	// BotToken is the API token for the bot.
+	BotToken string
+	// ChatID is the destination chat identifier.
+	ChatID string
+	// Client is used to make HTTP requests.
+	Client *http.Client
+	// APIBase overrides the Telegram API base URL for testing.
+	APIBase string
+}
+
+// Notify posts msg to the Telegram bot API.
+func (t TelegramNotifier) Notify(ctx context.Context, msg string) error {
+	if t.BotToken == "" || t.ChatID == "" {
+		return fmt.Errorf("token and chat ID required")
+	}
+	c := t.Client
+	if c == nil {
+		c = http.DefaultClient
+	}
+	body, _ := json.Marshal(map[string]string{"chat_id": t.ChatID, "text": msg})
+	base := t.APIBase
+	if base == "" {
+		base = "https://api.telegram.org"
+	}
+	url := fmt.Sprintf("%s/bot%s/sendMessage", base, t.BotToken)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add notifications package with Discord, Telegram and SMTP notifiers
- provide unit tests
- update TODO docs to mark notification providers as basic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c7fa046e48321841996dba37fa12b