### PR TITLE
Move user management to settings

### DIFF
--- a/webui/src/Settings.jsx
+++ b/webui/src/Settings.jsx
@@ -8,6 +8,7 @@ import {
     Notifications as NotificationIcon,
     CloudDownload as ProvidersIcon,
     Refresh as RefreshIcon,
+    People as UsersIcon,
 } from '@mui/icons-material';
 import {
     Alert,
@@ -32,6 +33,7 @@ import GeneralSettings from './components/GeneralSettings.jsx';
 import NotificationSettings from './components/NotificationSettings.jsx';
 import ProviderCard from './components/ProviderCard.jsx';
 import ProviderConfigDialog from './components/ProviderConfigDialog.jsx';
+import UserManagement from './UserManagement.jsx';
 import { apiService } from './services/api.js';
 
 /**
@@ -431,6 +433,13 @@ export default function Settings({ backendAvailable = true }) {
           onSave={saveSettings}
           backendAvailable={backendAvailable}
         />
+      ),
+    },
+    {
+      label: 'Users',
+      icon: <UsersIcon />,
+      component: () => (
+        <UserManagement backendAvailable={backendAvailable} />
       ),
     },
   ];

--- a/webui/src/System.jsx
+++ b/webui/src/System.jsx
@@ -31,7 +31,6 @@ import {
   useTheme,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
-import UserManagement from './UserManagement.jsx';
 
 /**
  * System component displays system information, logs, and running tasks.
@@ -147,7 +146,6 @@ export default function System({ backendAvailable = true }) {
 
       <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ mb: 3 }}>
         <Tab label="System" />
-        <Tab label="Users" />
       </Tabs>
 
       {tab === 0 && (
@@ -455,7 +453,6 @@ export default function System({ backendAvailable = true }) {
         </Box>
       )}
 
-      {tab === 1 && <UserManagement />}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- move user management tab from System to Settings

## Testing
- `go test ./...` *(fails: authentication not configured)*
- `npm test` *(fails: React component tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68509ce15d708321b30d4984e09cb236