### PR TITLE
Add periodic Sonarr/Radarr sync

### DIFF
--- a/pkg/radarr/client.go
+++ b/pkg/radarr/client.go
@@ -1,0 +1,88 @@
+package radarr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+)
+
+// Client provides minimal access to the Radarr API.
+type Client struct {
+	BaseURL string
+	APIKey  string
+	client  *http.Client
+}
+
+// NewClient returns a configured Radarr API client.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		APIKey:  apiKey,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type movie struct {
+	Title     string `json:"title"`
+	MovieFile struct {
+		Path string `json:"path"`
+	} `json:"movieFile"`
+}
+
+// Movies retrieves all movies with associated file paths.
+func (c *Client) Movies(ctx context.Context) ([]database.MediaItem, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v3/movie?includeMovieFile=true", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var m []movie
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, err
+	}
+	var items []database.MediaItem
+	for _, mv := range m {
+		if mv.MovieFile.Path == "" {
+			continue
+		}
+		items = append(items, database.MediaItem{Path: mv.MovieFile.Path, Title: mv.Title})
+	}
+	return items, nil
+}
+
+// Sync fetches the movie library and stores new items in store.
+func Sync(ctx context.Context, c *Client, store database.SubtitleStore) error {
+	movies, err := c.Movies(ctx)
+	if err != nil {
+		return err
+	}
+	existing, err := store.ListMediaItems()
+	if err != nil {
+		return err
+	}
+	paths := make(map[string]bool, len(existing))
+	for _, it := range existing {
+		paths[it.Path] = true
+	}
+	for _, it := range movies {
+		if !paths[it.Path] {
+			if err := store.InsertMediaItem(&it); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/radarr/scheduler.go
+++ b/pkg/radarr/scheduler.go
@@ -1,0 +1,17 @@
+package radarr
+
+import (
+	"context"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/scheduler"
+)
+
+// StartSync periodically syncs the Radarr library using interval.
+// The sync runs immediately then at each interval until ctx is cancelled.
+func StartSync(ctx context.Context, interval time.Duration, c *Client, store database.SubtitleStore) {
+	go scheduler.Run(ctx, interval, func(ctx context.Context) error {
+		return Sync(ctx, c, store)
+	})
+}

--- a/pkg/sonarr/client.go
+++ b/pkg/sonarr/client.go
@@ -1,0 +1,92 @@
+package sonarr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+)
+
+// Client provides minimal access to the Sonarr API.
+type Client struct {
+	BaseURL string
+	APIKey  string
+	client  *http.Client
+}
+
+// NewClient returns a configured Sonarr API client.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		APIKey:  apiKey,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type episode struct {
+	Series struct {
+		Title string `json:"title"`
+	} `json:"series"`
+	EpisodeFile struct {
+		Path string `json:"path"`
+	} `json:"episodeFile"`
+	SeasonNumber  int `json:"seasonNumber"`
+	EpisodeNumber int `json:"episodeNumber"`
+}
+
+// Episodes retrieves all episodes with associated file paths.
+func (c *Client) Episodes(ctx context.Context) ([]database.MediaItem, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v3/episode?includeEpisodeFile=true", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var e []episode
+	if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+		return nil, err
+	}
+	var items []database.MediaItem
+	for _, ep := range e {
+		if ep.EpisodeFile.Path == "" {
+			continue
+		}
+		items = append(items, database.MediaItem{Path: ep.EpisodeFile.Path, Title: ep.Series.Title, Season: ep.SeasonNumber, Episode: ep.EpisodeNumber})
+	}
+	return items, nil
+}
+
+// Sync fetches episodes and stores new items in store.
+func Sync(ctx context.Context, c *Client, store database.SubtitleStore) error {
+	eps, err := c.Episodes(ctx)
+	if err != nil {
+		return err
+	}
+	existing, err := store.ListMediaItems()
+	if err != nil {
+		return err
+	}
+	paths := make(map[string]bool, len(existing))
+	for _, it := range existing {
+		paths[it.Path] = true
+	}
+	for _, it := range eps {
+		if !paths[it.Path] {
+			if err := store.InsertMediaItem(&it); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/sonarr/scheduler.go
+++ b/pkg/sonarr/scheduler.go
@@ -1,0 +1,17 @@
+package sonarr
+
+import (
+	"context"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/scheduler"
+)
+
+// StartSync periodically syncs the Sonarr library using interval.
+// The sync runs immediately then at each interval until ctx is cancelled.
+func StartSync(ctx context.Context, interval time.Duration, c *Client, store database.SubtitleStore) {
+	go scheduler.Run(ctx, interval, func(ctx context.Context) error {
+		return Sync(ctx, c, store)
+	})
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -277,7 +277,6 @@ func StartServer(addr string) error {
 			}
 			url := fmt.Sprintf("%s://%s:%v/%s", scheme, host, port, base)
 			c := sonarr.NewClient(url, key)
-			ctx := context.Background()
 			sonarr.StartSync(ctx, time.Duration(interval)*time.Minute, c, store)
 		}
 	}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -258,7 +258,7 @@ func StartServer(addr string) error {
 			}
 			url := fmt.Sprintf("%s://%s:%v/%s", scheme, host, port, base)
 			c := radarr.NewClient(url, key)
-			ctx := context.Background()
+			ctx := parentCtx
 			radarr.StartSync(ctx, time.Duration(interval)*time.Minute, c, store)
 		}
 		if viper.GetBool("integrations.sonarr.enabled") {


### PR DESCRIPTION
## Summary
- implement basic Radarr and Sonarr API clients
- store media items from Radarr/Sonarr
- periodically sync libraries when enabled in configuration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852e9a542308321a91e95ee6dc6b45f