### PR TITLE
Fix flaky backup creation test

### DIFF
--- a/issue_updates.json
+++ b/issue_updates.json
@@ -133,6 +133,12 @@
       "labels": ["codex"],
       "state": "closed",
       "guid": "update-issue-921-2025-06-20"
+    },
+    {
+      "number": 922,
+      "labels": ["codex"],
+      "body": "[nitpick] Consider expanding the time threshold used to validate the backup's creation time, as the current 1-second tolerance may lead to flaky tests on slower systems.\n```suggestion\n        if time.Since(b.CreatedAt) > time.Second*3 {\n```\n\n_Originally posted by @Copilot in https://github.com/jdfalk/subtitle-manager/pull/916#discussion_r2157570601_\n\n---\n**Codex update**: Increased allowed backup creation time to 3 seconds in tests. This gives slower systems enough time and prevents flakiness.",
+      "guid": "update-issue-922-2025-06-20"
     }
   ],
   "comment": [
@@ -140,6 +146,11 @@
       "number": 921,
       "body": "Implemented t.Run subtests in pkg/webhooks to ensure each case runs in isolation before closing.",
       "guid": "comment-921-webhook-subtests-2025-06-20"
+    },
+    {
+      "number": 922,
+      "body": "Applying fix to backup creation tests by allowing a 3-second threshold. This reduces flakiness on slower machines.",
+      "guid": "comment-922-backup-timeout-2025-06-20"
     }
   ],
   "close": [],

--- a/pkg/backups/backups_test.go
+++ b/pkg/backups/backups_test.go
@@ -24,7 +24,8 @@ func TestCreate(t *testing.T) {
 	if b.Name == "" {
 		t.Fatalf("expected backup name")
 	}
-	if time.Since(b.CreatedAt) > time.Second {
+	// allow up to 3 seconds to avoid flakes on slow systems
+	if time.Since(b.CreatedAt) > time.Second*3 {
 		t.Fatalf("creation time too old: %v", b.CreatedAt)
 	}
 	list := List()


### PR DESCRIPTION
## Summary
- avoid test flakes by allowing up to three seconds before failing backup creation time check
- update GitHub issue #922 with `codex` label and comment describing the fix

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685491fe7b548321823dc83107c670f9