### PR TITLE
Add full settings UI

### DIFF
--- a/webui/COMPREHENSIVE_UI_OVERHAUL.md
+++ b/webui/COMPREHENSIVE_UI_OVERHAUL.md
@@ -41,7 +41,7 @@ This document outlines the comprehensive overhaul of the Subtitle Manager web UI
 **New Implementation:**
 - **Modern Tabbed Interface**:
   - Providers tab with card-based management
-  - General, Database, Authentication, Notifications tabs (scaffolded)
+  - Full tabs for General, Database, Authentication and Notifications
 - **Provider Management Tab**:
   - Grid layout with provider cards
   - Add new provider functionality

--- a/webui/src/Settings.jsx
+++ b/webui/src/Settings.jsx
@@ -28,6 +28,10 @@ import {
 import { useEffect, useState } from "react";
 import ProviderCard from "./components/ProviderCard.jsx";
 import ProviderConfigDialog from "./components/ProviderConfigDialog.jsx";
+import GeneralSettings from "./components/GeneralSettings.jsx";
+import DatabaseSettings from "./components/DatabaseSettings.jsx";
+import AuthSettings from "./components/AuthSettings.jsx";
+import NotificationSettings from "./components/NotificationSettings.jsx";
 
 /**
  * Settings component with modern tabbed interface for managing all aspects
@@ -217,6 +221,32 @@ export default function Settings() {
   };
 
   /**
+   * Save general configuration values via the API
+   *
+   * @param {Object} values - Key/value pairs to persist
+   */
+  const saveSettings = async (values) => {
+    try {
+      const response = await fetch('/api/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
+      });
+      if (response.ok) {
+        setStatus('Settings saved');
+        setSnackbarOpen(true);
+        await loadConfig();
+      } else {
+        setStatus('Failed to save settings');
+        setSnackbarOpen(true);
+      }
+    } catch {
+      setStatus('Error saving settings');
+      setSnackbarOpen(true);
+    }
+  };
+
+  /**
    * Import settings from Bazarr
    */
   const openImportDialog = async () => {
@@ -314,10 +344,18 @@ export default function Settings() {
 
   const tabs = [
     { label: 'Providers', icon: <ProvidersIcon />, component: renderProvidersTab },
-    { label: 'General', icon: <GeneralIcon />, component: () => <Typography>General settings coming soon</Typography> },
-    { label: 'Database', icon: <DatabaseIcon />, component: () => <Typography>Database settings coming soon</Typography> },
-    { label: 'Authentication', icon: <AuthIcon />, component: () => <Typography>Auth settings coming soon</Typography> },
-    { label: 'Notifications', icon: <NotificationIcon />, component: () => <Typography>Notification settings coming soon</Typography> },
+    { label: 'General', icon: <GeneralIcon />, component: () => (
+        <GeneralSettings config={_config} onSave={saveSettings} />
+      ) },
+    { label: 'Database', icon: <DatabaseIcon />, component: () => (
+        <DatabaseSettings config={_config} onSave={saveSettings} />
+      ) },
+    { label: 'Authentication', icon: <AuthIcon />, component: () => (
+        <AuthSettings config={_config} onSave={saveSettings} />
+      ) },
+    { label: 'Notifications', icon: <NotificationIcon />, component: () => (
+        <NotificationSettings config={_config} onSave={saveSettings} />
+      ) },
   ];
 
   if (loading) {

--- a/webui/src/__tests__/Settings.test.jsx
+++ b/webui/src/__tests__/Settings.test.jsx
@@ -10,20 +10,30 @@ describe("Settings component", () => {
     global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
   });
 
-  test("loads and saves configuration", async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ foo: "bar" }),
-    });
+  test("edits general settings", async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ server_name: "Test" }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
     render(<Settings />);
-    await screen.findByDisplayValue("bar");
+
+    fireEvent.click(screen.getByRole("tab", { name: /General/i }));
+    await screen.findByDisplayValue("Test");
+
     fetch.mockResolvedValueOnce({ ok: true });
-    fireEvent.change(screen.getByDisplayValue("bar"), {
-      target: { value: "baz" },
+    fireEvent.change(screen.getByLabelText("Server Name"), {
+      target: { value: "New" },
     });
     fireEvent.click(screen.getByText("Save"));
+
     await waitFor(() =>
-      expect(fetch).toHaveBeenLastCalledWith("/api/config", expect.any(Object)),
+      expect(fetch).toHaveBeenLastCalledWith(
+        "/api/config",
+        expect.objectContaining({ method: "POST" }),
+      ),
     );
   });
 });

