### PR TITLE
Verify RBAC handling in React

### DIFF
--- a/.github/issue-updates/b9c97ca6-f520-4b86-914d-220d45560bfa.json
+++ b/.github/issue-updates/b9c97ca6-f520-4b86-914d-220d45560bfa.json
@@ -1,0 +1,7 @@
+{
+  "action": "update",
+  "number": 542,
+  "body": "Add codex label",
+  "labels": ["codex"],
+  "guid": "update-issue-542-2025-06-23"
+}

--- a/.github/issue-updates/f126c6c3-3e0d-4d03-a948-4d97d5071530.json
+++ b/.github/issue-updates/f126c6c3-3e0d-4d03-a948-4d97d5071530.json
@@ -1,0 +1,6 @@
+{
+  "action": "close",
+  "number": 542,
+  "state_reason": "completed",
+  "guid": "close-issue-542-2025-06-23"
+}

--- a/.github/issue-updates/f1e60a7c-b759-47d4-b580-954169cae478.json
+++ b/.github/issue-updates/f1e60a7c-b759-47d4-b580-954169cae478.json
@@ -1,0 +1,6 @@
+{
+  "action": "comment",
+  "number": 542,
+  "body": "Plan: add frontend RBAC test and handle forbidden status",
+  "guid": "comment-542-2025-06-23-125739"
+}

--- a/webui/src/Settings.jsx
+++ b/webui/src/Settings.jsx
@@ -91,6 +91,10 @@ export default function Settings({ backendAvailable = true }) {
       if (response.ok) {
         const data = await response.json();
         setConfig(data);
+      } else if (response.status === 403) {
+        setError('Permission denied');
+      } else {
+        setError('Failed to load configuration');
       }
     } catch (error) {
       console.error('Failed to load configuration:', error);

--- a/webui/src/__tests__/Settings.test.jsx
+++ b/webui/src/__tests__/Settings.test.jsx
@@ -156,4 +156,23 @@ describe('Settings component', () => {
     expect(screen.getByLabelText('Bazarr URL')).toBeInTheDocument();
     expect(screen.getByLabelText('API Key')).toBeInTheDocument();
   });
+
+  test('shows permission error when config fetch forbidden', async () => {
+    const { apiService } = await import('../services/api.js');
+    apiService.get.mockImplementationOnce(url => {
+      if (url === '/api/config') {
+        return Promise.resolve({ ok: false, status: 403 });
+      }
+      if (url === '/api/providers') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    await act(async () => {
+      render(<Settings />);
+    });
+
+    expect(await screen.findByText('Permission denied')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description
Add front-end handling for forbidden responses and unit test for RBAC enforcement.

## Motivation
Issue #542 requires verifying role-based access control in both backend and frontend. React previously ignored 403 responses from `/api/config`, so users saw no error when lacking permissions.

## Changes
- display permission error when `/api/config` request returns 403
- import missing icons and progress indicator
- add test covering forbidden response handling
- record issue updates for labeling, commenting, and closing issue

## Testing
- `npm --prefix webui test`
- `go test ./...`

## Related Issues
Closes #542

------
https://chatgpt.com/codex/tasks/task_e_68594e791db48321896423b131b49512