### PR TITLE
Implement security headers and DOMPurify

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ For a detailed list of Bazarr features used as the parity target, see [docs/BAZA
 Instructions for importing an existing Bazarr configuration are documented in [docs/BAZARR_SETTINGS_SYNC.md](docs/BAZARR_SETTINGS_SYNC.md).
 A high-level code overview is available in [docs/CODE_OVERVIEW.md](docs/CODE_OVERVIEW.md).
 
+## Security
+
+Subtitle Manager applies strict security headers and sanitizes HTML content in the web interface using DOMPurify. When contributing UI or API code, ensure all user-provided data is properly validated and sanitized.
+
 ## License
 
 This project is licensed under the terms of the MIT license. See `LICENSE` for details.

--- a/pkg/webserver/security.go
+++ b/pkg/webserver/security.go
@@ -1,0 +1,17 @@
+// file: pkg/webserver/security.go
+
+package webserver
+
+import "net/http"
+
+// securityHeadersMiddleware sets common security headers on all responses.
+// It helps mitigate XSS, clickjacking and other browser based attacks.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'")
+		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -184,7 +184,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/media/", authMiddleware(db, "basic", mediaTagsHandler(db)))
 	fsHandler := spaFileServer(f)
 	mux.Handle(prefix+"/", staticFileMiddleware(http.StripPrefix(prefix+"/", fsHandler)))
-	return mux, nil
+	return securityHeadersMiddleware(mux), nil
 }
 
 // StartServer starts an HTTP server on the given address serving the embedded UI.

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
+        "dompurify": "^3.2.6",
         "jsdom": "^26.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2338,6 +2339,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3412,6 +3420,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-prop": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -25,6 +25,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
+    "dompurify": "^3.2.6",
     "jsdom": "^26.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/webui/src/System.jsx
+++ b/webui/src/System.jsx
@@ -35,6 +35,7 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { sanitizeConfig } from './utils/configSanitizer.js';
+import { sanitizeHTML } from './utils/sanitizeHTML.js';
 
 /**
  * System component displays system information, logs, and running tasks.
@@ -388,9 +389,10 @@ export default function System({ backendAvailable = true }) {
                           fontFamily:
                             '"Roboto Mono", "Consolas", "Monaco", monospace',
                         }}
-                      >
-                        {logs.join('\n')}
-                      </pre>
+                        dangerouslySetInnerHTML={{
+                          __html: sanitizeHTML(logs.join('\n')),
+                        }}
+                      />
                     )}
                   </Box>
                 </Paper>

--- a/webui/src/utils/__tests__/sanitizeHTML.test.js
+++ b/webui/src/utils/__tests__/sanitizeHTML.test.js
@@ -1,0 +1,13 @@
+// file: webui/src/utils/__tests__/sanitizeHTML.test.js
+import { describe, expect, test } from 'vitest';
+import { sanitizeHTML } from '../sanitizeHTML.js';
+
+describe('sanitizeHTML utility', () => {
+  test('removes dangerous HTML', () => {
+    const dirty = '<img src=x onerror=alert(1)><p>ok</p>';
+    const clean = sanitizeHTML(dirty);
+    expect(clean).not.toMatch(/onerror/);
+    expect(clean).toContain('<img src="x">');
+    expect(clean).toContain('<p>ok</p>');
+  });
+});

--- a/webui/src/utils/sanitizeHTML.js
+++ b/webui/src/utils/sanitizeHTML.js
@@ -1,0 +1,10 @@
+// file: webui/src/utils/sanitizeHTML.js
+
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize HTML to prevent XSS.
+ * @param {string} input - Untrusted HTML string.
+ * @returns {string} Sanitized HTML safe for rendering.
+ */
+export const sanitizeHTML = input => DOMPurify.sanitize(input);


### PR DESCRIPTION
## Summary
- add middleware for standard security headers
- sanitize HTML with DOMPurify in the React UI
- include DOMPurify dependency and tests for sanitizer
- update README with a brief security section

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852e8a59b4483219dd3325d2311b03c