### PR TITLE
Handle base URL for React router

### DIFF
--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -54,7 +54,7 @@ import {
 import './App.css';
 import OfflineInfo from './OfflineInfo.jsx';
 import LoadingComponent from './components/LoadingComponent.jsx';
-import { apiService } from './services/api.js';
+import { apiService, getBasePath } from './services/api.js';
 
 // Lazy load components for better performance
 const Dashboard = lazy(() => import('./Dashboard.jsx'));
@@ -287,6 +287,7 @@ const createAppTheme = (isDarkMode = true, kidMode = false) =>
   });
 
 function App() {
+  const basePath = getBasePath();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [status, setStatus] = useState('');
@@ -1024,7 +1025,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router>
+      <Router basename={basePath}>
         <AppContent />
       </Router>
     </ThemeProvider>

--- a/webui/src/__tests__/App.test.jsx
+++ b/webui/src/__tests__/App.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../services/api.js', () => ({
     put: vi.fn(),
     delete: vi.fn(),
   },
+  getBasePath: () => '',
 }));
 
 describe('App component', () => {

--- a/webui/src/__tests__/Dashboard.test.jsx
+++ b/webui/src/__tests__/Dashboard.test.jsx
@@ -16,6 +16,7 @@ vi.mock('../services/api.js', () => ({
     get: vi.fn(),
     post: vi.fn(),
   },
+  getBasePath: () => '',
 }));
 
 describe('Dashboard component', () => {

--- a/webui/src/__tests__/Settings.test.jsx
+++ b/webui/src/__tests__/Settings.test.jsx
@@ -16,6 +16,7 @@ vi.mock('../services/api.js', () => ({
     get: vi.fn(),
     post: vi.fn(),
   },
+  getBasePath: () => '',
 }));
 
 describe('Settings component', () => {

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -6,7 +6,35 @@
 /**
  * API service configuration
  */
-const API_BASE_URL = import.meta?.env?.VITE_API_URL || window.location.origin;
+/**
+ * Determine the base path for API requests by inspecting the current URL.
+ * If the first path segment isn't one of the known application routes, it is
+ * treated as an installation prefix specified via `base_url` on the server.
+ *
+ * @returns {string} Base path beginning with a slash or an empty string.
+ */
+export function getBasePath() {
+  const known = new Set([
+    '',
+    'dashboard',
+    'library',
+    'wanted',
+    'history',
+    'settings',
+    'system',
+    'tools',
+    'offline-info',
+    'setup',
+  ]);
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  if (parts.length > 0 && !known.has(parts[0])) {
+    return `/${parts[0]}`;
+  }
+  return '';
+}
+
+const API_BASE_URL =
+  import.meta?.env?.VITE_API_URL || `${window.location.origin}${getBasePath()}`;
 
 /**
  * Enhanced fetch wrapper with error handling and logging


### PR DESCRIPTION
## Summary
- determine base path from current location for API service
- use new base path for API calls
- set BrowserRouter basename using the base path
- update JS tests to provide `getBasePath`

## Testing
- `npm test --prefix webui`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685365c5b32083218ad05c9f5afee733