### PR TITLE
Add batch subtitle synchronization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
   BSplayer, GreekSubs, Podnapisi, Subscene, TVSubtitles, Titlovi, LegendasDivx
   and many more.
 - Batch translate multiple files concurrently.
+- Mass synchronize subtitles across entire libraries.
 - Monitor directories and automatically download subtitles.
 - Scan existing libraries and fetch missing or upgraded subtitles.
 - Download individual subtitles through the web API at `/api/download`.
@@ -245,6 +246,8 @@ subtitle-manager transcribe [media] [output] [lang]
 subtitle-manager fetch [media] [lang] [output]
 subtitle-manager search [media] [lang]
 subtitle-manager batch [lang] [files...]
+subtitle-manager syncbatch -config file.json
+  # syncbatch expects a JSON file describing media and subtitle pairs
 subtitle-manager scan [directory] [lang] [-u]
 subtitle-manager autoscan [directory] [lang] [-i duration] [-s cron] [-u]
 subtitle-manager scanlib [directory]
@@ -301,6 +304,7 @@ The web server exposes a comprehensive REST API for all subtitle operations:
 
 - `POST /api/convert` - Convert uploaded subtitle files to SRT format
 - `POST /api/translate` - Translate uploaded subtitle files
+- `POST /api/sync/batch` - Synchronize multiple subtitle files in one request
 - `POST /api/extract` - Extract subtitles from media files using ffmpeg
 - `POST /api/download` - Download subtitles for specific media files
 

--- a/cmd/syncbatch.go
+++ b/cmd/syncbatch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"

