### PR TITLE
Fix accessibility test configuration

### DIFF
--- a/webui/lighthouserc.json
+++ b/webui/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "categories:accessibility": ["error", {"minScore": 0.9}]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/webui/package.json
+++ b/webui/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:a11y": "echo 'Accessibility tests not yet configured'",
+    "test:a11y": "npx lhci autorun --config=./lighthouserc.json",
     "analyze": "echo 'Bundle analysis not yet configured'"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add Lighthouse CI config
- update `test:a11y` script to run Lighthouse

## Testing
- `npm run build`
- `npm run test:a11y` *(fails: Chrome snap not installed)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684ed41f571483219be6d912576e4b5d