--- a/webui/src/components/AuthSettings.jsx
+++ b/webui/src/components/AuthSettings.jsx
@@ -1,0 +1,65 @@
+// file: webui/src/components/AuthSettings.jsx
+import { Box, Button, TextField, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+/**
+ * AuthSettings configures authentication credentials and API key.
+ *
+ * @param {Object} props - Component properties
+ * @param {Object} props.config - Current configuration values
+ * @param {Function} props.onSave - Callback invoked with updated values
+ */
+export default function AuthSettings({ config, onSave }) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [apiKey, setApiKey] = useState("");
+
+  useEffect(() => {
+    if (config && config.auth) {
+      setUsername(config.auth.username || "");
+      setPassword(config.auth.password || "");
+      setApiKey(config.auth.api_key || "");
+    }
+  }, [config]);
+
+  const handleSave = () => {
+    onSave({
+      "auth.username": username,
+      "auth.password": password,
+      "auth.api_key": apiKey,
+    });
+  };
+
+  return (
+    <Box sx={{ maxWidth: 500 }}>
+      <Typography variant="h6" gutterBottom>
+        Authentication
+      </Typography>
+      <TextField
+        label="Username"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <TextField
+        label="API Key"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+      />
+      <Button variant="contained" onClick={handleSave}>
+        Save
+      </Button>
+    </Box>
+  );
+}

