### PR TITLE
Fix path validation in scanner

### DIFF
--- a/.github/issue-updates/98225ad6-d28d-48ed-8788-375594c99835.json
+++ b/.github/issue-updates/98225ad6-d28d-48ed-8788-375594c99835.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 1106,
+  "body": "Label issue with codex",
+  "labels": ["codex"],
+  "guid": "update-issue-1106-2025-06-23"
+}

--- a/.github/issue-updates/b157236a-c446-4564-b531-2997b48abadf.json
+++ b/.github/issue-updates/b157236a-c446-4564-b531-2997b48abadf.json
@@ -1,0 +1,6 @@
+{
+  "action": "close",
+  "number": 1106,
+  "state_reason": "completed",
+  "guid": "close-issue-1106-2025-06-23"
+}

--- a/.github/issue-updates/ba333a7a-e9fb-4fbe-b8b7-d2d9854299d9.json
+++ b/.github/issue-updates/ba333a7a-e9fb-4fbe-b8b7-d2d9854299d9.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 1106,
+  "body": "Plan: validate dir path to prevent path injection and use filepath.Join for output",
+  "guid": "comment-1106-2025-06-23-125105"
+}

--- a/pkg/scanner/progress_test.go
+++ b/pkg/scanner/progress_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -18,6 +19,8 @@ func TestScanDirectoryProgress(t *testing.T) {
 	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
 		t.Fatalf("create video: %v", err)
 	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	var called int
 	cb := func(string) { called++ }
 	m := providersmocks.NewProvider(t)

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,6 +17,8 @@ func TestScanDirectory(t *testing.T) {
 	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
 		t.Fatalf("create video: %v", err)
 	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	// first scan creates subtitle
 	m := providersmocks.NewProvider(t)
 	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("a"), nil)
@@ -50,5 +53,19 @@ func TestScanDirectory(t *testing.T) {
 	data, _ = os.ReadFile(sub)
 	if string(data) != "c" {
 		t.Fatalf("subtitle not upgraded: %q", data)
+	}
+}
+
+func TestScanDirectoryInvalidPath(t *testing.T) {
+	err := ScanDirectory(context.Background(), "../invalid", "en", "test", nil, false, 1, nil)
+	if err == nil {
+		t.Fatalf("expected error for invalid path")
+	}
+}
+
+func TestProcessFileInvalidPath(t *testing.T) {
+	err := ProcessFile(context.Background(), "../bad/movie.mkv", "en", "test", nil, false, nil)
+	if err == nil {
+		t.Fatalf("expected error for invalid path")
 	}
 }

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -8,11 +8,14 @@ import (
 	"time"
 
 	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestWatchDirectory(t *testing.T) {
 	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	ctx, cancel := context.WithCancel(context.Background())
 	m := providersmocks.NewProvider(t)
 	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("sub"), nil)
@@ -49,6 +52,8 @@ func TestWatchDirectoryRecursive(t *testing.T) {
 	if err := os.MkdirAll(subdir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	ctx, cancel := context.WithCancel(context.Background())
 	m := providersmocks.NewProvider(t)
 	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("sub"), nil)

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -224,6 +224,8 @@ func TestScanHandlers(t *testing.T) {
 	defer srv.Close()
 	// create video file
 	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	vid := filepath.Join(dir, "file.mkv")
 	_ = os.WriteFile(vid, []byte("x"), 0644) // nolint:errcheck
 	// trigger scan
@@ -278,6 +280,8 @@ func TestExtract(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	script := filepath.Join(dir, "ffmpeg")
 	data := "#!/bin/sh\ncp ../../testdata/simple.srt \"$6\"\n"
 	if err := os.WriteFile(script, []byte(data), 0755); err != nil {
@@ -572,6 +576,8 @@ func TestDownload(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	vid := filepath.Join(dir, "video.mkv")
 	os.WriteFile(vid, []byte("x"), 0644)
 
@@ -631,6 +637,8 @@ func TestWebhookSonarr(t *testing.T) {
 	defer viper.Reset()
 
 	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
 	vid := filepath.Join(dir, "file.mkv")
 	os.WriteFile(vid, []byte("x"), 0644)
 


### PR DESCRIPTION
## Description
Use security module for path checks in scanner operations and update tests.

## Motivation
Align path validation with centralized security helpers and resolve CodeQL alert.

## Changes
- Sanitize directory and file paths via `ValidateAndSanitizePath`
- Remove custom path validation logic
- Adjust tests to configure allowed media directories
- Close issue #1106

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68594d53675083218f546bf18ea10f92