### PR TITLE
Fix CI false failures

### DIFF
--- a/.github/issue-updates/071cbaf3-aa67-45b4-a6f9-5f6af86220a7.json
+++ b/.github/issue-updates/071cbaf3-aa67-45b4-a6f9-5f6af86220a7.json
@@ -1,0 +1,9 @@
+{
+  "number": 531,
+  "labels": [
+    "codex",
+    "in-progress"
+  ],
+  "guid": "update-issue-531-2025-06-21",
+  "action": "update"
+}

--- a/.github/issue-updates/12e1b655-3174-4184-b84c-aaea14ac9249.json
+++ b/.github/issue-updates/12e1b655-3174-4184-b84c-aaea14ac9249.json
@@ -1,0 +1,6 @@
+{
+  "number": 531,
+  "state_reason": "completed",
+  "guid": "close-issue-531-2025-06-21",
+  "action": "close"
+}

--- a/.github/issue-updates/217e062c-5077-4d87-a706-3dac6d44ce0a.json
+++ b/.github/issue-updates/217e062c-5077-4d87-a706-3dac6d44ce0a.json
@@ -1,0 +1,6 @@
+{
+  "number": 532,
+  "state_reason": "completed",
+  "guid": "close-issue-532-2025-06-21",
+  "action": "close"
+}

--- a/.github/issue-updates/2544dd66-fc79-4334-b38f-7519c85525dd.json
+++ b/.github/issue-updates/2544dd66-fc79-4334-b38f-7519c85525dd.json
@@ -1,0 +1,6 @@
+{
+  "number": 923,
+  "state_reason": "completed",
+  "guid": "close-issue-923-2025-06-21",
+  "action": "close"
+}

--- a/.github/issue-updates/26608e02-7242-4caa-ae0f-9601076ecd63.json
+++ b/.github/issue-updates/26608e02-7242-4caa-ae0f-9601076ecd63.json
@@ -1,0 +1,6 @@
+{
+  "number": 532,
+  "body": "## Plan of Action\n\n1. Add benchmark tests for merging and translation functions\n2. Update issue_updates.json to close the issue after merging",
+  "guid": "plan-comment-532-2025-06-21",
+  "action": "comment"
+}

--- a/.github/issue-updates/3991813e-6546-4b86-b087-619da879c37c.json
+++ b/.github/issue-updates/3991813e-6546-4b86-b087-619da879c37c.json
@@ -1,0 +1,9 @@
+{
+  "number": 532,
+  "labels": [
+    "codex",
+    "in-progress"
+  ],
+  "guid": "update-issue-532-2025-06-20",
+  "action": "update"
+}

--- a/.github/issue-updates/5cec10c3-995a-4c3b-a4d1-1e907ef8eb08.json
+++ b/.github/issue-updates/5cec10c3-995a-4c3b-a4d1-1e907ef8eb08.json
@@ -1,0 +1,6 @@
+{
+  "number": 531,
+  "body": "## Plan of Action\n\n1. Replace manual HTTP calls with osdb SDK.\n2. Update tests for new implementation.\n3. Document change in CHANGELOG.",
+  "guid": "comment-issue-531-plan-2025-06-21",
+  "action": "comment"
+}

--- a/.github/issue-updates/a4d7a2e2-f643-466f-84c7-dcd476ec287f.json
+++ b/.github/issue-updates/a4d7a2e2-f643-466f-84c7-dcd476ec287f.json
@@ -1,0 +1,8 @@
+{
+  "number": 923,
+  "labels": [
+    "codex"
+  ],
+  "guid": "update-issue-923-2025-06-21",
+  "action": "update"
+}

--- a/.github/issue-updates/c481d112-69fd-4e9a-a3c9-af3061ab9a24.json
+++ b/.github/issue-updates/c481d112-69fd-4e9a-a3c9-af3061ab9a24.json
@@ -1,0 +1,6 @@
+{
+  "number": 923,
+  "body": "CI updated to ignore Codecov failures using `fail_ci_if_error: false`. This prevents false negatives during backend testing.",
+  "guid": "comment-923-codecov-fix-2025-06-21",
+  "action": "comment"
+}

