### PR TITLE
Fix SPA refresh path retention

### DIFF
--- a/webui/src/services/__tests__/api.test.js
+++ b/webui/src/services/__tests__/api.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, test, afterEach } from 'vitest';
+import { getBasePath } from '../api.js';
+
+function setPath(path) {
+  delete window.location;
+  window.location = new URL(`http://localhost${path}`);
+}
+
+describe('getBasePath', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    // Restore original location after each test
+    window.location = originalLocation;
+  });
+
+  test('returns empty string for known routes', () => {
+    setPath('/library');
+    expect(getBasePath()).toBe('');
+    setPath('/details');
+    expect(getBasePath()).toBe('');
+  });
+
+  test('returns prefix for unknown first segment', () => {
+    setPath('/prefix/dashboard');
+    expect(getBasePath()).toBe('/prefix');
+  });
+});

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -23,6 +23,7 @@ export function getBasePath() {
     'settings',
     'system',
     'tools',
+    'details',
     'offline-info',
     'setup',
   ]);


### PR DESCRIPTION
## Summary
- ensure `getBasePath` recognises details route
- test base path detection logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685369c5527c8321b38489cf4e05a53b