### PR TITLE
Add user management and OAuth settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: America/New_York
     open-pull-requests-limit: 10
     reviewers:
       - "jdfalk"
@@ -29,7 +29,6 @@ updates:
     labels:
       - "dependencies"
       - "npm"
-    milestone: "Dependencies"
     target-branch: "main"
     versioning-strategy: "increase"
     allow:
@@ -66,7 +65,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -99,7 +98,7 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 3
     reviewers:
       - "jdfalk"
@@ -119,7 +118,7 @@ updates:
       interval: "weekly"
       day: "thursday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -146,7 +145,7 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -171,7 +170,7 @@ updates:
       interval: "weekly"
       day: "saturday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -196,7 +195,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -221,7 +220,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "10:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -246,7 +245,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "10:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -271,7 +270,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "10:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -296,7 +295,7 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "10:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 3
     reviewers:
       - "jdfalk"
@@ -317,7 +316,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "11:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"
@@ -338,7 +337,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "11:00"
-      timezone: "UTC"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
     reviewers:
       - "jdfalk"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out
           flags: backend
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
 
@@ -123,7 +123,7 @@ jobs:
           ./bin/subtitle-manager --help
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: subtitle-manager-binary
           path: bin/subtitle-manager

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload build artifacts
         if: matrix.node-version == '20' # Only upload from one Node version
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-build
           path: webui/dist/
@@ -103,7 +103,7 @@ jobs:
         run: npm run test:e2e --if-present
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -204,7 +204,7 @@ jobs:
         run: npm run analyze --if-present
 
       - name: Upload bundle analysis
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle-analysis
           path: webui/dist/

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ The web server exposes a comprehensive REST API for all subtitle operations:
 - `GET /api/logs` - Get recent log entries
 - `GET /api/system` - System information (Go version, OS, architecture, goroutines)
 - `GET /api/tasks` - Current task status and progress
+- `GET /api/users` - List all users (admin only)
+- `POST /api/users/{id}/reset` - Reset a user's password and email credentials
 
 All endpoints require authentication via session cookies or API keys using the `X-API-Key` header. Role-based access control is enforced with three permission levels: `read`, `basic`, and `admin`.
 

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -163,6 +163,8 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	// New API endpoints for modern UI
 	mux.Handle(prefix+"/api/providers", authMiddleware(db, "basic", providersHandler()))
 	mux.Handle(prefix+"/api/library/browse", authMiddleware(db, "basic", libraryBrowseHandler()))
+	mux.Handle(prefix+"/api/users", authMiddleware(db, "admin", usersHandler(db)))
+	mux.Handle(prefix+"/api/users/", authMiddleware(db, "admin", userResetHandler(db)))
 	fsHandler := http.FileServer(http.FS(f))
 	mux.Handle(prefix+"/", staticFileMiddleware(http.StripPrefix(prefix+"/", fsHandler)))
 	return mux, nil