--- a/.github/issue-updates/d70174a4-98fc-401f-8432-c247da5116b2.json
+++ b/.github/issue-updates/d70174a4-98fc-401f-8432-c247da5116b2.json
@@ -1,0 +1,6 @@
+{
+  "number": 930,
+  "body": "## Plan of Action\n\n1. Parse URL with the JavaScript URL constructor to extract the hostname.\n2. Check that the hostname ends with 'omdbapi.com' before mocking the response.\n3. Update related tests for strict host validation.\n4. Document the security fix.",
+  "guid": "comment-930-plan-2025-06-21",
+  "action": "comment"
+}

--- a/.github/issue-updates/dd754499-2a3b-44ed-a30a-eab2bbf5aa1e.json
+++ b/.github/issue-updates/dd754499-2a3b-44ed-a30a-eab2bbf5aa1e.json
@@ -1,0 +1,8 @@
+{
+  "number": 930,
+  "labels": [
+    "codex"
+  ],
+  "guid": "update-issue-930-2025-06-21",
+  "action": "update"
+}

--- a/.github/issue-updates/e9077445-fe3e-4cc6-95a0-d67597eed470.json
+++ b/.github/issue-updates/e9077445-fe3e-4cc6-95a0-d67597eed470.json
@@ -1,0 +1,10 @@
+{
+  "title": "CI fails due to Codecov upload errors",
+  "body": "Backend tests succeeded but CI marked the job failed when the Codecov upload step returned an error. Ignore these failures to avoid false negatives.",
+  "labels": [
+    "bug",
+    "ci"
+  ],
+  "guid": "create-codecov-failure-2025-06-21",
+  "action": "create"
+}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -105,6 +105,8 @@ jobs:
           files: ./coverage.out
           flags: backend
           name: backend-coverage
+          # Allow Codecov errors without failing tests
+          fail_ci_if_error: false
 
   build:
     name: Build Binary

--- a/issue_updates.json
+++ b/issue_updates.json
@@ -170,6 +170,12 @@
         "enhancement"
       ],
       "guid": "create-progress-updates-2025-06-20"
+    },
+    {
+      "title": "CI fails due to Codecov upload errors",
+      "body": "Backend tests succeeded but CI marked the job failed when the Codecov upload step returned an error. Ignore these failures to avoid false negatives.",
+      "labels": ["bug", "ci"],
+      "guid": "create-codecov-failure-2025-06-21"
     }
   ],
   "update": [
@@ -223,6 +229,11 @@
         "in-progress"
       ],
       "guid": "update-issue-531-2025-06-21"
+    },
+    {
+      "number": 923,
+      "labels": ["codex"],
+      "guid": "update-issue-923-2025-06-21"
     }
   ],
   "comment": [
@@ -260,6 +271,11 @@
       "number": 531,
       "body": "## Plan of Action\n\n1. Replace manual HTTP calls with osdb SDK.\n2. Update tests for new implementation.\n3. Document change in CHANGELOG.",
       "guid": "comment-issue-531-plan-2025-06-21"
+    },
+    {
+      "number": 923,
+      "body": "CI updated to ignore Codecov failures using `fail_ci_if_error: false`. This prevents false negatives during backend testing.",
+      "guid": "comment-923-codecov-fix-2025-06-21"
     }
   ],
   "close": [
@@ -272,6 +288,11 @@
       "number": 531,
       "state_reason": "completed",
       "guid": "close-issue-531-2025-06-21"
+    },
+    {
+      "number": 923,
+      "state_reason": "completed",
+      "guid": "close-issue-923-2025-06-21"
     }
   ],
   "delete": []


### PR DESCRIPTION
## Description
Ignore Codecov upload errors to prevent CI from reporting failed backend tests.

## Motivation
The backend workflow failed when coverage upload returned an error, even though tests succeeded.

## Changes
- allow Codecov errors without failing tests
- document issue lifecycle in `issue_updates.json`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856a777cccc8321b3b62baaad03952a