### PR TITLE
Fix CI failure from Codecov errors

### DIFF
--- a/.github/issue-updates/82007900-04f5-4ffd-a3c3-9015c7783464.json
+++ b/.github/issue-updates/82007900-04f5-4ffd-a3c3-9015c7783464.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 1102,
+  "body": "Work is in progress under Codex.",
+  "labels": ["bug", "ci", "codex"],
+  "guid": "update-issue-1102-2025-06-23"
+}

--- a/.github/issue-updates/a8a6a366-c4f1-46f8-a849-e4f8dbaa256e.json
+++ b/.github/issue-updates/a8a6a366-c4f1-46f8-a849-e4f8dbaa256e.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 1102,
+  "body": "Plan: update CI workflow to ignore Codecov errors using continue-on-error.",
+  "guid": "comment-1102-2025-06-23-125302"
+}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -107,6 +107,7 @@ jobs:
           name: backend-coverage
           # Allow Codecov errors without failing tests
           fail_ci_if_error: false
+      continue-on-error: true
 
   build:
     name: Build Binary


### PR DESCRIPTION
## Description
Ensure Codecov upload failures don't mark backend CI as failed.

## Motivation
Codecov occasionally returns errors that cause the backend workflow to fail even though tests pass.

## Changes
- allow Codecov upload step to continue on error
- add issue updates for tracking

## Testing
- `go test ./...`

## Related Issues
Closes #1102

------
https://chatgpt.com/codex/tasks/task_e_68594d9f96c883219b15819d15ea80ae