### PR TITLE
Implement subtitle synchronization via audio and embedded tracks

### DIFF
--- a/pkg/subtitles/extract.go
+++ b/pkg/subtitles/extract.go
@@ -17,10 +17,10 @@ func SetFFmpegPath(path string) {
 	ffmpegPath = path
 }
 
-// ExtractFromMedia extracts the first subtitle stream from the given media
-// container using the `ffmpeg` command line tool. The resulting subtitle items
-// are returned. The `ffmpeg` binary must be available in $PATH.
-func ExtractFromMedia(mediaPath string) ([]*astisub.Item, error) {
+// ExtractSubtitleTrack extracts the subtitle stream at the given track index
+// from mediaPath using `ffmpeg`. The resulting subtitle items are returned.
+// Track indexes start at 0. The `ffmpeg` binary must be available in $PATH.
+func ExtractSubtitleTrack(mediaPath string, track int) ([]*astisub.Item, error) {
 	tmp, err := os.CreateTemp("", "subextract-*.srt")
 	if err != nil {
 		return nil, err
@@ -28,7 +28,8 @@ func ExtractFromMedia(mediaPath string) ([]*astisub.Item, error) {
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 
-	cmd := exec.CommandContext(context.Background(), ffmpegPath, "-y", "-i", mediaPath, "-map", "0:s:0", tmp.Name())
+	mapArg := fmt.Sprintf("0:s:%d", track)
+	cmd := exec.CommandContext(context.Background(), ffmpegPath, "-y", "-i", mediaPath, "-map", mapArg, tmp.Name())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("ffmpeg: %v: %s", err, out)
 	}
@@ -40,4 +41,11 @@ func ExtractFromMedia(mediaPath string) ([]*astisub.Item, error) {
 	items := make([]*astisub.Item, len(sub.Items))
 	copy(items, sub.Items)
 	return items, nil
+}
+
+// ExtractFromMedia extracts the first subtitle stream from the given media
+// container using the `ffmpeg` command line tool. The resulting subtitle items
+// are returned. The `ffmpeg` binary must be available in $PATH.
+func ExtractFromMedia(mediaPath string) ([]*astisub.Item, error) {
+	return ExtractSubtitleTrack(mediaPath, 0)
 }

--- a/pkg/subtitles/extract_test.go
+++ b/pkg/subtitles/extract_test.go
@@ -44,3 +44,24 @@ func TestSetFFmpegPath(t *testing.T) {
 		t.Fatal("no items extracted")
 	}
 }
+
+// TestExtractSubtitleTrack verifies extraction of a specific subtitle track.
+func TestExtractSubtitleTrack(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "ffmpeg")
+	data := "#!/bin/sh\ncp ../../testdata/simple.srt \"$6\"\n"
+	if err := os.WriteFile(script, []byte(data), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir+":"+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	items, err := ExtractSubtitleTrack("dummy.mkv", 0)
+	if err != nil {
+		t.Fatalf("extract track: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("no items extracted")
+	}
+}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -1,9 +1,12 @@
 package syncer
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/asticode/go-astisub"
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+	"github.com/jdfalk/subtitle-manager/pkg/transcriber"
 )
 
 // Options controls how the synchronization process behaves.
@@ -16,6 +19,29 @@ type Options struct {
 	AudioTrack int
 	// SubtitleTracks selects embedded subtitle track indices when UseEmbedded is true.
 	SubtitleTracks []int
+	// WhisperKey provides the API key for audio transcription when
+	// UseAudio is true.
+	WhisperKey string
+	// AudioWeight controls the influence of audio alignment versus embedded
+	// subtitles. A value between 0 and 1 is expected. When zero, 0.7 is
+	// used.
+	AudioWeight float64
+}
+
+// transcribeFn wraps the audio transcription function. Tests may override it.
+var transcribeFn = transcriber.WhisperTranscribe
+
+// extractFn wraps subtitle track extraction. Tests may override it.
+var extractFn = subtitles.ExtractSubtitleTrack
+
+// SetTranscribeFunc overrides the default audio transcription function.
+func SetTranscribeFunc(fn func(string, string, string) ([]byte, error)) {
+	transcribeFn = fn
+}
+
+// SetExtractFunc overrides the default subtitle extraction function.
+func SetExtractFunc(fn func(string, int) ([]*astisub.Item, error)) {
+	extractFn = fn
 }
 
 // Sync attempts to synchronize the subtitle at subPath with the media file at
@@ -31,6 +57,49 @@ func Sync(mediaPath, subPath string, opts Options) ([]*astisub.Item, error) {
 	}
 	items := make([]*astisub.Item, len(sub.Items))
 	copy(items, sub.Items)
+
+	weight := opts.AudioWeight
+	if weight == 0 {
+		weight = 0.7
+	}
+
+	var total time.Duration
+	var applied float64
+
+	if opts.UseAudio {
+		b, err := transcribeFn(mediaPath, "", opts.WhisperKey)
+		if err == nil {
+			refSub, err := astisub.ReadFromSRT(bytes.NewReader(b))
+			if err == nil {
+				off := computeOffset(refSub.Items, items)
+				total += time.Duration(float64(off) * weight)
+				applied += weight
+			}
+		}
+	}
+
+	if opts.UseEmbedded {
+		tracks := opts.SubtitleTracks
+		if len(tracks) == 0 {
+			tracks = []int{0}
+		}
+		if len(tracks) > 0 {
+			per := (1 - weight) / float64(len(tracks))
+			for _, t := range tracks {
+				refItems, err := extractFn(mediaPath, t)
+				if err == nil {
+					off := computeOffset(refItems, items)
+					total += time.Duration(float64(off) * per)
+					applied += per
+				}
+			}
+		}
+	}
+
+	if applied > 0 {
+		offset := time.Duration(float64(total) / applied)
+		items = Shift(items, offset)
+	}
 	return items, nil
 }
 
@@ -44,4 +113,24 @@ func Shift(items []*astisub.Item, offset time.Duration) []*astisub.Item {
 		out[i] = &c
 	}
 	return out
+}
+
+// computeOffset returns the average difference between the start times of ref
+// and target. Up to the first five items are compared.
+func computeOffset(ref, target []*astisub.Item) time.Duration {
+	n := len(ref)
+	if len(target) < n {
+		n = len(target)
+	}
+	if n > 5 {
+		n = 5
+	}
+	if n == 0 {
+		return 0
+	}
+	var sum time.Duration
+	for i := 0; i < n; i++ {
+		sum += ref[i].StartAt - target[i].StartAt
+	}
+	return sum / time.Duration(n)
 }

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -1,6 +1,8 @@
 package syncer
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,5 +26,58 @@ func TestSync(t *testing.T) {
 	}
 	if len(items) == 0 {
 		t.Fatal("no items returned")
+	}
+}
+
+// TestComputeOffset verifies that computeOffset returns the expected duration.
+func TestComputeOffset(t *testing.T) {
+	ref := []*astisub.Item{{StartAt: 2 * time.Second}}
+	target := []*astisub.Item{{StartAt: time.Second}}
+	if d := computeOffset(ref, target); d != time.Second {
+		t.Fatalf("unexpected offset %v", d)
+	}
+}
+
+// TestSyncWeighted verifies synchronization using both audio and embedded
+// subtitles with weighted averaging.
+func TestSyncWeighted(t *testing.T) {
+	base, err := astisub.OpenFile("../../testdata/simple.srt")
+	if err != nil {
+		t.Fatalf("open base: %v", err)
+	}
+	shifted := Shift(base.Items, -1*time.Second)
+	dir := t.TempDir()
+	subFile := filepath.Join(dir, "shifted.srt")
+	f, err := os.Create(subFile)
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	astisub.Subtitles{Items: shifted}.WriteToSRT(f)
+	f.Close()
+
+	defer func(oldT func(string, string, string) ([]byte, error), oldE func(string, int) ([]*astisub.Item, error)) {
+		SetTranscribeFunc(oldT)
+		SetExtractFunc(oldE)
+	}(transcribeFn, extractFn)
+
+	SetTranscribeFunc(func(string, string, string) ([]byte, error) {
+		b, _ := os.ReadFile("../../testdata/simple.srt")
+		return b, nil
+	})
+
+	SetExtractFunc(func(string, int) ([]*astisub.Item, error) {
+		return Shift(base.Items, time.Second), nil
+	})
+
+	items, err := Sync("dummy.mkv", subFile, Options{UseAudio: true, UseEmbedded: true, AudioWeight: 0.7})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("no items returned")
+	}
+	exp := 1300 * time.Millisecond
+	if items[0].StartAt != exp {
+		t.Fatalf("unexpected start %v", items[0].StartAt)
 	}
 }


### PR DESCRIPTION
## Summary
- enable selecting specific subtitle streams with `ExtractSubtitleTrack`
- implement weighted subtitle sync that prefers audio analysis
- support custom transcription and extraction functions for tests
- cover new functionality with unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ebf1b60a483219b693bf0bf684a6b