--- a/pkg/webserver/users.go
+++ b/pkg/webserver/users.go
@@ -1,0 +1,74 @@
+package webserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"subtitle-manager/pkg/auth"
+	"subtitle-manager/pkg/notifications"
+)
+
+// usersHandler returns a list of all users.
+func usersHandler(db *sql.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		users, err := auth.ListUsers(db)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(users)
+	})
+}
+
+// userResetHandler resets the password for the specified user ID, generates a new
+// API key and emails the credentials using the configured notification service.
+func userResetHandler(db *sql.DB) http.Handler {
+	type response struct {
+		Password string `json:"password"`
+		APIKey   string `json:"api_key"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/users/"), "/")
+		if len(parts) != 2 || parts[1] != "reset" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		id, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil || id == 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		pass, key, err := auth.ResetPassword(db, id)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var email, username string
+		row := db.QueryRow(`SELECT email, username FROM users WHERE id = ?`, id)
+		_ = row.Scan(&email, &username)
+		if email != "" {
+			svc := notifications.New(
+				viper.GetString("notifications.discord_webhook"),
+				viper.GetString("notifications.telegram_token"),
+				viper.GetString("notifications.telegram_chat_id"),
+				viper.GetString("notifications.email_url"),
+			)
+			msg := fmt.Sprintf("Credentials for %s\nPassword: %s\nAPI Key: %s", username, pass, key)
+			_ = svc.Send(context.Background(), msg)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response{Password: pass, APIKey: key})
+	})
+}

--- a/webui/src/System.jsx
+++ b/webui/src/System.jsx
@@ -28,8 +28,11 @@ import {
   Tooltip,
   Typography,
   useTheme,
+  Tabs,
+  Tab,
 } from "@mui/material";
 import { useEffect, useState } from "react";
+import UserManagement from "./UserManagement.jsx";
 
 /**
  * System component displays system information, logs, and running tasks.
@@ -42,6 +45,7 @@ export default function System() {
   const [tasks, setTasks] = useState({});
   const [loading, setLoading] = useState(true);
   const [expandedRawData, setExpandedRawData] = useState(false);
+  const [tab, setTab] = useState(0);
 
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
@@ -113,6 +117,11 @@ export default function System() {
         </Tooltip>
       </Box>
 
+      <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ mb: 3 }}>
+        <Tab label="System" />
+        <Tab label="Users" />
+      </Tabs>
+      {tab === 0 && (
       <Grid container spacing={3}>
         {/* System Information */}
         <Grid item xs={12} md={6}>
@@ -240,9 +249,12 @@ export default function System() {
               </Paper>
             </CardContent>
           </Card>
-        </Grid>
-
-        {/* Raw Data Section - Collapsible */}
+      </Grid>
+      )}
+      {tab === 1 && (
+        <UserManagement />
+      )}
+      {/* Raw Data Section - Collapsible */}
         <Grid item xs={12}>
           <Accordion
             expanded={expandedRawData}

--- a/webui/src/UserManagement.jsx
+++ b/webui/src/UserManagement.jsx
@@ -1,0 +1,68 @@
+// file: webui/src/UserManagement.jsx
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+
+/**
+ * UserManagement displays all users and allows password resets.
+ */
+export default function UserManagement() {
+  const [users, setUsers] = useState([]);
+
+  const loadUsers = async () => {
+    const res = await fetch("/api/users");
+    if (res.ok) setUsers(await res.json());
+  };
+
+  const reset = async (id) => {
+    if (!window.confirm("Reset password for this user?")) return;
+    const res = await fetch(`/api/users/${id}/reset`, { method: "POST" });
+    if (res.ok) {
+      alert("Password reset and emailed");
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Users
+      </Typography>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Username</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Role</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {users.map((u) => (
+            <TableRow key={u.id}>
+              <TableCell>{u.username}</TableCell>
+              <TableCell>{u.email}</TableCell>
+              <TableCell>{u.role}</TableCell>
+              <TableCell>
+                <Button size="small" onClick={() => reset(u.id)}>
+                  Reset Password
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/webui/src/components/AuthSettings.jsx
+++ b/webui/src/components/AuthSettings.jsx
@@ -3,59 +3,59 @@ import { Box, Button, TextField, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 
 /**
- * AuthSettings configures authentication credentials and API key.
+ * AuthSettings configures OAuth integration settings such as GitHub client
+ * credentials.
  *
  * @param {Object} props - Component properties
  * @param {Object} props.config - Current configuration values
  * @param {Function} props.onSave - Callback invoked with updated values
  */
 export default function AuthSettings({ config, onSave }) {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [apiKey, setApiKey] = useState("");
+  const [clientID, setClientID] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [redirectURL, setRedirectURL] = useState("");
 
   useEffect(() => {
-    if (config && config.auth) {
-      setUsername(config.auth.username || "");
-      setPassword(config.auth.password || "");
-      setApiKey(config.auth.api_key || "");
+    if (config) {
+      setClientID(config.github_client_id || "");
+      setClientSecret(config.github_client_secret || "");
+      setRedirectURL(config.github_redirect_url || "");
     }
   }, [config]);
 
   const handleSave = () => {
     onSave({
-      "auth.username": username,
-      "auth.password": password,
-      "auth.api_key": apiKey,
+      github_client_id: clientID,
+      github_client_secret: clientSecret,
+      github_redirect_url: redirectURL,
     });
   };
 
   return (
     <Box sx={{ maxWidth: 500 }}>
       <Typography variant="h6" gutterBottom>
-        Authentication
+        OAuth Integrations
       </Typography>
       <TextField
-        label="Username"
+        label="GitHub Client ID"
         fullWidth
         sx={{ mb: 2 }}
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
+        value={clientID}
+        onChange={(e) => setClientID(e.target.value)}
       />
       <TextField
-        label="Password"
-        type="password"
+        label="GitHub Client Secret"
         fullWidth
         sx={{ mb: 2 }}
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
+        value={clientSecret}
+        onChange={(e) => setClientSecret(e.target.value)}
       />
       <TextField
-        label="API Key"
+        label="GitHub Redirect URL"
         fullWidth
         sx={{ mb: 2 }}
-        value={apiKey}
-        onChange={(e) => setApiKey(e.target.value)}
+        value={redirectURL}
+        onChange={(e) => setRedirectURL(e.target.value)}
       />
       <Button variant="contained" onClick={handleSave}>
         Save


### PR DESCRIPTION
## Summary
- generate API key automatically for users and implement password reset API
- add user management handlers
- expose user management endpoints in the server
- update OAuth settings UI
- create user management React component and integrate into System page
- document new API endpoints

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e0ecf49108321b60d5f820394bc31