### PR TITLE
Update Node workflow versions

### DIFF
--- a/.github/WORKFLOW_SETUP_COMPLETE.md
+++ b/.github/WORKFLOW_SETUP_COMPLETE.md
@@ -20,7 +20,7 @@
    - Binary build verification
 
 3. **Frontend Workflow** (`frontend.yml`)
-   - Multi-version Node.js testing (18, 20, 21)
+   - Multi-version Node.js testing (22, 24)
    - ESLint code quality
    - Prettier formatting
    - Build verification

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,7 +31,7 @@ This project uses a modern CI/CD setup with separate workflows for frontend and 
 - **Purpose**: Tests Node.js frontend code
 - **Triggers**: Changes to `webui/**`
 - **Features**:
-  - Multi-version Node.js testing (18, 20, 21)
+  - Multi-version Node.js testing (22, 24)
   - ESLint code quality checks
   - Prettier formatting verification
   - TypeScript type checking

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.check_commit.outputs.skip == 'false'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout code
@@ -68,7 +68,7 @@ jobs:
           du -sh dist/
 
       - name: Upload build artifacts
-        if: matrix.node-version == '20' # Only upload from one Node version
+        if: matrix.node-version == '22' # Only upload from one Node version
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 
@@ -179,7 +179,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 
@@ -208,7 +208,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: webui/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Optimized multi-stage Dockerfile to reduce build times from ~20min to ~3-5min
 
 # Stage 1: Node.js build stage (can be cached separately)
-FROM node:20-alpine AS node-builder
+FROM node:22-alpine AS node-builder
 WORKDIR /src/webui
 
 # Copy package files first for better caching

--- a/Dockerfile.hybrid
+++ b/Dockerfile.hybrid
@@ -2,7 +2,7 @@
 # Hybrid approach: Install Node.js in Go builder for go generate compatibility
 
 # Stage 1: Node.js build stage (can be cached separately)
-FROM node:20-alpine AS node-builder
+FROM node:22-alpine AS node-builder
 WORKDIR /src/webui
 
 # Copy package files first for better caching

--- a/UI_UX_IMPLEMENTATION_PLAN_COMPLETE.md
+++ b/UI_UX_IMPLEMENTATION_PLAN_COMPLETE.md
@@ -211,7 +211,7 @@ The Subtitle Manager web UI requires significant improvements to match Bazarr's 
 
 Before starting implementation, ensure you have:
 
-- Node.js 18+ installed
+- Node.js 22+ installed
 - React development environment set up
 - Access to the existing codebase
 - Basic understanding of React, Material-UI, and JavaScript/TypeScript


### PR DESCRIPTION
## Description

Switch workflows and Docker images to Node 22 and add Node 24 to tests.

## Motivation

Prepare CI for upcoming Node upgrade and remove older test environments.

## Changes

- update frontend workflow matrix to `22` and `24`
- update build-assets and auto-format workflows to use Node 22
- switch Dockerfiles to Node 22 base image
- document new Node versions in workflow docs
- update implementation plan prerequisites

## Testing

- `npm test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852bdd246bc832184ebe2b844ea4aa1