### PR TITLE
Implement OMDb metadata fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Automated maintenance tasks with configurable scheduling.
 
+### Added
+- Fetch languages, ratings, and episode data from OMDb via new metadata functions.
+
 ## [0.9.0] - 2025-06-30
 
 ### Status Update

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Scan existing libraries and fetch missing or upgraded subtitles.
 - Download individual subtitles through the web API at `/api/download`.
 - Schedule scans with the `autoscan` command using intervals or cron expressions.
-- Parse file names and retrieve movie or episode details from TheMovieDB.
+- Parse file names and retrieve movie or episode details from TheMovieDB with language and rating data from OMDb.
 - High performance scanning using concurrent workers.
 - Recursive directory watching with -r flag.
 - Integrate with Sonarr, Radarr and Plex using dedicated commands.


### PR DESCRIPTION
## Summary
- extend `MediaInfo` with languages and rating fields
- add OMDb API integration and helper functions
- provide `FetchMovieMetadata` and `FetchEpisodeMetadata`
- update README and CHANGELOG
- test OMDb metadata fetch

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852e9b38e348321b3923e50da7fbdc3