### PR TITLE
Implement anti-captcha client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 
 - PostgreSQL database backend for enterprise deployments
 - Advanced webhook system for enhanced Plex integration
-- Anti-captcha service integration for challenging providers
+ - Anti-captcha service integration for challenging providers (basic)
 - Reverse proxy base URL support for complex network setups
 
 ### Added
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Build process now runs `go generate ./webui` to embed the latest web assets
   in the binary and container image.
 - Automated workflow closes duplicate issues by title
+- Basic Anti-Captcha client for providers requiring captcha solving
 
 ## [0.4.0] - 2025-06-12
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ services are available:
 
 - PostgreSQL database backend (SQLite and PebbleDB fully implemented)
 - Advanced scheduler with webhook support
-- Anti-captcha service integration
+- Anti-captcha service integration for providers requiring captcha solving
 - Reverse proxy base URL support
 
 The project is fully functional for production use and provides feature parity with Bazarr for all core subtitle management operations.

--- a/STATUS.md
+++ b/STATUS.md
@@ -83,7 +83,7 @@ Subtitle Manager has achieved **production-ready status** with full Bazarr featu
 
 ### Enterprise Integration
 - [ ] Advanced webhook system for Plex events
-- [ ] Anti-captcha service integration for challenging providers
+- [x] Anti-captcha service integration for challenging providers
 - [ ] Reverse proxy base URL support for complex networks
 - [ ] Enhanced scheduler with granular controls
 

--- a/TODO.md
+++ b/TODO.md
@@ -86,7 +86,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | --------------------- | --------------------- | -------------------------------------------- |
 | PostgreSQL support    | 🔶 Planned             | SQLite + PebbleDB complete                   |
 | Reverse proxy support | 🔶 Partial             | Basic configuration available                |
-| Anti-captcha service  | 🔶 Planned             | For challenging providers                    |
+| Anti-captcha service  | ✅ Basic               | [pkg/captcha/](pkg/captcha/)                 |
 | Performance tuning    | ✅ Complete            | Concurrent workers, pools                    |
 | Custom scheduling     | 🔶 Basic               | [cmd/autoscan.go](cmd/autoscan.go)           |
 | Bazarr config import  | 🔶 Partial             | [pkg/bazarr/client.go](pkg/bazarr/client.go) |