--- a/cmd/syncbatch.go
+++ b/cmd/syncbatch.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/syncer"
+)
+
+var syncBatchConfig string
+
+// syncBatchCmd synchronizes multiple subtitle files using a JSON configuration.
+// The configuration file should contain an array of objects with media, subtitle
+// and output fields along with optional sync options.
+var syncBatchCmd = &cobra.Command{
+	Use:   "syncbatch",
+	Short: "Synchronize multiple subtitles via configuration file",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("syncbatch")
+		f, err := os.Open(syncBatchConfig)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		var req struct {
+			Items   []syncer.BatchItem `json:"items"`
+			Options syncer.Options     `json:"options"`
+		}
+		if err := json.NewDecoder(f).Decode(&req); err != nil {
+			return err
+		}
+		// Fill API keys from config when not provided
+		if req.Options.WhisperKey == "" {
+			req.Options.WhisperKey = viper.GetString("openai_api_key")
+		}
+		if req.Options.GoogleAPIKey == "" {
+			req.Options.GoogleAPIKey = viper.GetString("google_api_key")
+		}
+		if req.Options.GPTAPIKey == "" {
+			req.Options.GPTAPIKey = viper.GetString("openai_api_key")
+		}
+		if req.Options.GRPCAddr == "" {
+			req.Options.GRPCAddr = viper.GetString("grpc_addr")
+		}
+		errs := syncer.SyncBatch(req.Items, req.Options)
+		for i, it := range req.Items {
+			if err := errs[i]; err != nil {
+				logger.Warnf("sync %s: %v", it.Subtitle, err)
+			} else {
+				logger.Infof("synchronized %s -> %s", it.Subtitle, it.Output)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	syncBatchCmd.Flags().StringVarP(&syncBatchConfig, "config", "c", "", "JSON configuration file")
+	syncBatchCmd.MarkFlagRequired("config")
+	rootCmd.AddCommand(syncBatchCmd)
+}

--- a/cmd/syncbatch.go
+++ b/cmd/syncbatch.go
@@ -47,12 +47,17 @@ var syncBatchCmd = &cobra.Command{
 			req.Options.GRPCAddr = viper.GetString("grpc_addr")
 		}
 		errs := syncer.SyncBatch(req.Items, req.Options)
+		var hasErrors bool
 		for i, it := range req.Items {
 			if err := errs[i]; err != nil {
 				logger.Warnf("sync %s: %v", it.Subtitle, err)
+				hasErrors = true
 			} else {
 				logger.Infof("synchronized %s -> %s", it.Subtitle, it.Output)
 			}
+		}
+		if hasErrors {
+			return fmt.Errorf("some items failed during synchronization")
 		}
 		return nil
 	},

--- a/pkg/syncer/batch.go
+++ b/pkg/syncer/batch.go
@@ -1,0 +1,46 @@
+package syncer
+
+import (
+	"os"
+
+	"github.com/asticode/go-astisub"
+)
+
+// BatchItem specifies a single subtitle synchronization request.
+// Media is the video file path, Subtitle is the subtitle to adjust and
+// Output is the destination file written in SRT format. When Output is
+// empty the Subtitle path is overwritten.
+type BatchItem struct {
+	Media    string
+	Subtitle string
+	Output   string
+}
+
+// SyncBatch synchronizes multiple subtitle files in sequence using the given
+// options. The returned slice contains an error entry for each item processed.
+// A nil value indicates the file was synchronized successfully.
+func SyncBatch(items []BatchItem, opts Options) []error {
+	errs := make([]error, len(items))
+	for i, it := range items {
+		outPath := it.Output
+		if outPath == "" {
+			outPath = it.Subtitle
+		}
+		result, err := Sync(it.Media, it.Subtitle, opts)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+		sub := astisub.Subtitles{Items: result}
+		f, ferr := os.Create(outPath)
+		if ferr != nil {
+			errs[i] = ferr
+			continue
+		}
+		if err := sub.WriteToSRT(f); err != nil {
+			errs[i] = err
+		}
+		f.Close()
+	}
+	return errs
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -201,6 +201,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/webhooks/radarr", webhooks.RadarrHandler())
 	mux.Handle(prefix+"/api/webhooks/custom", webhooks.CustomHandler())
 	mux.Handle(prefix+"/api/translate", authMiddleware(db, "basic", translateHandler()))
+	mux.Handle(prefix+"/api/sync/batch", authMiddleware(db, "basic", syncBatchHandler()))
 	// New API endpoints for modern UI
 	mux.Handle(prefix+"/api/providers", authMiddleware(db, "basic", providersHandler()))
 	mux.Handle(prefix+"/api/library/browse", authMiddleware(db, "basic", libraryBrowseHandler()))

--- a/pkg/webserver/syncbatch.go
+++ b/pkg/webserver/syncbatch.go
@@ -1,0 +1,58 @@
+// file: pkg/webserver/syncbatch.go
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jdfalk/subtitle-manager/pkg/syncer"
+)
+
+// syncBatchHandler processes a batch of subtitle synchronization requests.
+// Each request contains the media path, subtitle path and optional output path.
+// Synchronization options mirror those of the single sync operation.
+func syncBatchHandler() http.Handler {
+	type item struct {
+		Media    string `json:"media"`
+		Subtitle string `json:"subtitle"`
+		Output   string `json:"output"`
+	}
+	type req struct {
+		Items   []item         `json:"items"`
+		Options syncer.Options `json:"options"`
+	}
+	type result struct {
+		Output string `json:"output"`
+		Error  string `json:"error,omitempty"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var q req
+		if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		batch := make([]syncer.BatchItem, len(q.Items))
+		for i, it := range q.Items {
+			batch[i] = syncer.BatchItem{Media: it.Media, Subtitle: it.Subtitle, Output: it.Output}
+		}
+		errs := syncer.SyncBatch(batch, q.Options)
+		resp := struct {
+			Results []result `json:"results"`
+		}{Results: make([]result, len(batch))}
+		for i := range batch {
+			resp.Results[i].Output = batch[i].Output
+			if resp.Results[i].Output == "" {
+				resp.Results[i].Output = batch[i].Subtitle
+			}
+			if errs[i] != nil {
+				resp.Results[i].Error = errs[i].Error()
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+}


### PR DESCRIPTION
## Summary
- allow mass subtitle sync via new `syncbatch` CLI command
- implement `SyncBatch` for bulk processing
- expose `/api/sync/batch` endpoint for the web UI
- document new command and endpoint
- test new sync batch logic

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68543d4616008321b8f8d0746a9ee104