### PR TITLE
Implement automatic updater

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -171,6 +171,9 @@ func initConfig() {
 	viper.SetDefault("integrations.bazarr.import", false)
 	viper.SetDefault("integrations.plex.enabled", false)
 	viper.SetDefault("integrations.notifications.enabled", false)
+	viper.SetDefault("auto_update", false)
+	viper.SetDefault("update_branch", "master")
+	viper.SetDefault("update_frequency", "daily")
 
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -18,4 +18,6 @@ var webCmd = &cobra.Command{
 func init() {
 	webCmd.Flags().StringVar(&addr, "addr", ":8080", "listen address")
 	rootCmd.AddCommand(webCmd)
+	v, _, _ := GetVersionInfo()
+	webserver.SetVersion(v)
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -94,6 +94,7 @@ func checkForUpdate(ctx context.Context, repo, current string) (*Release, bool, 
 // findAsset returns the download URL for the release asset matching the current
 // OS and architecture.
 const projectName = "subtitle-manager"
+
 func findAsset(rel *Release) (string, error) {
 	name := fmt.Sprintf("%s-%s-%s", projectName, runtime.GOOS, runtime.GOARCH)
 	if runtime.GOOS == "windows" {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -191,7 +191,7 @@ func StartPeriodic(ctx context.Context, repo, current, frequency string) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				_ = SelfUpdate(context.Background(), repo, current)
+				_ = SelfUpdate(ctx, repo, current)
 			}
 		}
 	}()

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1,0 +1,197 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// githubAPIBaseURL is the base URL for GitHub API requests. It can be
+// overridden in tests using SetGitHubAPIBaseURL.
+var githubAPIBaseURL = "https://api.github.com"
+
+// httpClient is used for network requests. Tests can replace it with a custom
+// client.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+// exePathFunc returns the path to the current executable. It is overridable for
+// testing.
+var exePathFunc = os.Executable
+
+// restartFunc is called after a successful update to launch the new binary.
+// The default implementation starts the new process and exits.
+var restartFunc = func() error {
+	exe, err := exePathFunc()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, os.Args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}
+
+// SetGitHubAPIBaseURL overrides the GitHub API base URL. This is primarily used
+// for tests.
+func SetGitHubAPIBaseURL(u string) { githubAPIBaseURL = u }
+
+// SetHTTPClient overrides the HTTP client used for requests. Used in tests.
+func SetHTTPClient(c *http.Client) { httpClient = c }
+
+// SetExecutablePathFunc overrides the function used to determine the
+// executable path. Used in tests.
+func SetExecutablePathFunc(fn func() (string, error)) { exePathFunc = fn }
+
+// SetRestartFunc overrides the restart behavior. Used in tests to avoid
+// exiting the process.
+func SetRestartFunc(fn func() error) { restartFunc = fn }
+
+// Release represents the subset of GitHub release information used by the
+// updater.
+type Release struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name string `json:"name"`
+		URL  string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// checkForUpdate retrieves the latest release for repo and compares it with the
+// current version. It returns the release when a newer version is available.
+func checkForUpdate(ctx context.Context, repo, current string) (*Release, bool, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIBaseURL+"/repos/"+repo+"/releases/latest", nil)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, false, err
+	}
+	latest := strings.TrimPrefix(rel.TagName, "v")
+	if latest == current {
+		return &rel, false, nil
+	}
+	return &rel, true, nil
+}
+
+// findAsset returns the download URL for the release asset matching the current
+// OS and architecture.
+func findAsset(rel *Release) (string, error) {
+	name := fmt.Sprintf("subtitle-manager-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	for _, a := range rel.Assets {
+		if a.Name == name {
+			return a.URL, nil
+		}
+	}
+	return "", fmt.Errorf("asset %s not found", name)
+}
+
+// downloadBinary retrieves the binary from url and returns its contents.
+func downloadBinary(ctx context.Context, url string) ([]byte, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// replaceExecutable writes data to the current executable path.
+func replaceExecutable(data []byte) error {
+	path, err := exePathFunc()
+	if err != nil {
+		return err
+	}
+	tmp := path + ".new"
+	if err := os.WriteFile(tmp, data, 0755); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SelfUpdate checks for a newer release in repo and, if available, downloads the
+// appropriate binary, replaces the current executable, and restarts the
+// application.
+func SelfUpdate(ctx context.Context, repo, current string) error {
+	rel, newer, err := checkForUpdate(ctx, repo, current)
+	if err != nil || !newer {
+		return err
+	}
+	url, err := findAsset(rel)
+	if err != nil {
+		return err
+	}
+	data, err := downloadBinary(ctx, url)
+	if err != nil {
+		return err
+	}
+	if err := replaceExecutable(data); err != nil {
+		return err
+	}
+	return restartFunc()
+}
+
+// frequencyToDuration converts a textual frequency like "daily" to a
+// time.Duration. Unknown values default to 24 hours.
+func frequencyToDuration(freq string) time.Duration {
+	switch strings.ToLower(freq) {
+	case "hourly":
+		return time.Hour
+	case "daily":
+		return 24 * time.Hour
+	case "weekly":
+		return 7 * 24 * time.Hour
+	default:
+		d, err := time.ParseDuration(freq)
+		if err != nil {
+			return 24 * time.Hour
+		}
+		return d
+	}
+}
+
+// StartPeriodic updates periodically according to frequency. The repo and
+// current version are used for update checks. The provided context controls the
+// lifetime of the background goroutine.
+func StartPeriodic(ctx context.Context, repo, current, frequency string) {
+	interval := frequencyToDuration(frequency)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_ = SelfUpdate(context.Background(), repo, current)
+			}
+		}
+	}()
+}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -93,8 +93,9 @@ func checkForUpdate(ctx context.Context, repo, current string) (*Release, bool, 
 
 // findAsset returns the download URL for the release asset matching the current
 // OS and architecture.
+const projectName = "subtitle-manager"
 func findAsset(rel *Release) (string, error) {
-	name := fmt.Sprintf("subtitle-manager-%s-%s", runtime.GOOS, runtime.GOARCH)
+	name := fmt.Sprintf("%s-%s-%s", projectName, runtime.GOOS, runtime.GOARCH)
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -1,0 +1,56 @@
+package updater
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestSelfUpdate verifies that SelfUpdate downloads the new binary and replaces
+// the executable without restarting when restartFunc is overridden.
+func TestSelfUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	exePath := filepath.Join(tmpDir, "app")
+	os.WriteFile(exePath, []byte("old"), 0755)
+
+	SetExecutablePathFunc(func() (string, error) { return exePath, nil })
+	defer SetExecutablePathFunc(os.Executable)
+
+	var restarted bool
+	SetRestartFunc(func() error { restarted = true; return nil })
+	defer SetRestartFunc(func() error { return nil })
+
+	var url string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/test/repo/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"tag_name":"v1.1.0","assets":[{"name":"subtitle-manager-`+runtime.GOOS+`-`+runtime.GOARCH+`","browser_download_url":"`+url+`/bin"}]}`)
+		case "/bin":
+			w.Write([]byte("new"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	url = srv.URL
+	defer srv.Close()
+
+	SetGitHubAPIBaseURL(srv.URL)
+	defer SetGitHubAPIBaseURL("https://api.github.com")
+
+	if err := SelfUpdate(context.Background(), "test/repo", "1.0.0"); err != nil {
+		t.Fatalf("self update: %v", err)
+	}
+	data, _ := os.ReadFile(exePath)
+	if string(data) != "new" {
+		t.Fatalf("binary not replaced")
+	}
+	if !restarted {
+		t.Fatalf("restartFunc not called")
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,6 +1,7 @@
 package webserver
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/jdfalk/subtitle-manager/pkg/bazarr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+	"github.com/jdfalk/subtitle-manager/pkg/updater"
 	"github.com/jdfalk/subtitle-manager/pkg/webhooks"
 	"github.com/jdfalk/subtitle-manager/webui"
 )
@@ -217,6 +219,14 @@ func StartServer(addr string) error {
 
 	// Start periodic cleanup of expired sessions
 	go startSessionCleanup(db)
+
+	// Start automatic update checker if enabled
+	if viper.GetBool("auto_update") {
+		freq := viper.GetString("update_frequency")
+		repo := "subtitle-manager/subtitle-manager"
+		ctx := context.Background()
+		updater.StartPeriodic(ctx, repo, AppVersion, freq)
+	}
 
 	return http.ListenAndServe(addr, h)
 }

--- a/pkg/webserver/version.go
+++ b/pkg/webserver/version.go
@@ -1,0 +1,7 @@
+package webserver
+
+// AppVersion holds the application version set by the cmd package.
+var AppVersion = "dev"
+
+// SetVersion stores the application version for the webserver package.
+func SetVersion(v string) { AppVersion = v }


### PR DESCRIPTION
## Summary
- add `updater` package for GitHub-based self-updates
- launch periodic updater in web server when `auto_update` is enabled
- store app version in webserver package
- expose updater configuration defaults
- test updater logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850e7ba397c832184330ce9fe31a8d4