### PR TITLE
Integrate tag editing in library

### DIFF
--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -204,6 +204,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	// New API endpoints for modern UI
 	mux.Handle(prefix+"/api/providers", authMiddleware(db, "basic", providersHandler()))
 	mux.Handle(prefix+"/api/library/browse", authMiddleware(db, "basic", libraryBrowseHandler()))
+	mux.Handle(prefix+"/api/library/tags", authMiddleware(db, "basic", libraryTagsHandler(db)))
 	mux.Handle(prefix+"/api/users/", authMiddleware(db, "admin", userRouter(db)))
 	mux.Handle(prefix+"/api/tags", authMiddleware(db, "admin", tagsHandler(db)))
 	mux.Handle(prefix+"/api/tags/", authMiddleware(db, "admin", tagItemHandler(db)))

--- a/webui/src/MediaLibrary.jsx
+++ b/webui/src/MediaLibrary.jsx
@@ -43,6 +43,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
+import TagSelector from './components/TagSelector.jsx';
 import { useNavigate } from 'react-router-dom';
 
 /**
@@ -545,6 +546,11 @@ export default function MediaLibrary({ backendAvailable = true }) {
                           {item?.size &&
                             `${(item.size / 1024 / 1024 / 1024).toFixed(1)} GB`}
                         </Typography>
+                      )}
+                      {item?.isVideo && (
+                        <Box mt={1}>
+                          <TagSelector path={item.path} />
+                        </Box>
                       )}
                     </Box>
 

--- a/webui/src/__tests__/TagSelector.test.jsx
+++ b/webui/src/__tests__/TagSelector.test.jsx
@@ -1,0 +1,44 @@
+// file: webui/src/__tests__/TagSelector.test.jsx
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import TagSelector from '../components/TagSelector.jsx';
+
+describe('TagSelector component', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  test('loads tags for a media path', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+    render(<TagSelector path="/a.mkv" />);
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith('/api/library/tags?path=%2Fa.mkv')
+    );
+  });
+
+  test('assigns a tag when checked', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: '1', name: 'tag' }]),
+      })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
+
+    render(<TagSelector path="/b.mkv" />);
+    fireEvent.click(screen.getByRole('button', { name: /manage tags/i }));
+    await screen.findByText('tag');
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/library/tags',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+  });
+});

--- a/webui/src/components/TagSelector.jsx
+++ b/webui/src/components/TagSelector.jsx
@@ -1,0 +1,117 @@
+// file: webui/src/components/TagSelector.jsx
+import {
+  Box,
+  Button,
+  Chip,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * TagSelector allows assigning tags to a media item identified by path.
+ *
+ * @param {Object} props - Component props
+ * @param {string} props.path - Media file path
+ */
+export default function TagSelector({ path }) {
+  const [allTags, setAllTags] = useState([]);
+  const [itemTags, setItemTags] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  const loadTags = useCallback(async () => {
+    if (!path) return;
+    try {
+      const res = await fetch(
+        `/api/library/tags?path=${encodeURIComponent(path)}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setItemTags(Array.isArray(data) ? data : []);
+      }
+    } catch {
+      // ignore
+    }
+  }, [path]);
+
+  const loadAll = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tags');
+      if (res.ok) {
+        const data = await res.json();
+        setAllTags(Array.isArray(data) ? data : []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTags();
+  }, [loadTags]);
+
+  const toggleTag = async (tagId, checked) => {
+    try {
+      await fetch('/api/library/tags', {
+        method: checked ? 'POST' : 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, tag_id: tagId }),
+      });
+      loadTags();
+    } catch {
+      // ignore
+    }
+  };
+
+  const assigned = id => itemTags.some(t => t.id === String(id));
+
+  return (
+    <Box>
+      <Box display="flex" flexWrap="wrap" gap={1} mb={1}>
+        {itemTags.map(t => (
+          <Chip key={t.id} label={t.name} size="small" />
+        ))}
+        <Button
+          size="small"
+          onClick={() => {
+            setOpen(true);
+            loadAll();
+          }}
+        >
+          Manage Tags
+        </Button>
+      </Box>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Manage Tags</DialogTitle>
+        <DialogContent>
+          <List>
+            {allTags.map(tag => (
+              <ListItem key={tag.id} disableGutters>
+                <Checkbox
+                  edge="start"
+                  checked={assigned(tag.id)}
+                  onChange={e => toggleTag(tag.id, e.target.checked)}
+                />
+                <ListItemText primary={tag.name} />
+              </ListItem>
+            ))}
+          </List>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/webui/src/components/TagSelector.jsx
+++ b/webui/src/components/TagSelector.jsx
@@ -35,8 +35,8 @@ export default function TagSelector({ path }) {
         const data = await res.json();
         setItemTags(Array.isArray(data) ? data : []);
       }
-    } catch {
-      // ignore
+    } catch (error) {
+      console.error('Failed to load tags for path:', path, error);
     }
   }, [path]);
 

--- a/webui/src/components/TagSelector.jsx
+++ b/webui/src/components/TagSelector.jsx
@@ -47,8 +47,8 @@ export default function TagSelector({ path }) {
         const data = await res.json();
         setAllTags(Array.isArray(data) ? data : []);
       }
-    } catch {
-      // ignore
+    } catch (error) {
+      console.error('Failed to fetch all tags:', error);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- manage tags for library items via new `libraryTagsHandler`
- persist media records for tag assignments
- expose `/api/library/tags` endpoint
- add `TagSelector` component for assigning tags by path
- show tags in Media Library list view
- test tag selector behaviour

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68543b5edf0c83218169f83dd9b79503