### PR TITLE
Fix database stats not displaying

### DIFF
--- a/.github/issue-updates/8d58f140-d329-4fbb-868d-8f01402473cd.json
+++ b/.github/issue-updates/8d58f140-d329-4fbb-868d-8f01402473cd.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 999,
+  "body": "Plan: implement count methods and update stats handler.",
+  "guid": "comment-999-2025-06-22-160217"
+}

--- a/.github/issue-updates/9cea9501-3a48-4d53-a85d-354e008b3cac.json
+++ b/.github/issue-updates/9cea9501-3a48-4d53-a85d-354e008b3cac.json
@@ -1,0 +1,7 @@
+{
+  "action": "create",
+  "title": "Database stats endpoint returns empty results",
+  "body": "The /api/database/stats endpoint always returns zeros, so the UI shows no statistics.",
+  "labels": ["bug", "codex"],
+  "guid": "create-database-stats-endpoint-returns-empty-results-2025-06-22"
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -378,6 +378,30 @@ func (s *SQLStore) DeleteMediaItem(path string) error {
 	return err
 }
 
+// CountSubtitles returns the number of subtitle records.
+func (s *SQLStore) CountSubtitles() (int, error) {
+	row := s.db.QueryRow(`SELECT COUNT(*) FROM subtitles`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
+// CountDownloads returns the number of download records.
+func (s *SQLStore) CountDownloads() (int, error) {
+	row := s.db.QueryRow(`SELECT COUNT(*) FROM downloads`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
+// CountMediaItems returns the number of media items.
+func (s *SQLStore) CountMediaItems() (int, error) {
+	row := s.db.QueryRow(`SELECT COUNT(*) FROM media_items`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
 // DB returns the underlying *sql.DB for compatibility with existing code.
 func (s *SQLStore) DB() *sql.DB {
 	return s.db

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -232,6 +232,63 @@ func (p *PebbleStore) DeleteMediaItem(path string) error {
 	return iter.Error()
 }
 
+// CountSubtitles returns the number of subtitle records.
+func (p *PebbleStore) CountSubtitles() (int, error) {
+	iter, err := p.db.NewIter(nil)
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		if strings.HasPrefix(string(iter.Key()), "subtitle:") {
+			count++
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// CountDownloads returns the number of download records.
+func (p *PebbleStore) CountDownloads() (int, error) {
+	iter, err := p.db.NewIter(nil)
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		if strings.HasPrefix(string(iter.Key()), "download:") {
+			count++
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// CountMediaItems returns the number of media item records.
+func (p *PebbleStore) CountMediaItems() (int, error) {
+	iter, err := p.db.NewIter(nil)
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		if strings.HasPrefix(string(iter.Key()), "media:") {
+			count++
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 // InsertTag is unsupported for PebbleStore and returns nil for compatibility.
 func (p *PebbleStore) InsertTag(name string) error { return nil }
 

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -166,6 +166,30 @@ func (p *PostgresStore) DeleteMediaItem(path string) error {
 	return err
 }
 
+// CountSubtitles returns the number of subtitle records.
+func (p *PostgresStore) CountSubtitles() (int, error) {
+	row := p.db.QueryRow(`SELECT COUNT(*) FROM subtitles`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
+// CountDownloads returns the number of download records.
+func (p *PostgresStore) CountDownloads() (int, error) {
+	row := p.db.QueryRow(`SELECT COUNT(*) FROM downloads`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
+// CountMediaItems returns the number of media items.
+func (p *PostgresStore) CountMediaItems() (int, error) {
+	row := p.db.QueryRow(`SELECT COUNT(*) FROM media_items`)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}
+
 // InsertTag adds a tag to the database.
 func (p *PostgresStore) InsertTag(name string) error {
 	_, err := p.db.Exec(`INSERT INTO tags (name, created_at) VALUES ($1, $2)`, name, time.Now())

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -6,18 +6,24 @@ type SubtitleStore interface {
 	InsertSubtitle(rec *SubtitleRecord) error
 	// ListSubtitles retrieves all subtitle records sorted by creation time.
 	ListSubtitles() ([]SubtitleRecord, error)
+	// CountSubtitles returns the total number of subtitle records.
+	CountSubtitles() (int, error)
 	// DeleteSubtitle removes all records for the specified file.
 	DeleteSubtitle(file string) error
 	// InsertDownload stores a download record.
 	InsertDownload(rec *DownloadRecord) error
 	// ListDownloads retrieves all download records sorted by creation time.
 	ListDownloads() ([]DownloadRecord, error)
+	// CountDownloads returns the total number of download records.
+	CountDownloads() (int, error)
 	// DeleteDownload removes download records for the specified subtitle file.
 	DeleteDownload(file string) error
 	// InsertMediaItem stores a media library record.
 	InsertMediaItem(rec *MediaItem) error
 	// ListMediaItems retrieves all media items sorted by creation time.
 	ListMediaItems() ([]MediaItem, error)
+	// CountMediaItems returns the total number of media items.
+	CountMediaItems() (int, error)
 	// DeleteMediaItem removes a record for the specified media path.
 	DeleteMediaItem(path string) error
 	// InsertTag stores a new tag value.

--- a/pkg/webserver/database.go
+++ b/pkg/webserver/database.go
@@ -95,17 +95,17 @@ func databaseStatsHandler(db *sql.DB) http.Handler {
 			return
 		}
 		defer store.Close()
-		subs, _ := store.ListSubtitles()
-		downloads, _ := store.ListDownloads()
-		media, _ := store.ListMediaItems()
+		subCount, _ := store.CountSubtitles()
+		downCount, _ := store.CountDownloads()
+		mediaCount, _ := store.CountMediaItems()
 		var users int
 		row := db.QueryRow(`SELECT COUNT(1) FROM users`)
 		_ = row.Scan(&users)
 		st := stats{
-			TotalRecords: len(subs),
+			TotalRecords: subCount,
 			Users:        users,
-			Downloads:    len(downloads),
-			MediaItems:   len(media),
+			Downloads:    downCount,
+			MediaItems:   mediaCount,
 		}
 		if hist := backups.List(); len(hist) > 0 {
 			st.LastBackup = hist[len(hist)-1].CreatedAt


### PR DESCRIPTION
## Description
Add counting methods for subtitle, download, and media records and update the stats handler to use them. Created an issue and plan comment.

## Motivation
Stats API returned zeros because it listed records instead of counting them. Using explicit counts fixes incorrect statistics.

## Changes
- Added `CountSubtitles`, `CountDownloads`, and `CountMediaItems` to store interface
- Implemented counting for SQLite, Postgres, and Pebble backends
- Updated `/api/database/stats` handler to use new count methods
- Added issue update files

## Testing
- `make test`

## Related Issues
Fixes #999

------
https://chatgpt.com/codex/tasks/task_e_6858271474948321a47412de9bf24121