### PR TITLE
Fix decoder checks in tests and label issue

### DIFF
--- a/issue_updates.json
+++ b/issue_updates.json
@@ -129,6 +129,11 @@
   ],
   "update": [
     {
+      "number": 920,
+      "labels": ["codex"],
+      "guid": "update-issue-920-2025-06-20"
+    },
+    {
       "number": 921,
       "labels": ["codex"],
       "state": "closed",
@@ -142,6 +147,11 @@
     }
   ],
   "comment": [
+    {
+      "number": 920,
+      "body": "I'll update tests to fail fast when JSON decoding fails, covering webhooks, notifications, captcha, and web server handlers.",
+      "guid": "comment-920-json-decode-tests-2025-06-20"
+    },
     {
       "number": 921,
       "body": "Implemented t.Run subtests in pkg/webhooks to ensure each case runs in isolation before closing.",

--- a/pkg/captcha/client_test.go
+++ b/pkg/captcha/client_test.go
@@ -14,7 +14,9 @@ func TestSolveImage(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/createTask", func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any
-		json.NewDecoder(r.Body).Decode(&req)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 		json.NewEncoder(w).Encode(map[string]any{"errorId": 0, "taskId": 1})
 	})
 	handler.HandleFunc("/getTaskResult", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/notifications/notifications_test.go
+++ b/pkg/notifications/notifications_test.go
@@ -14,7 +14,9 @@ func TestDiscordNotifier(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var m map[string]string
-		json.NewDecoder(r.Body).Decode(&m)
+		if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 		got = m["content"]
 	}))
 	defer srv.Close()
@@ -33,7 +35,9 @@ func TestTelegramNotifier(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var m map[string]string
-		json.NewDecoder(r.Body).Decode(&m)
+		if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 		got = m["text"]
 	}))
 	defer srv.Close()

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -20,7 +20,9 @@ func TestDispatcherSend(t *testing.T) {
 	}
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		json.NewDecoder(r.Body).Decode(&got)
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 	}))
 	defer srv.Close()
 

--- a/pkg/webserver/database_test.go
+++ b/pkg/webserver/database_test.go
@@ -49,7 +49,9 @@ func TestDatabaseHandlers(t *testing.T) {
 		t.Fatalf("info: %v %d", err, r1.StatusCode)
 	}
 	var info struct{ Type string }
