### PR TITLE
Add subtitle renaming command

### DIFF
--- a/.github/issue-updates/20725920-e9ed-443c-aa3c-5ace212d3d5f.json
+++ b/.github/issue-updates/20725920-e9ed-443c-aa3c-5ace212d3d5f.json
@@ -1,0 +1,7 @@
+{
+  "action": "create",
+  "title": "Improve rename command",
+  "body": "Handle multiple matching subtitles to prevent overwrites",
+  "labels": ["bug", "enhancement"],
+  "guid": "create-improve-rename-command-2025-06-23"
+}

--- a/.github/issue-updates/598b6e73-f566-417e-a265-f27583ffea34.json
+++ b/.github/issue-updates/598b6e73-f566-417e-a265-f27583ffea34.json
@@ -1,0 +1,7 @@
+{
+  "action": "create",
+  "title": "Add rename command",
+  "body": "Implement CLI command to rename subtitles when video filenames change.",
+  "labels": ["enhancement"],
+  "guid": "create-add-rename-command-2025-06-22"
+}

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ subtitle-manager scanlib [directory]
 subtitle-manager watch [directory] [lang] [-r]
 subtitle-manager grpc-server --addr :50051
 subtitle-manager delete [file]
+subtitle-manager rename [video] [lang]
 subtitle-manager downloads
 subtitle-manager login [username] [password]
 subtitle-manager login-token [token]

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -16,7 +16,7 @@ var renameCmd = &cobra.Command{
 		logger := logging.GetLogger("rename")
 		video, lang := args[0], args[1]
 		if err := renamer.Rename(video, lang); err != nil {
-			logger.Warnf("rename %s: %v", video, err)
+			logger.Errorf("rename %s: %v", video, err)
 			return err
 		}
 		logger.Infof("renamed subtitles for %s", video)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/renamer"
+)
+
+// renameCmd renames subtitle files to match a video filename.
+var renameCmd = &cobra.Command{
+	Use:   "rename [video] [lang]",
+	Short: "Rename subtitle to match video file",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("rename")
+		video, lang := args[0], args[1]
+		if err := renamer.Rename(video, lang); err != nil {
+			logger.Warnf("rename %s: %v", video, err)
+			return err
+		}
+		logger.Infof("renamed subtitles for %s", video)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(renameCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,7 @@ func init() {
 	rootCmd.AddCommand(batchCmd)
 	rootCmd.AddCommand(sonarrCmd)
 	rootCmd.AddCommand(radarrCmd)
+	rootCmd.AddCommand(renameCmd)
 }
 
 func initConfig() {

--- a/pkg/renamer/renamer.go
+++ b/pkg/renamer/renamer.go
@@ -1,6 +1,7 @@
 package renamer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,14 +19,15 @@ func Rename(videoPath, lang string) error {
 	if err != nil {
 		return err
 	}
-	newName := base + "." + lang + ".srt"
-	for _, f := range files {
-		if f == newName {
-			continue
-		}
-		if err := os.Rename(f, newName); err != nil {
-			return err
-		}
+	if len(files) > 1 {
+		return fmt.Errorf("multiple subtitle files for %s", videoPath)
 	}
-	return nil
+	if len(files) == 0 {
+		return nil
+	}
+	newName := base + "." + lang + ".srt"
+	if files[0] == newName {
+		return nil
+	}
+	return os.Rename(files[0], newName)
 }

--- a/pkg/renamer/renamer.go
+++ b/pkg/renamer/renamer.go
@@ -1,0 +1,31 @@
+package renamer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Rename updates subtitle filenames so they match the given video path.
+// It searches the video directory for files named "*.{lang}.srt" and
+// renames them to use the video base name. Existing matching files are
+// left untouched.
+func Rename(videoPath, lang string) error {
+	base := strings.TrimSuffix(videoPath, filepath.Ext(videoPath))
+	dir := filepath.Dir(videoPath)
+	pattern := filepath.Join(dir, "*."+lang+".srt")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return err
+	}
+	newName := base + "." + lang + ".srt"
+	for _, f := range files {
+		if f == newName {
+			continue
+		}
+		if err := os.Rename(f, newName); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/renamer/renamer_test.go
+++ b/pkg/renamer/renamer_test.go
@@ -1,0 +1,30 @@
+package renamer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRename ensures subtitle files are renamed to match the video file.
+func TestRename(t *testing.T) {
+	dir := t.TempDir()
+	video := filepath.Join(dir, "new.mkv")
+	if err := os.WriteFile(video, []byte("x"), 0644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+	subOld := filepath.Join(dir, "old.en.srt")
+	if err := os.WriteFile(subOld, []byte("y"), 0644); err != nil {
+		t.Fatalf("write sub: %v", err)
+	}
+	if err := Rename(video, "en"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	newSub := filepath.Join(dir, "new.en.srt")
+	if _, err := os.Stat(newSub); err != nil {
+		t.Fatalf("expected %s: %v", newSub, err)
+	}
+	if _, err := os.Stat(subOld); !os.IsNotExist(err) {
+		t.Fatalf("old subtitle still exists")
+	}
+}

--- a/pkg/renamer/renamer_test.go
+++ b/pkg/renamer/renamer_test.go
@@ -28,3 +28,20 @@ func TestRename(t *testing.T) {
 		t.Fatalf("old subtitle still exists")
 	}
 }
+
+// TestRenameMultiple ensures an error is returned when more than one subtitle matches.
+func TestRenameMultiple(t *testing.T) {
+	dir := t.TempDir()
+	video := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(video, []byte("x"), 0644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+	for _, name := range []string{"one.en.srt", "two.en.srt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("y"), 0644); err != nil {
+			t.Fatalf("write sub: %v", err)
+		}
+	}
+	if err := Rename(video, "en"); err == nil {
+		t.Fatal("expected error for multiple subtitles")
+	}
+}


### PR DESCRIPTION
## Description
Introduce a new command that renames subtitle files when video filenames change and track the related issue.

## Motivation
Media upgrades often result in new filenames while subtitles remain unchanged. This command keeps subtitles synchronized with their videos to avoid mismatched playback.

## Changes
- Added `rename` CLI command wiring it into the root command
- Implemented `renamer` package with a `Rename` helper
- Documented command usage in `README`
- Created unit test verifying renaming logic
- Added issue update for feature tracking

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68585e241624832181aabf6b55ca14e4