### PR TITLE
Add config editor page to web UI

### DIFF
--- a/.github/issue-updates/3dedb562-625f-44f8-b847-4ff80d5bfeea.json
+++ b/.github/issue-updates/3dedb562-625f-44f8-b847-4ff80d5bfeea.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 541,
+  "body": "Implement ConfigEditor page to edit YAML config via /api/config endpoint",
+  "guid": "comment-541-2025-06-23-125628"
+}

--- a/.github/issue-updates/8ec3b761-691e-4707-a88b-05c44bdcdf0e.json
+++ b/.github/issue-updates/8ec3b761-691e-4707-a88b-05c44bdcdf0e.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 541,
+  "body": "Add codex label",
+  "labels": ["codex"],
+  "guid": "update-issue-541-2025-06-23"
+}

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The interface provides a complete user experience with:
 - **System**: Real-time logs, task progress, and system information
 - **Wanted**: Search interface for missing subtitles with provider selection
 - **Tags**: Edit and organize custom tags for language preferences
+- **Config File**: Edit the YAML configuration directly in the browser
 
 Configuration values are loaded from `$HOME/.subtitle-manager.yaml` by default. Environment variables prefixed with `SM_` override configuration values. API keys may be specified via flags `--google-key`, `--openai-key` and `--opensubtitles-key` or in the configuration file. Additional flags include `--ffmpeg-path` for a custom ffmpeg binary, `--batch-workers` and `--scan-workers` to control concurrency. The SQLite database location defaults to `$HOME/.subtitle-manager.db` and can be overridden with `--db`. Use `--db-backend` to switch between the `sqlite` and `pebble` engines. When using PebbleDB a directory path may be supplied instead of a file. Translation can be delegated to a remote gRPC server using the `--grpc` flag and providing an address such as `localhost:50051`. Generic provider options may also be set with variables like `SM_PROVIDERS_GENERIC_API_URL`.
 Run `subtitle-manager migrate old.db newdir` to copy existing subtitle history from SQLite to PebbleDB.

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
         "dompurify": "^3.2.6",
+        "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2596,8 +2597,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -4811,7 +4811,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/webui/package.json
+++ b/webui/package.json
@@ -26,6 +26,7 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "dompurify": "^3.2.6",
+    "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -11,6 +11,7 @@ import {
   Menu as MenuIcon,
   PushPin as PinIcon,
   Schedule as ScheduleIcon,
+  Edit as EditIcon,
   Settings as SettingsIcon,
   BugReport as SystemIcon,
   Translate as TranslateIcon,
@@ -68,6 +69,7 @@ const Convert = lazy(() => import('./Convert.jsx'));
 const Translate = lazy(() => import('./Translate.jsx'));
 const Scheduling = lazy(() => import('./Scheduling.jsx'));
 const Setup = lazy(() => import('./Setup.jsx'));
