### PR TITLE
Increase logging package tests

### DIFF
--- a/.github/issue-updates/22095436-9c2e-4f6a-ae66-8c42260ab32d.json
+++ b/.github/issue-updates/22095436-9c2e-4f6a-ae66-8c42260ab32d.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 544,
+  "body": "Added tests for memory hook",
+  "guid": "comment-544-2025-06-23-125749"
+}

--- a/.github/issue-updates/a0930a54-9d86-40b9-8b76-94b580fe9fc7.json
+++ b/.github/issue-updates/a0930a54-9d86-40b9-8b76-94b580fe9fc7.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 544,
+  "body": "Work started by Codex",
+  "labels": ["codex"],
+  "guid": "update-issue-544-2025-06-23"
+}

--- a/pkg/logging/memory_test.go
+++ b/pkg/logging/memory_test.go
@@ -1,0 +1,47 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestMemoryHookFire verifies that old entries are dropped when limit is reached.
+func TestMemoryHookFire(t *testing.T) {
+	hook := NewMemoryHook(2)
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logger.AddHook(hook)
+
+	logger.Info("first")
+	logger.Info("second")
+	logger.Info("third")
+
+	logs := hook.Logs()
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(logs))
+	}
+	if !strings.Contains(logs[0], "second") || !strings.Contains(logs[1], "third") {
+		t.Fatalf("unexpected log contents: %v", logs)
+	}
+}
+
+// TestMemoryHookLogsCopy ensures that Logs returns a copy and not internal slice.
+func TestMemoryHookLogsCopy(t *testing.T) {
+	hook := NewMemoryHook(1)
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logger.AddHook(hook)
+
+	logger.Info("entry")
+
+	logs := hook.Logs()
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	logs[0] = "changed"
+	if hook.Logs()[0] == "changed" {
+		t.Fatalf("Logs returned slice is not a copy")
+	}
+}


### PR DESCRIPTION
## Description
Add tests for logging memory hook to improve coverage.

## Motivation
Enhancing test coverage ensures reliability for log retention.

## Changes
- Added `memory_test.go` to verify ring buffer and slice copy behavior
- Created issue updates for #544

## Testing
- `go test ./...`

## Related Issues
Closes #544

------
https://chatgpt.com/codex/tasks/task_e_68594e63f4908321915a46cc72cc51ae