### PR TITLE
Implement Bazarr settings import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,36 @@
+// file: cmd/import.go
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/bazarr"
+)
+
+// importBazarrCmd imports configuration from a running Bazarr instance.
+var importBazarrCmd = &cobra.Command{
+	Use:   "import-bazarr [url] [api-key]",
+	Short: "Import configuration from Bazarr",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, key := args[0], args[1]
+		settings, err := bazarr.FetchSettings(url, key)
+		if err != nil {
+			return err
+		}
+		mapped := bazarr.MapSettings(settings)
+		for k, v := range mapped {
+			viper.Set(k, v)
+		}
+		if cfg := viper.ConfigFileUsed(); cfg != "" {
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+		}
+		cmd.Println("Bazarr settings imported")
+		return nil
+	},
+}
+
+func init() { rootCmd.AddCommand(importBazarrCmd) }

--- a/docs/BAZARR_SETTINGS_SYNC.md
+++ b/docs/BAZARR_SETTINGS_SYNC.md
@@ -24,3 +24,14 @@ Existing Bazarr users can migrate their configuration to Subtitle Manager to avo
 - Reduces configuration errors by reusing verified settings.
 
 Further implementation details should consider error handling for unreachable Bazarr instances and partial imports when settings do not have direct equivalents.
+
+### Import Command Usage
+
+Run the CLI tool to automatically migrate your configuration:
+
+```bash
+subtitle-manager import-bazarr http://localhost:6767 MY_API_KEY
+```
+
+The command fetches `/api/system/settings`, maps the values to Subtitle Manager's
+configuration keys and writes them to your current config file.

--- a/pkg/bazarr/mapper.go
+++ b/pkg/bazarr/mapper.go
@@ -1,0 +1,64 @@
+// file: pkg/bazarr/mapper.go
+package bazarr
+
+// MapSettings converts Bazarr settings to Subtitle Manager configuration keys.
+// The returned map can be written into Viper.
+func MapSettings(s Settings) map[string]any {
+	out := make(map[string]any)
+	if gen, ok := s["general"].(map[string]any); ok {
+		if host, ok := gen["bind_address"].(string); ok {
+			out["web.host"] = host
+		}
+		if p, ok := gen["port"]; ok {
+			switch v := p.(type) {
+			case float64:
+				out["web.port"] = int(v)
+			case int:
+				out["web.port"] = v
+			}
+		}
+		if base, ok := gen["url_base"].(string); ok {
+			out["web.base_url"] = base
+		}
+	}
+	if auth, ok := s["auth"].(map[string]any); ok {
+		if user, ok := auth["user"].(string); ok {
+			out["auth.user"] = user
+		}
+		if pass, ok := auth["password"].(string); ok {
+			out["auth.password"] = pass
+		}
+		if key, ok := auth["api_key"].(string); ok {
+			out["auth.api_key"] = key
+		}
+	}
+	if prov, ok := s["providers"].(map[string]any); ok {
+		enabled := map[string]bool{}
+		for name, v := range prov {
+			if p, ok := v.(map[string]any); ok {
+				if en, ok := p["enabled"].(bool); ok && en {
+					enabled[name] = true
+				}
+			}
+		}
+		if len(enabled) > 0 {
+			out["providers"] = enabled
+		}
+	}
+	if langs, ok := s["languages"].([]any); ok {
+		list := []string{}
+		for _, v := range langs {
+			if m, ok := v.(map[string]any); ok {
+				if en, ok := m["enabled"].(bool); ok && en {
+					if code, ok := m["code"].(string); ok {
+						list = append(list, code)
+					}
+				}
+			}
+		}
+		if len(list) > 0 {
+			out["languages"] = list
+		}
+	}
+	return out
+}

--- a/pkg/bazarr/mapper_test.go
+++ b/pkg/bazarr/mapper_test.go
@@ -1,0 +1,42 @@
+package bazarr
+
+import "testing"
+
+// TestMapSettings verifies mapping of Bazarr settings.
+func TestMapSettings(t *testing.T) {
+	in := Settings{
+		"general": map[string]any{
+			"bind_address": "0.0.0.0",
+			"port":         6767,
+			"url_base":     "/bazarr",
+		},
+		"auth": map[string]any{
+			"api_key":  "k",
+			"user":     "u",
+			"password": "p",
+		},
+		"providers": map[string]any{
+			"opensubtitles": map[string]any{"enabled": true},
+			"embedded":      map[string]any{"enabled": false},
+		},
+		"languages": []any{
+			map[string]any{"code": "en", "enabled": true},
+			map[string]any{"code": "fr", "enabled": false},
+		},
+	}
+	out := MapSettings(in)
+	if out["web.host"] != "0.0.0.0" {
+		t.Fatalf("web.host unexpected: %v", out["web.host"])
+	}
+	if out["web.port"].(int) != 6767 {
+		t.Fatalf("web.port unexpected: %v", out["web.port"])
+	}
+	prov, ok := out["providers"].(map[string]bool)
+	if !ok || !prov["opensubtitles"] || prov["embedded"] {
+		t.Fatalf("provider mapping incorrect: %v", prov)
+	}
+	langs, ok := out["languages"].([]string)
+	if !ok || len(langs) != 1 || langs[0] != "en" {
+		t.Fatalf("language mapping incorrect: %v", langs)
+	}
+}

--- a/webui/src/Setup.jsx
+++ b/webui/src/Setup.jsx
@@ -45,6 +45,11 @@ export default function Setup() {
   return (
     <div className="setup">
       <h1>Initial Setup</h1>
+      <p>
+        Already using Bazarr? Run
+        <code>subtitle-manager import-bazarr http://localhost:6767 MY_API_KEY</code>
+        to copy your settings.
+      </p>
       {step === 0 && (
         <div>
           <p>Server settings</p>


### PR DESCRIPTION
## Summary
- add `import-bazarr` command for configuration migration
- map Bazarr settings to local configuration
- document import command
- surface docs link in setup UI
- test settings mapper

## Testing
- `make pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_684c7fcbe2108321a849d2bcd2e3a2c8