### PR TITLE
Fix pinned sidebar gap

### DIFF
--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -892,7 +892,7 @@ function App() {
               easing: theme.transitions.easing.sharp,
               duration: theme.transitions.duration.leavingScreen,
             }),
-            marginLeft: drawerPinned ? '280px' : 0,
+            marginLeft: 0,
             backgroundColor: 'background.default',
             minHeight: '100vh',
           }}


### PR DESCRIPTION
## Summary
- pinning the sidebar caused duplicate spacing in the layout
- remove margin offset when the drawer is pinned

## Testing
- `npm --prefix webui ci --legacy-peer-deps --silent`
- `npm --prefix webui test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850dea732c483219ea00e8850ba0dfd