### PR TITLE
Fix 914: close temp files with defer

### DIFF
--- a/issue_updates.json
+++ b/issue_updates.json
@@ -144,6 +144,11 @@
       "labels": ["codex"],
       "body": "[nitpick] Consider expanding the time threshold used to validate the backup's creation time, as the current 1-second tolerance may lead to flaky tests on slower systems.\n```suggestion\n        if time.Since(b.CreatedAt) > time.Second*3 {\n```\n\n_Originally posted by @Copilot in https://github.com/jdfalk/subtitle-manager/pull/916#discussion_r2157570601_\n\n---\n**Codex update**: Increased allowed backup creation time to 3 seconds in tests. This gives slower systems enough time and prevents flakiness.",
       "guid": "update-issue-922-2025-06-20"
+    },
+    {
+      "number": 914,
+      "labels": ["codex"],
+      "guid": "update-issue-914-2025-06-20"
     }
   ],
   "comment": [
@@ -161,6 +166,11 @@
       "number": 922,
       "body": "Applying fix to backup creation tests by allowing a 3-second threshold. This reduces flakiness on slower machines.",
       "guid": "comment-922-backup-timeout-2025-06-20"
+    },
+    {
+      "number": 914,
+      "body": "Working on ensuring temp files are closed with defer across all handlers.",
+      "guid": "comment-914-temp-files-defer-2025-06-20"
     }
   ],
   "close": [],

--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -28,6 +28,7 @@ func ExtractTrack(mediaPath string, track int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = tmp.Close() }()
 	tmp.Close() // Close immediately so ffmpeg can write to it
 
 	mapArg := fmt.Sprintf("0:a:%d", track)
@@ -58,6 +59,7 @@ func ExtractTrackWithDuration(mediaPath string, track int, offset, duration time
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = tmp.Close() }()
 	tmp.Close()
 
 	mapArg := fmt.Sprintf("0:a:%d", track)

--- a/pkg/providers/opensubtitles/hash_test.go
+++ b/pkg/providers/opensubtitles/hash_test.go
@@ -10,6 +10,7 @@ func TestFileHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 	data := make([]byte, 200000)
 	for i := range data {
 		data[i] = byte(i % 255)
@@ -17,7 +18,6 @@ func TestFileHash(t *testing.T) {
 	if _, err := f.Write(data); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
 	defer os.Remove(f.Name())
 
 	h, size, err := realFileHash(f.Name())

--- a/pkg/subtitles/extract.go
+++ b/pkg/subtitles/extract.go
@@ -32,6 +32,7 @@ func ExtractTrack(mediaPath string, track int) ([]*astisub.Item, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = tmp.Close() }()
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -141,11 +141,11 @@ func TestSyncWithAudioTrack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp: %v", err)
 	}
+	defer f.Close()
 	subs := astisub.Subtitles{Items: base.Items}
 	if err := subs.WriteToSRT(f); err != nil {
 		t.Fatalf("write SRT: %v", err)
 	}
-	f.Close()
 
 	// Create mock transcriber
 	mockTranscriber := mocks.NewTranscriber(t)
@@ -192,11 +192,11 @@ func TestSyncWithMultipleSubtitleTracks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp: %v", err)
 	}
+	defer f.Close()
 	subs := astisub.Subtitles{Items: base.Items}
 	if err := subs.WriteToSRT(f); err != nil {
 		t.Fatalf("write SRT: %v", err)
 	}
-	f.Close()
 
 	// Create mock extractor
 	mockExtractor := mocks.NewSubtitleExtractor(t)
@@ -256,11 +256,11 @@ func TestSyncWithTranslation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp: %v", err)
 	}
+	defer f.Close()
 	subs := astisub.Subtitles{Items: items}
 	if err := subs.WriteToSRT(f); err != nil {
 		t.Fatalf("write SRT: %v", err)
 	}
-	f.Close()
 
 	// Mock successful sync without actual translation service
 	// In a real test, you'd mock the translator.Translate function
@@ -364,11 +364,11 @@ func TestSyncWeighted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp: %v", err)
 	}
+	defer f.Close()
 	subs := astisub.Subtitles{Items: shifted}
 	if err := subs.WriteToSRT(f); err != nil {
 		t.Fatalf("write SRT: %v", err)
 	}
-	f.Close()
 
 	// Create mocks
 	mockTranscriber := mocks.NewTranscriber(t)

--- a/pkg/webserver/convert.go
+++ b/pkg/webserver/convert.go
@@ -33,12 +33,13 @@ func convertHandler() http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		defer func() { _ = tmp.Close() }()
 		defer os.Remove(tmp.Name())
 		if _, err := io.Copy(tmp, f); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		tmp.Close()
+		_ = tmp.Close()
 		data, err := subtitles.ConvertToSRT(tmp.Name())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/webserver/convert.go
+++ b/pkg/webserver/convert.go
@@ -39,7 +39,6 @@ func convertHandler() http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_ = tmp.Close()
 		data, err := subtitles.ConvertToSRT(tmp.Name())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/webserver/translate.go
+++ b/pkg/webserver/translate.go
@@ -65,7 +65,6 @@ func translateHandler() http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_ = in.Close()
 
 		out, err := os.CreateTemp("", "out-*.srt")
 		if err != nil {


### PR DESCRIPTION
## Summary
- ensure temp files are closed with `defer`
- note GitHub issue updates for issue #914

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685493ad18d48321ac802f93a221f03a