### PR TITLE
Add directory chooser with autocomplete

### DIFF
--- a/webui/src/__tests__/Dashboard.test.jsx
+++ b/webui/src/__tests__/Dashboard.test.jsx
@@ -75,7 +75,7 @@ describe('Dashboard component', () => {
     });
 
     // Click on the Language select to open it and select French
-    const languageSelect = screen.getAllByRole('combobox')[0]; // First combobox is language
+    const languageSelect = screen.getAllByRole('combobox')[1];
     await act(async () => {
       fireEvent.mouseDown(languageSelect);
     });

--- a/webui/src/components/DirectoryChooser.jsx
+++ b/webui/src/components/DirectoryChooser.jsx
@@ -1,0 +1,115 @@
+// file: webui/src/components/DirectoryChooser.jsx
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  CircularProgress,
+} from '@mui/material';
+import {
+  Folder as FolderIcon,
+  ArrowBack as BackIcon,
+} from '@mui/icons-material';
+import { useEffect, useState } from 'react';
+import { apiService } from '../services/api.js';
+
+/**
+ * DirectoryChooser provides a simple dialog to browse and select
+ * directories on the server's file system using the library browse API.
+ *
+ * @param {boolean} open - Whether the dialog is open
+ * @param {function} onClose - Callback when the dialog closes
+ * @param {function} onSelect - Callback with the chosen directory path
+ */
+export default function DirectoryChooser({ open, onClose, onSelect }) {
+  const [currentPath, setCurrentPath] = useState('/');
+  const [dirs, setDirs] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setCurrentPath('/');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const resp = await apiService.get(
+          `/api/library/browse?path=${encodeURIComponent(currentPath)}`
+        );
+        if (resp.ok) {
+          const data = await resp.json();
+          const directories =
+            data.items
+              ?.filter(item => item.isDirectory)
+              .map(item => item.path) || [];
+          setDirs(directories);
+        } else {
+          setDirs([]);
+        }
+      } catch (err) {
+        console.error('Failed to browse directory:', err);
+        setDirs([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [currentPath, open]);
+
+  const goUp = () => {
+    if (currentPath === '/' || currentPath === '') return;
+    const parts = currentPath.split('/').filter(Boolean);
+    parts.pop();
+    setCurrentPath('/' + parts.join('/'));
+  };
+
+  const handleSelect = path => {
+    onSelect(path);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Select Directory</DialogTitle>
+      <DialogContent dividers>
+        {loading && <CircularProgress size={20} sx={{ mb: 2 }} />}
+        <List>
+          {currentPath !== '/' && (
+            <ListItemButton onClick={goUp}>
+              <ListItemIcon>
+                <BackIcon />
+              </ListItemIcon>
+              <ListItemText primary=".." />
+            </ListItemButton>
+          )}
+          {dirs.map(dir => (
+            <ListItemButton
+              key={dir}
+              onClick={() => setCurrentPath(dir)}
+              onDoubleClick={() => handleSelect(dir)}
+            >
+              <ListItemIcon>
+                <FolderIcon />
+              </ListItemIcon>
+              <ListItemText primary={dir.split('/').pop()} />
+            </ListItemButton>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => handleSelect(currentPath)} variant="contained">
+          Select
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- improve Dashboard directory input with new Autocomplete
- open a DirectoryChooser dialog when clicking the folder icon
- fetch directory suggestions from `/api/library/browse`
- update Dashboard test for new combobox order

## Testing
- `npm run lint`
- `npm test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685350c382388321b6044e63d3caed18