### PR TITLE
Implement OAuth2 credential generation API

### DIFF
--- a/pkg/webserver/oauth_management.go
+++ b/pkg/webserver/oauth_management.go
@@ -1,0 +1,67 @@
+// file: pkg/webserver/oauth_management.go
+package webserver
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+
+	"github.com/spf13/viper"
+)
+
+// oauthCredentials represents OAuth2 credentials returned to clients.
+type oauthCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RedirectURL  string `json:"redirect_url,omitempty"`
+}
+
+// generateSecureToken returns a cryptographically secure random hex string.
+func generateSecureToken(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// githubOAuthGenerateHandler handles POST /api/oauth/github/generate requests.
+// It generates new GitHub OAuth2 credentials and persists them via Viper.
+func githubOAuthGenerateHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		id, err := generateSecureToken(16)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		secret, err := generateSecureToken(32)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		creds := oauthCredentials{
+			ClientID:     "gh_" + id,
+			ClientSecret: "ghs_" + secret,
+			RedirectURL:  r.Header.Get("Origin") + "/api/oauth/github/callback",
+		}
+
+		viper.Set("github_client_id", creds.ClientID)
+		viper.Set("github_client_secret", creds.ClientSecret)
+		viper.Set("github_redirect_url", creds.RedirectURL)
+		if cfg := viper.ConfigFileUsed(); cfg != "" {
+			if err := viper.WriteConfig(); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(creds)
+	})
+}

--- a/pkg/webserver/oauth_management_test.go
+++ b/pkg/webserver/oauth_management_test.go
@@ -1,0 +1,67 @@
+// file: pkg/webserver/oauth_management_test.go
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/auth"
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/testutil"
+)
+
+// TestGitHubOAuthGenerate verifies POST /api/oauth/github/generate creates new credentials.
+func TestGitHubOAuthGenerate(t *testing.T) {
+	db, err := database.Open(":memory:")
+	testutil.MustNoError(t, "open db", err)
+	defer db.Close()
+
+	testutil.MustNoError(t, "create admin", auth.CreateUser(db, "admin", "p", "", "admin"))
+	key := testutil.MustGet(t, "api key", func() (string, error) { return auth.GenerateAPIKey(db, 1) })
+
+	tmp := filepath.Join(t.TempDir(), "cfg.yaml")
+	viper.SetConfigFile(tmp)
+	testutil.MustNoError(t, "write config", viper.WriteConfig())
+	defer viper.Reset()
+
+	h, err := Handler(db)
+	testutil.MustNoError(t, "handler", err)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/api/oauth/github/generate", nil)
+	req.Header.Set("X-API-Key", key)
+	req.Header.Set("Origin", srv.URL)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var creds struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		RedirectURL  string `json:"redirect_url"`
+	}
+	json.NewDecoder(resp.Body).Decode(&creds)
+	resp.Body.Close()
+
+	if !strings.HasPrefix(creds.ClientID, "gh_") || !strings.HasPrefix(creds.ClientSecret, "ghs_") {
+		t.Fatalf("unexpected credentials: %#v", creds)
+	}
+	if viper.GetString("github_client_id") != creds.ClientID {
+		t.Fatalf("client id not stored")
+	}
+	data := testutil.MustGet(t, "read file", func() ([]byte, error) { return os.ReadFile(tmp) })
+	if !strings.Contains(string(data), creds.ClientID) {
+		t.Fatalf("config not written")
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -135,6 +135,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/setup/bazarr/upload", bazarrConfigUploadHandler(db))
 	mux.Handle(prefix+"/api/oauth/github/login", githubLoginHandler(db))
 	mux.Handle(prefix+"/api/oauth/github/callback", githubCallbackHandler(db))
+	mux.Handle(prefix+"/api/oauth/github/generate", authMiddleware(db, "admin", githubOAuthGenerateHandler()))
 	mux.Handle(prefix+"/api/config", authMiddleware(db, "basic", configHandler()))
 	// Add Bazarr endpoints for Settings UI
 	mux.Handle(prefix+"/api/bazarr/config", authMiddleware(db, "basic", bazarrConfigHandler()))


### PR DESCRIPTION
## Summary
- add `githubOAuthGenerateHandler` with secure token generation
- expose POST `/api/oauth/github/generate` route
- test OAuth credential generation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850e1c1d2c88321b3b5a4fafba3b09a