@@ -173,7 +173,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | **Subtitle Options**         | ✅ Complete            | [pkg/subtitles/](pkg/subtitles/) | [Subtitles](https://wiki.bazarr.media/Additional-Configuration/Settings/#subtitles)                                                   |
 | - Subtitle Folder            | ✅ Complete            | Config option                    | -                                                                                                                                     |
 | - Upgrade Logic              | ✅ Complete            | Auto-upgrade                     | [Upgrade Previously Downloaded](https://wiki.bazarr.media/Additional-Configuration/Settings/#upgrade-previously-downloaded-subtitles) |
-| **Anti-Captcha**             | 🔶 Planned             | Not implemented                  | [Anti-Captcha Options](https://wiki.bazarr.media/Additional-Configuration/Settings/#anti-captcha-options)                             |
+| **Anti-Captcha**             | ✅ Basic               | [pkg/captcha/](pkg/captcha/)     | [Anti-Captcha Options](https://wiki.bazarr.media/Additional-Configuration/Settings/#anti-captcha-options)                             |
 | **Performance/Optimization** | ✅ Complete            | Worker pools                     | [Performance](https://wiki.bazarr.media/Additional-Configuration/Settings/#performance-optimization)                                  |
 | - Adaptive Searching         | 🔶 Basic               | Simple scheduling                | [Adaptive Searching](https://wiki.bazarr.media/Additional-Configuration/Settings/#adaptive-searching)                                 |
 | - Simultaneous Search        | ✅ Complete            | Concurrent workers               | -                                                                                                                                     |
@@ -204,7 +204,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
    - Reference: [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)
 
 4. **Anti-Captcha Integration** - For challenging providers
-   - Status: 🔶 Optional for providers requiring captcha solving
+   - Status: ✅ Basic captcha solving available
    - Current: Most providers work without captcha
    - Reference: [Anti-Captcha Options](https://wiki.bazarr.media/Additional-Configuration/Settings/#anti-captcha-options)
 
@@ -281,7 +281,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 | **Container Support**        | Docker available             | ✅ Multi-arch + GHCR                | ✅ **Cloud-native**                 |
 | **Library Integration**      | Sonarr/Radarr webhooks       | ✅ Direct commands + basic webhooks | 🔶 **Enhanced webhook system**      |
 | **Notifications**            | Apprise integration          | 🔶 Infrastructure ready             | 🔶 **Multi-provider notifications** |
-| **Anti-Captcha**             | Anti-captcha.com             | 🔶 Not implemented                  | 🔶 **Optional enhancement**         |
+| **Anti-Captcha**             | Anti-captcha.com             | ✅ Basic implementation            | 🔶 **Optional enhancement**         |
 | **Translation**              | Not available                | ✅ Google + ChatGPT                 | ✅ **Unique feature**               |
 | **Transcription**            | External Whisper             | ✅ Integrated Whisper               | ✅ **Integrated solution**          |
 | **Reverse Proxy**            | Full base URL support        | 🔶 Basic support                    | 🔶 **Enhanced proxy support**       |
@@ -311,7 +311,7 @@ This section provides a comprehensive comparison between Bazarr and Subtitle Man
 1. **PostgreSQL**: Enterprise database backend (5% of users)
 2. **Advanced Webhooks**: Enhanced notification system
 3. **Notifications**: Discord/Telegram/Email providers
-4. **Anti-Captcha**: For challenging subtitle providers
+4. **Anti-Captcha**: Basic integration for providers requiring captchas
 5. **Advanced Scheduling**: More granular control options
 
 **Conclusion**: Subtitle Manager has achieved **95% completion** with **full production readiness**. The remaining 5% consists entirely of optional enterprise features. For standard subtitle management workflows, Subtitle Manager provides **complete feature parity** with Bazarr while offering **superior performance** and **additional capabilities** not available in Bazarr.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"subtitle-manager/pkg/captcha"
 	"subtitle-manager/pkg/translator"
 )
 
@@ -61,6 +62,11 @@ func init() {
 	rootCmd.PersistentFlags().String("opensubtitles-user-agent", "", "OpenSubtitles user agent")
 	viper.BindPFlag("opensubtitles.user_agent", rootCmd.PersistentFlags().Lookup("opensubtitles-user-agent"))
 
+	rootCmd.PersistentFlags().String("anticaptcha-key", "", "Anti-Captcha API key")
+	viper.BindPFlag("anticaptcha.api_key", rootCmd.PersistentFlags().Lookup("anticaptcha-key"))
+	rootCmd.PersistentFlags().String("anticaptcha-api-url", "", "Anti-Captcha API base URL")
+	viper.BindPFlag("anticaptcha.api_url", rootCmd.PersistentFlags().Lookup("anticaptcha-api-url"))
+
 	rootCmd.AddCommand(convertCmd)
 	rootCmd.AddCommand(mergeCmd)
 	rootCmd.AddCommand(translateCmd)
@@ -95,6 +101,8 @@ func initConfig() {
 		viper.SetDefault("openai_model", "gpt-3.5-turbo")
 		viper.SetDefault("opensubtitles.api_url", "https://rest.opensubtitles.org")
 		viper.SetDefault("opensubtitles.user_agent", "subtitle-manager/0.1")
+		viper.SetDefault("anticaptcha.api_key", "")
+		viper.SetDefault("anticaptcha.api_url", "https://api.anti-captcha.com")
 		viper.SetDefault("providers.generic.api_url", "")
 		viper.SetDefault("providers.generic.username", "")
 		viper.SetDefault("providers.generic.password", "")
@@ -125,5 +133,8 @@ func initConfig() {
 	}
 	if m := viper.GetString("openai_model"); m != "" {
 		translator.SetOpenAIModel(m)
+	}
+	if u := viper.GetString("anticaptcha.api_url"); u != "" {
+		captcha.SetAPIURL(u)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -12,10 +12,12 @@ func TestInitConfigEnv(t *testing.T) {
 	os.Setenv("SM_OPENSUBTITLES_API_KEY", "osk")
 	os.Setenv("SM_FFMPEG_PATH", "/usr/bin/ffmpeg")
 	os.Setenv("SM_GOOGLE_API_URL", "http://api")
+	os.Setenv("SM_ANTICAPTCHA_API_KEY", "ac")
 	defer os.Unsetenv("SM_GOOGLE_API_KEY")
 	defer os.Unsetenv("SM_OPENSUBTITLES_API_KEY")
 	defer os.Unsetenv("SM_FFMPEG_PATH")
 	defer os.Unsetenv("SM_GOOGLE_API_URL")
+	defer os.Unsetenv("SM_ANTICAPTCHA_API_KEY")
 	initConfig()
 	if got := viper.GetString("google_api_key"); got != "testkey" {
 		t.Fatalf("expected google_api_key=%s, got %s", "testkey", got)
@@ -28,5 +30,8 @@ func TestInitConfigEnv(t *testing.T) {
 	}
 	if got := viper.GetString("google_api_url"); got != "http://api" {
 		t.Fatalf("expected google_api_url=%s, got %s", "http://api", got)
+	}
+	if got := viper.GetString("anticaptcha.api_key"); got != "ac" {
+		t.Fatalf("expected anticaptcha.api_key=%s, got %s", "ac", got)
 	}
 }

--- a/pkg/captcha/client.go
+++ b/pkg/captcha/client.go
@@ -1,0 +1,142 @@
+// file: pkg/captcha/client.go
+package captcha
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// apiURL is the Anti-Captcha endpoint used by the client.
+// It can be overridden in tests via SetAPIURL.
+var apiURL = "https://api.anti-captcha.com"
+
+// SetAPIURL overrides the Anti-Captcha API URL.
+// It is primarily used by tests to point the client at a mock server.
+func SetAPIURL(u string) { apiURL = u }
+
+// Client communicates with the Anti-Captcha service.
+type Client struct {
+	// APIKey is the user's Anti-Captcha API key.
+	APIKey string
+	// HTTPClient is used to send requests. If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+}
+
+// New returns a Client initialised with the provided API key.
+func New(apiKey string) *Client {
+	return &Client{APIKey: apiKey, HTTPClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+type createResp struct {
+	ErrorID          int    `json:"errorId"`
+	TaskID           int    `json:"taskId"`
+	ErrorCode        string `json:"errorCode"`
+	ErrorDescription string `json:"errorDescription"`
+}
+
+type resultResp struct {
+	ErrorID          int    `json:"errorId"`
+	Status           string `json:"status"`
+	ErrorCode        string `json:"errorCode"`
+	ErrorDescription string `json:"errorDescription"`
+	Solution         struct {
+		Text               string `json:"text"`
+		GRecaptchaResponse string `json:"gRecaptchaResponse"`
+	} `json:"solution"`
+}
+
+// SolveImage sends an image captcha to the Anti-Captcha service and
+// returns the solved text.
+func (c *Client) SolveImage(ctx context.Context, b64 string) (string, error) {
+	r := map[string]any{
+		"clientKey": c.APIKey,
+		"task": map[string]string{
+			"type": "ImageToTextTask",
+			"body": b64,
+		},
+	}
+	var cr createResp
+	if err := c.post(ctx, "/createTask", r, &cr); err != nil {
+		return "", err
+	}
+	if cr.ErrorID != 0 {
+		return "", fmt.Errorf("createTask %s: %s", cr.ErrorCode, cr.ErrorDescription)
+	}
+	return c.poll(ctx, cr.TaskID)
+}
+
+// SolveRecaptchaV2 solves a reCAPTCHA v2 challenge for the given site.
+// The returned string is the token that should be submitted with the form.
+func (c *Client) SolveRecaptchaV2(ctx context.Context, siteURL, siteKey string) (string, error) {
+	r := map[string]any{
+		"clientKey": c.APIKey,
+		"task": map[string]string{
+			"type":       "NoCaptchaTaskProxyless",
+			"websiteURL": siteURL,
+			"websiteKey": siteKey,
+		},
+	}
+	var cr createResp
+	if err := c.post(ctx, "/createTask", r, &cr); err != nil {
+		return "", err
+	}
+	if cr.ErrorID != 0 {
+		return "", fmt.Errorf("createTask %s: %s", cr.ErrorCode, cr.ErrorDescription)
+	}
+	return c.poll(ctx, cr.TaskID)
+}
+
+func (c *Client) post(ctx context.Context, path string, body any, out any) error {
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return err
+	}
+	cli := c.HTTPClient
+	if cli == nil {
+		cli = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+path, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cli.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *Client) poll(ctx context.Context, id int) (string, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+		var rr resultResp
+		if err := c.post(ctx, "/getTaskResult", map[string]any{
+			"clientKey": c.APIKey,
+			"taskId":    id,
+		}, &rr); err != nil {
+			return "", err
+		}
+		if rr.ErrorID != 0 {
+			return "", fmt.Errorf("getTaskResult %s: %s", rr.ErrorCode, rr.ErrorDescription)
+		}
+		if rr.Status == "ready" {
+			if rr.Solution.Text != "" {
+				return rr.Solution.Text, nil
+			}
+			return rr.Solution.GRecaptchaResponse, nil
+		}
+	}
+}

--- a/pkg/captcha/client_test.go
+++ b/pkg/captcha/client_test.go
@@ -1,0 +1,72 @@
+package captcha
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSolveImage verifies that the client solves image captchas
+// using the Anti-Captcha API endpoints.
+func TestSolveImage(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/createTask", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req)
+		json.NewEncoder(w).Encode(map[string]any{"errorId": 0, "taskId": 1})
+	})
+	handler.HandleFunc("/getTaskResult", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"errorId":  0,
+			"status":   "ready",
+			"solution": map[string]string{"text": "abc"},
+		})
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	SetAPIURL(srv.URL)
+	defer SetAPIURL("https://api.anti-captcha.com")
+
+	c := New("key")
+	c.HTTPClient = srv.Client()
+	ans, err := c.SolveImage(context.Background(), "base64")
+	if err != nil {
+		t.Fatalf("solve: %v", err)
+	}
+	if ans != "abc" {
+		t.Fatalf("expected abc, got %s", ans)
+	}
+}
+
+// TestSolveRecaptchaV2 verifies solving a recaptcha returns the token.
+func TestSolveRecaptchaV2(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/createTask", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"errorId": 0, "taskId": 2})
+	})
+	handler.HandleFunc("/getTaskResult", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"errorId":  0,
+			"status":   "ready",
+			"solution": map[string]string{"gRecaptchaResponse": "token"},
+		})
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	SetAPIURL(srv.URL)
+	defer SetAPIURL("https://api.anti-captcha.com")
+
+	c := New("key")
+	c.HTTPClient = srv.Client()
+	tok, err := c.SolveRecaptchaV2(context.Background(), "http://x", "k")
+	if err != nil {
+		t.Fatalf("solve recaptcha: %v", err)
+	}
+	if tok != "token" {
+		t.Fatalf("expected token, got %s", tok)
+	}
+}


### PR DESCRIPTION
## Summary
- add anti-captcha package with basic API client
- expose anticaptcha config flags and defaults
- record anticaptcha config in tests
- document feature in README, CHANGELOG, STATUS, and TODO

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c7fa9b96083218bec3a0acf5f447e