+const ConfigEditor = lazy(() => import('./ConfigEditor.jsx'));
 const MediaDetails = lazy(() => import('./MediaDetails.jsx'));
 
 /**
@@ -419,6 +421,12 @@ function App() {
       label: 'Scheduling',
       icon: <ScheduleIcon />,
       path: '/tools/scheduling',
+    },
+    {
+      id: 'config',
+      label: 'Config File',
+      icon: <EditIcon />,
+      path: '/tools/config',
     },
   ];
 
@@ -996,6 +1004,10 @@ function App() {
               <Route
                 path="/tools/scheduling"
                 element={<Scheduling backendAvailable={backendAvailable} />}
+              />
+              <Route
+                path="/tools/config"
+                element={<ConfigEditor backendAvailable={backendAvailable} />}
               />
               <Route path="/offline-info" element={<OfflineInfo />} />
             </Routes>

--- a/webui/src/ConfigEditor.jsx
+++ b/webui/src/ConfigEditor.jsx
@@ -1,6 +1,13 @@
 // file: webui/src/ConfigEditor.jsx
 import { Edit as EditIcon, Save as SaveIcon } from '@mui/icons-material';
-import { Alert, Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useEffect, useState } from 'react';
 import { apiService } from './services/api.js';
 import yaml from 'js-yaml';
@@ -73,7 +80,12 @@ export default function ConfigEditor({ backendAvailable = true }) {
       )}
 
       {loading ? (
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          minHeight="200px"
+        >
           <CircularProgress />
         </Box>
       ) : (
@@ -84,7 +96,11 @@ export default function ConfigEditor({ backendAvailable = true }) {
             </Alert>
           )}
           {status && (
-            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setStatus('')}>
+            <Alert
+              severity="success"
+              sx={{ mb: 2 }}
+              onClose={() => setStatus('')}
+            >
               {status}
             </Alert>
           )}
@@ -97,7 +113,9 @@ export default function ConfigEditor({ backendAvailable = true }) {
             fullWidth
             variant="outlined"
             disabled={!backendAvailable}
-            sx={{ fontFamily: '"Roboto Mono", "Consolas", "Monaco", monospace' }}
+            sx={{
+              fontFamily: '"Roboto Mono", "Consolas", "Monaco", monospace',
+            }}
             data-testid="config-editor"
           />
           <Box mt={2}>

--- a/webui/src/ConfigEditor.jsx
+++ b/webui/src/ConfigEditor.jsx
@@ -1,0 +1,117 @@
+// file: webui/src/ConfigEditor.jsx
+import { Edit as EditIcon, Save as SaveIcon } from '@mui/icons-material';
+import { Alert, Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { apiService } from './services/api.js';
+import yaml from 'js-yaml';
+
+/**
+ * ConfigEditor allows viewing and editing of the raw configuration
+ * file using YAML format. Changes are persisted via the /api/config
+ * endpoint which writes to Viper's configuration.
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.backendAvailable - Whether the backend service is available
+ */
+export default function ConfigEditor({ backendAvailable = true }) {
+  const [yamlText, setYamlText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+
+  const loadConfig = async () => {
+    if (!backendAvailable) return;
+    setLoading(true);
+    try {
+      const res = await apiService.get('/api/config');
+      if (res.ok) {
+        const data = await res.json();
+        setYamlText(yaml.dump(data));
+      } else {
+        setError('Failed to load configuration');
+      }
+    } catch {
+      setError('Failed to load configuration');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveConfig = async () => {
+    if (!backendAvailable) return;
+    setSaving(true);
+    try {
+      const obj = yaml.load(yamlText);
+      const res = await apiService.post('/api/config', obj);
+      if (res.ok) {
+        setStatus('Configuration saved');
+      } else {
+        setError('Failed to save configuration');
+      }
+    } catch {
+      setError('Invalid YAML or network error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  useEffect(() => {
+    loadConfig();
+  }, [backendAvailable]);
+
+  return (
+    <Box>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Configuration File
+      </Typography>
+
+      {!backendAvailable && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Backend service is not available. Configuration cannot be edited.
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Box>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+              {error}
+            </Alert>
+          )}
+          {status && (
+            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setStatus('')}>
+              {status}
+            </Alert>
+          )}
+          <TextField
+            label="YAML Configuration"
+            multiline
+            minRows={20}
+            value={yamlText}
+            onChange={e => setYamlText(e.target.value)}
+            fullWidth
+            variant="outlined"
+            disabled={!backendAvailable}
+            sx={{ fontFamily: '"Roboto Mono", "Consolas", "Monaco", monospace' }}
+            data-testid="config-editor"
+          />
+          <Box mt={2}>
+            <Button
+              variant="contained"
+              startIcon={<SaveIcon />}
+              onClick={saveConfig}
+              disabled={saving || !backendAvailable}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/webui/src/__tests__/ConfigEditor.test.jsx
+++ b/webui/src/__tests__/ConfigEditor.test.jsx
@@ -1,0 +1,32 @@
+// file: webui/src/__tests__/ConfigEditor.test.jsx
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import ConfigEditor from '../ConfigEditor.jsx';
+
+describe('ConfigEditor component', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn(url => {
+      if (url === '/api/config') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ test_key: 'value' }),
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+  });
+
+  test('loads config and saves updates', async () => {
+    render(<ConfigEditor />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/config'));
+    expect(screen.getByTestId('config-editor').value).toContain('test_key');
+    fireEvent.change(screen.getByTestId('config-editor'), {
+      target: { value: 'test_key: new' },
+    });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(fetch).toHaveBeenLastCalledWith('/api/config', expect.any(Object)));
+  });
+});
+

--- a/webui/src/__tests__/ConfigEditor.test.jsx
+++ b/webui/src/__tests__/ConfigEditor.test.jsx
@@ -26,7 +26,8 @@ describe('ConfigEditor component', () => {
       target: { value: 'test_key: new' },
     });
     fireEvent.click(screen.getByText('Save'));
-    await waitFor(() => expect(fetch).toHaveBeenLastCalledWith('/api/config', expect.any(Object)));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenLastCalledWith('/api/config', expect.any(Object))
+    );
   });
 });
-


### PR DESCRIPTION
## Description
Implement configuration file editing through new ConfigEditor page. Updated navigation and routes, added `js-yaml` dependency and documented feature.

## Motivation
Allows managing raw YAML configuration from the browser as requested.

## Changes
- Added ConfigEditor React component for YAML editing
- Added navigation item and route
- Included js-yaml dependency
- Documented feature in README
- Added unit test for ConfigEditor

## Testing
- `npm test` *(fails: 2 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68594e1e8f088321b16723c880e9b911