### PR TITLE
Close test issue 1073 with workflow update

### DIFF
--- a/.github/issue-updates/d72b6041-4ecd-4ee4-8fd4-50b3e613ec2d.json
+++ b/.github/issue-updates/d72b6041-4ecd-4ee4-8fd4-50b3e613ec2d.json
@@ -1,0 +1,6 @@
+{
+  "action": "close",
+  "number": 1073,
+  "state_reason": "completed",
+  "guid": "close-issue-1073-2025-06-23"
+}

--- a/.github/issue-updates/e8eb1cbc-ec1a-4c8b-a504-fb7ad0c83671.json
+++ b/.github/issue-updates/e8eb1cbc-ec1a-4c8b-a504-fb7ad0c83671.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 1073,
+  "body": "## Plan of Action\n\n1. Apply codex label using distributed update.\n2. Verify the workflow processes this file correctly.",
+  "guid": "comment-1073-2025-06-23-125343"
+}

--- a/.github/issue-updates/fd2bf618-806c-4d3e-97c9-5419a8e70ad3.json
+++ b/.github/issue-updates/fd2bf618-806c-4d3e-97c9-5419a8e70ad3.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 1073,
+  "body": "Marking issue for codex work",
+  "labels": ["codex"],
+  "guid": "update-issue-1073-2025-06-23"
+}


### PR DESCRIPTION
## Description
Add a distributed issue update that closes #1073 after verifying the workflow.

## Motivation
Issue #1073 was left open after verification. Closing the issue ensures the test workflow is complete.

## Changes
- add JSON update to close issue 1073

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68594dda9d3083218f48032d069fb5f7