--- a/webui/src/components/DatabaseSettings.jsx
+++ b/webui/src/components/DatabaseSettings.jsx
@@ -1,0 +1,99 @@
+// file: webui/src/components/DatabaseSettings.jsx
+import { Box, Button, MenuItem, TextField, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+/**
+ * DatabaseSettings allows selection of the storage backend and connection details.
+ *
+ * @param {Object} props - Component properties
+ * @param {Object} props.config - Current configuration values
+ * @param {Function} props.onSave - Callback invoked with updated values
+ */
+export default function DatabaseSettings({ config, onSave }) {
+  const [backend, setBackend] = useState("pebble");
+  const [dbPath, setDbPath] = useState("");
+  const [sqliteFile, setSqliteFile] = useState("subtitle-manager.db");
+  const [pgHost, setPgHost] = useState("");
+  const [pgPort, setPgPort] = useState("");
+  const [pgDB, setPgDB] = useState("");
+  const [pgUser, setPgUser] = useState("");
+  const [pgPass, setPgPass] = useState("");
+
+  useEffect(() => {
+    if (config) {
+      setBackend(config.db_backend || "pebble");
+      setDbPath(config.db_path || "");
+      setSqliteFile(config.sqlite3_filename || "subtitle-manager.db");
+      const pg = (config.database && config.database.postgres) || {};
+      setPgHost(pg.host || "");
+      setPgPort(pg.port || "");
+      setPgDB(pg.database || "");
+      setPgUser(pg.username || "");
+      setPgPass(pg.password || "");
+    }
+  }, [config]);
+
+  const handleSave = () => {
+    const values = {
+      db_backend: backend,
+      db_path: dbPath,
+      sqlite3_filename: sqliteFile,
+      "database.postgres.host": pgHost,
+      "database.postgres.port": pgPort,
+      "database.postgres.database": pgDB,
+      "database.postgres.username": pgUser,
+      "database.postgres.password": pgPass,
+    };
+    onSave(values);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 500 }}>
+      <Typography variant="h6" gutterBottom>
+        Database Settings
+      </Typography>
+      <TextField
+        select
+        label="Backend"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={backend}
+        onChange={(e) => setBackend(e.target.value)}
+      >
+        {['sqlite', 'pebble', 'postgres'].map((opt) => (
+          <MenuItem key={opt} value={opt}>
+            {opt}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        label="Database Path"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={dbPath}
+        onChange={(e) => setDbPath(e.target.value)}
+      />
+      {backend === 'sqlite' && (
+        <TextField
+          label="SQLite Filename"
+          fullWidth
+          sx={{ mb: 2 }}
+          value={sqliteFile}
+          onChange={(e) => setSqliteFile(e.target.value)}
+        />
+      )}
+      {backend === 'postgres' && (
+        <>
+          <TextField label="Host" fullWidth sx={{ mb: 2 }} value={pgHost} onChange={(e) => setPgHost(e.target.value)} />
+          <TextField label="Port" fullWidth sx={{ mb: 2 }} value={pgPort} onChange={(e) => setPgPort(e.target.value)} />
+          <TextField label="Database" fullWidth sx={{ mb: 2 }} value={pgDB} onChange={(e) => setPgDB(e.target.value)} />
+          <TextField label="Username" fullWidth sx={{ mb: 2 }} value={pgUser} onChange={(e) => setPgUser(e.target.value)} />
+          <TextField label="Password" type="password" fullWidth sx={{ mb: 2 }} value={pgPass} onChange={(e) => setPgPass(e.target.value)} />
+        </>
+      )}
+      <Button variant="contained" onClick={handleSave}>
+        Save
+      </Button>
+    </Box>
+  );
+}

--- a/webui/src/components/GeneralSettings.jsx
+++ b/webui/src/components/GeneralSettings.jsx
@@ -1,0 +1,80 @@
+// file: webui/src/components/GeneralSettings.jsx
+import { Box, Button, FormControlLabel, MenuItem, Switch, TextField, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+/**
+ * GeneralSettings provides configuration fields for core server options.
+ *
+ * @param {Object} props - Component properties
+ * @param {Object} props.config - Current configuration values
+ * @param {Function} props.onSave - Callback invoked with updated values
+ */
+export default function GeneralSettings({ config, onSave }) {
+  const [serverName, setServerName] = useState("");
+  const [baseURL, setBaseURL] = useState("");
+  const [logLevel, setLogLevel] = useState("info");
+  const [reverseProxy, setReverseProxy] = useState(false);
+
+  useEffect(() => {
+    if (config) {
+      setServerName(config.server_name || "");
+      setBaseURL(config.base_url || "");
+      setLogLevel(config.log_level || "info");
+      setReverseProxy(config.reverse_proxy || false);
+    }
+  }, [config]);
+
+  const handleSave = () => {
+    onSave({
+      server_name: serverName,
+      base_url: baseURL,
+      log_level: logLevel,
+      reverse_proxy: reverseProxy,
+    });
+  };
+
+  return (
+    <Box sx={{ maxWidth: 500 }}>
+      <Typography variant="h6" gutterBottom>
+        General Settings
+      </Typography>
+      <TextField
+        label="Server Name"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={serverName}
+        onChange={(e) => setServerName(e.target.value)}
+      />
+      <TextField
+        label="Base URL"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={baseURL}
+        onChange={(e) => setBaseURL(e.target.value)}
+        helperText="Path prefix when behind a reverse proxy"
+      />
+      <TextField
+        select
+        label="Log Level"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={logLevel}
+        onChange={(e) => setLogLevel(e.target.value)}
+      >
+        {['debug', 'info', 'warn', 'error'].map((lvl) => (
+          <MenuItem key={lvl} value={lvl}>
+            {lvl}
+          </MenuItem>
+        ))}
+      </TextField>
+      <FormControlLabel
+        sx={{ mb: 2 }}
+        control={<Switch checked={reverseProxy} onChange={(e) => setReverseProxy(e.target.checked)} />}
+        label="Running behind a reverse proxy"
+      />
+      <Button variant="contained" onClick={handleSave}>
+        Save
+      </Button>
+    </Box>
+  );
+}

--- a/webui/src/components/NotificationSettings.jsx
+++ b/webui/src/components/NotificationSettings.jsx
@@ -1,0 +1,81 @@
+// file: webui/src/components/NotificationSettings.jsx
+import { Box, Button, FormControlLabel, Switch, TextField, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+/**
+ * NotificationSettings configures external notification services.
+ *
+ * @param {Object} props - Component properties
+ * @param {Object} props.config - Current configuration values
+ * @param {Function} props.onSave - Callback invoked with updated values
+ */
+export default function NotificationSettings({ config, onSave }) {
+  const [enabled, setEnabled] = useState(false);
+  const [discord, setDiscord] = useState("");
+  const [telegramToken, setTelegramToken] = useState("");
+  const [telegramChat, setTelegramChat] = useState("");
+  const [emailURL, setEmailURL] = useState("");
+
+  useEffect(() => {
+    const n = (config && config.notifications) || {};
+    setEnabled(n.enabled || false);
+    setDiscord(n.discord_webhook || "");
+    setTelegramToken(n.telegram_token || "");
+    setTelegramChat(n.telegram_chat_id || "");
+    setEmailURL(n.email_url || "");
+  }, [config]);
+
+  const handleSave = () => {
+    onSave({
+      "notifications.enabled": enabled,
+      "notifications.discord_webhook": discord,
+      "notifications.telegram_token": telegramToken,
+      "notifications.telegram_chat_id": telegramChat,
+      "notifications.email_url": emailURL,
+    });
+  };
+
+  return (
+    <Box sx={{ maxWidth: 500 }}>
+      <Typography variant="h6" gutterBottom>
+        Notifications
+      </Typography>
+      <FormControlLabel
+        sx={{ mb: 2 }}
+        control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+        label="Enable notifications"
+      />
+      <TextField
+        label="Discord Webhook"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={discord}
+        onChange={(e) => setDiscord(e.target.value)}
+      />
+      <TextField
+        label="Telegram Token"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={telegramToken}
+        onChange={(e) => setTelegramToken(e.target.value)}
+      />
+      <TextField
+        label="Telegram Chat ID"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={telegramChat}
+        onChange={(e) => setTelegramChat(e.target.value)}
+      />
+      <TextField
+        label="Email URL"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={emailURL}
+        onChange={(e) => setEmailURL(e.target.value)}
+      />
+      <Button variant="contained" onClick={handleSave}>
+        Save
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- implement general, database, authentication and notification settings tabs
- add individual React components for each settings section
- hook new components into Settings page with save handler
- update UI overhaul docs
- adjust unit test to match new general settings UI

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_684dd2e355c48321b8339f865fc204c4