-	json.NewDecoder(r1.Body).Decode(&info)
+	if err := json.NewDecoder(r1.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	r1.Body.Close()
 	if info.Type != "sqlite" {
 		t.Fatalf("unexpected type %s", info.Type)

--- a/pkg/webserver/oauth_management_test.go
+++ b/pkg/webserver/oauth_management_test.go
@@ -46,7 +46,9 @@ func TestGitHubOAuthGenerate(t *testing.T) {
 		t.Fatalf("status %d", resp.StatusCode)
 	}
 	var creds OAuthCredentials
-	json.NewDecoder(resp.Body).Decode(&creds)
+	if err := json.NewDecoder(resp.Body).Decode(&creds); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp.Body.Close()
 
 	if !strings.HasPrefix(creds.ClientID, "gh_") || !strings.HasPrefix(creds.ClientSecret, "ghs_") {
@@ -89,7 +91,9 @@ func TestGitHubOAuthRegenerate(t *testing.T) {
 	testutil.MustEqual(t, "status", http.StatusOK, resp.StatusCode)
 
 	var creds OAuthCredentials
-	_ = json.NewDecoder(resp.Body).Decode(&creds)
+	if err := json.NewDecoder(resp.Body).Decode(&creds); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	testutil.MustEqual(t, "client id", "gh_id", creds.ClientID)
 	testutil.MustEqual(t, "redirect", "http://cb", creds.RedirectURL)
 	if !strings.HasPrefix(creds.ClientSecret, "ghs_") {

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -244,7 +244,9 @@ func TestScanHandlers(t *testing.T) {
 			Running   bool `json:"running"`
 			Completed int  `json:"completed"`
 		}
-		json.NewDecoder(r2.Body).Decode(&s)
+		if err := json.NewDecoder(r2.Body).Decode(&s); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 		r2.Body.Close()
 		if !s.Running {
 			if s.Completed != 1 {
@@ -301,7 +303,7 @@ func TestExtract(t *testing.T) {
 	defer resp.Body.Close()
 	var items []any
 	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
-		t.Fatalf("decode: %v", err)
+		t.Fatalf("failed to decode request body: %v", err)
 	}
 	if len(items) == 0 {
 		t.Fatalf("no items returned")
@@ -446,7 +448,9 @@ func TestSetup(t *testing.T) {
 	var st struct {
 		Needed bool `json:"needed"`
 	}
-	json.NewDecoder(resp.Body).Decode(&st)
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp.Body.Close()
 	if !st.Needed {
 		t.Fatalf("expected setup needed")
@@ -466,7 +470,9 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status2: %v", err)
 	}
-	json.NewDecoder(resp3.Body).Decode(&st)
+	if err := json.NewDecoder(resp3.Body).Decode(&st); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp3.Body.Close()
 	if st.Needed {
 		t.Fatalf("setup still needed")
@@ -508,7 +514,9 @@ func TestHistory(t *testing.T) {
 		Translations []database.SubtitleRecord `json:"translations"`
 		Downloads    []database.DownloadRecord `json:"downloads"`
 	}
-	json.NewDecoder(resp.Body).Decode(&out)
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp.Body.Close()
 	if len(out.Translations) != 1 || len(out.Downloads) != 1 {
 		t.Fatalf("unexpected counts %d %d", len(out.Translations), len(out.Downloads))
@@ -520,7 +528,9 @@ func TestHistory(t *testing.T) {
 		Translations []database.SubtitleRecord `json:"translations"`
 		Downloads    []database.DownloadRecord `json:"downloads"`
 	}
-	json.NewDecoder(resp2.Body).Decode(&out2)
+	if err := json.NewDecoder(resp2.Body).Decode(&out2); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp2.Body.Close()
 	if len(out2.Translations) != 0 || len(out2.Downloads) != 0 {
 		t.Fatalf("filter failed")
@@ -576,7 +586,9 @@ func TestDownload(t *testing.T) {
 	var res struct {
 		File string `json:"file"`
 	}
-	json.NewDecoder(resp.Body).Decode(&res)
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	resp.Body.Close()
 
 	out := strings.TrimSuffix(vid, filepath.Ext(vid)) + ".en.srt"
@@ -777,7 +789,7 @@ func TestProvidersDefault(t *testing.T) {
 	}
 	var out []ProviderInfo
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatalf("decode: %v", err)
+		t.Fatalf("failed to decode request body: %v", err)
 	}
 	resp.Body.Close()
 	if len(out) != 52 {

--- a/pkg/webserver/system_test.go
+++ b/pkg/webserver/system_test.go
@@ -43,7 +43,9 @@ func TestSystemHandlers(t *testing.T) {
 		t.Fatalf("logs: %v %d", err, r.StatusCode)
 	}
 	var lines []string
-	json.NewDecoder(r.Body).Decode(&lines)
+	if err := json.NewDecoder(r.Body).Decode(&lines); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	r.Body.Close()
 	if len(lines) == 0 {
 		t.Fatalf("no logs returned")
@@ -58,7 +60,9 @@ func TestSystemHandlers(t *testing.T) {
 	var info struct {
 		GoVersion string `json:"go_version"`
 	}
-	json.NewDecoder(r2.Body).Decode(&info)
+	if err := json.NewDecoder(r2.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	r2.Body.Close()
 	if info.GoVersion == "" {
 		t.Fatalf("no info")
@@ -71,7 +75,9 @@ func TestSystemHandlers(t *testing.T) {
 		t.Fatalf("announcements: %v %d", err, r3.StatusCode)
 	}
 	var ann []map[string]any
-	json.NewDecoder(r3.Body).Decode(&ann)
+	if err := json.NewDecoder(r3.Body).Decode(&ann); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
 	r3.Body.Close()
 	if len(ann) == 0 {
 		t.Fatalf("no announcements")


### PR DESCRIPTION
## Summary
- label #920 with codex and add comment about fixing decode errors
- enforce decode error checks in captcha, notifications, webhooks, and webserver tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854930ebca083219b358e2f1b3acbb3