### PR TITLE
Handle empty sensitive config gracefully

### DIFF
--- a/webui/src/utils/__tests__/configSanitizer.test.js
+++ b/webui/src/utils/__tests__/configSanitizer.test.js
@@ -76,8 +76,8 @@ describe('configSanitizer utility', () => {
       const sanitized = sanitizeConfig(config);
 
       expect(sanitized.password).toBe('****');
-      expect(sanitized.api_key).toBe('****');
-      expect(sanitized.token).toBe('****');
+      expect(sanitized.api_key).toBe('');
+      expect(sanitized.token).toBe('');
     });
 
     test('handles null and undefined inputs', () => {

--- a/webui/src/utils/configSanitizer.js
+++ b/webui/src/utils/configSanitizer.js
@@ -24,7 +24,7 @@ export const sanitizeConfig = (obj, showSensitive = false) => {
         const last = val.slice(-4);
         return `****${last}`;
       }
-      if (val === null || typeof val === 'undefined') return '';
+      if (val == null) return '';
       return '****';
     }
     return val;

--- a/webui/src/utils/configSanitizer.js
+++ b/webui/src/utils/configSanitizer.js
@@ -21,6 +21,7 @@ export const sanitizeConfig = (obj, showSensitive = false) => {
     if (sensitive.some(s => lower.includes(s))) {
       if (typeof val === 'string') {
         if (!val) return '';
+        if (val.length <= 4) return '****';
         const last = val.slice(-4);
         return `****${last}`;
       }

--- a/webui/src/utils/configSanitizer.js
+++ b/webui/src/utils/configSanitizer.js
@@ -20,9 +20,11 @@ export const sanitizeConfig = (obj, showSensitive = false) => {
     const lower = key.toLowerCase();
     if (sensitive.some(s => lower.includes(s))) {
       if (typeof val === 'string') {
+        if (!val) return '';
         const last = val.slice(-4);
         return `****${last}`;
       }
+      if (val === null || typeof val === 'undefined') return '';
       return '****';
     }
     return val;


### PR DESCRIPTION
## Summary
- return blank string when sensitive fields are undefined
- update config sanitizer tests

## Testing
- `npm --prefix webui test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68537a9e89e4832196ec00e93e3797cc