### PR TITLE
Implement library scanning feature

### DIFF
--- a/.github/issue-updates/cb0e667b-b888-4530-8f27-7c5566ec0c52.json
+++ b/.github/issue-updates/cb0e667b-b888-4530-8f27-7c5566ec0c52.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Optimize library scanning progress callback",
+  "body": "Refactor ScanLibraryProgress to avoid second directory walk and use typed store.",
+  "labels": ["enhancement", "codex"],
+  "guid": "aba846b5-222a-4edd-bccd-95075ba75c0d",
+  "legacy_guid": "create-optimize-library-scanning-progress-callback-2025-06-23"
+}

--- a/README.md
+++ b/README.md
@@ -329,10 +329,10 @@ The web server exposes a comprehensive REST API for all subtitle operations:
 - `POST /api/extract` - Extract subtitles from media files using ffmpeg
 - `POST /api/download` - Download subtitles for specific media files
 
-#### Library Management
+-#### Library Management
 
-- `POST /api/scan` - Start library scanning with provider selection
-- `GET /api/scan/status` - Check scan progress and status
+- `POST /api/library/scan` - Scan directories and generate metadata
+- `GET /api/library/scan/status` - Check library scan progress
 - `GET /api/search` - Search for subtitles with provider and language filters
 - `GET /api/wanted` - Retrieve wanted subtitles list
 - `POST /api/wanted` - Add subtitles to wanted list

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -19,8 +19,8 @@ This document outlines the design philosophy of the REST and gRPC APIs provided 
 - `POST /api/translate` – translate uploaded subtitles to another language.
 - `POST /api/extract` – extract embedded subtitles from media files.
 - `GET /api/history` – list translation and download history.
-- `POST /api/scan` – initiate library scanning.
-- `GET /api/scan/status` – check progress for the last scan.
+- `POST /api/library/scan` – index media files and generate metadata.
+- `GET /api/library/scan/status` – check progress for the last library scan.
 - `GET /api/wanted` – retrieve wanted subtitles list.
 
 Example error response:

--- a/pkg/webserver/scan.go
+++ b/pkg/webserver/scan.go
@@ -3,12 +3,21 @@ package webserver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/metadata"
 	"github.com/jdfalk/subtitle-manager/pkg/providers"
+	"github.com/jdfalk/subtitle-manager/pkg/radarr"
 	"github.com/jdfalk/subtitle-manager/pkg/scanner"
+	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
 )
 
 // scanStatus tracks progress for an active scan.
@@ -21,6 +30,18 @@ type scanStatus struct {
 var (
 	scanMu sync.Mutex
 	status = scanStatus{Files: []string{}}
+)
+
+// libScanStatus tracks progress for library scanning.
+type libScanStatus struct {
+	Running   bool     `json:"running"`
+	Completed int      `json:"completed"`
+	Files     []string `json:"files"`
+}
+
+var (
+	libMu     sync.Mutex
+	libStatus = libScanStatus{Files: []string{}}
 )
 
 func scanHandler() http.Handler {
@@ -80,5 +101,91 @@ func scanStatusHandler() http.Handler {
 		scanMu.Lock()
 		defer scanMu.Unlock()
 		_ = json.NewEncoder(w).Encode(status)
+	})
+}
+
+func libraryScanHandler(db *sql.DB) http.Handler {
+	type req struct {
+		Path string `json:"path"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var q req
+		if err := json.NewDecoder(r.Body).Decode(&q); err != nil || q.Path == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		libMu.Lock()
+		if libStatus.Running {
+			libMu.Unlock()
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		libStatus = libScanStatus{Running: true, Files: []string{}}
+		libMu.Unlock()
+		go func() {
+			backend := database.GetDatabaseBackend()
+			storePath := database.GetDatabasePath()
+			store, err := database.OpenStore(storePath, backend)
+			if err != nil {
+				libMu.Lock()
+				libStatus.Running = false
+				libMu.Unlock()
+				return
+			}
+			defer store.Close()
+			cb := func(f string) {
+				libMu.Lock()
+				libStatus.Completed++
+				libStatus.Files = append(libStatus.Files, f)
+				libMu.Unlock()
+			}
+			_ = metadata.ScanLibraryProgress(context.Background(), q.Path, store, cb)
+
+			if viper.GetBool("integrations.radarr.enabled") {
+				host := viper.GetString("integrations.radarr.host")
+				port := viper.GetString("integrations.radarr.port")
+				key := viper.GetString("integrations.radarr.api_key")
+				ssl := viper.GetBool("integrations.radarr.ssl")
+				base := strings.Trim(viper.GetString("integrations.radarr.base_url"), "/")
+				scheme := "http"
+				if ssl {
+					scheme = "https"
+				}
+				url := fmt.Sprintf("%s://%s:%s/%s", scheme, host, port, base)
+				c := radarr.NewClient(url, key)
+				_ = radarr.Sync(context.Background(), c, store)
+			}
+			if viper.GetBool("integrations.sonarr.enabled") {
+				host := viper.GetString("integrations.sonarr.host")
+				port := viper.GetString("integrations.sonarr.port")
+				key := viper.GetString("integrations.sonarr.api_key")
+				ssl := viper.GetBool("integrations.sonarr.ssl")
+				base := strings.Trim(viper.GetString("integrations.sonarr.base_url"), "/")
+				scheme := "http"
+				if ssl {
+					scheme = "https"
+				}
+				url := fmt.Sprintf("%s://%s:%s/%s", scheme, host, port, base)
+				c := sonarr.NewClient(url, key)
+				_ = sonarr.Sync(context.Background(), c, store)
+			}
+			libMu.Lock()
+			libStatus.Running = false
+			libMu.Unlock()
+		}()
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func libraryScanStatusHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		libMu.Lock()
+		defer libMu.Unlock()
+		_ = json.NewEncoder(w).Encode(libStatus)
 	})
 }

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -183,6 +183,8 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/providers", authMiddleware(db, "basic", providersHandler()))
 	mux.Handle(prefix+"/api/library/browse", authMiddleware(db, "basic", libraryBrowseHandler()))
 	mux.Handle(prefix+"/api/library/tags", authMiddleware(db, "basic", libraryTagsHandler(db)))
+	mux.Handle(prefix+"/api/library/scan", authMiddleware(db, "basic", libraryScanHandler(db)))
+	mux.Handle(prefix+"/api/library/scan/status", authMiddleware(db, "basic", libraryScanStatusHandler()))
 	mux.Handle(prefix+"/api/widgets/layout", authMiddleware(db, "basic", dashboardLayoutHandler(db)))
 	mux.Handle(prefix+"/api/users/", authMiddleware(db, "admin", userRouter(db)))
 

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -16,6 +16,7 @@ import {
   BugReport as SystemIcon,
   Translate as TranslateIcon,
   Download as WantedIcon,
+  Refresh as RefreshIcon,
 } from '@mui/icons-material';
 import {
   Alert,
@@ -67,6 +68,7 @@ const System = lazy(() => import('./System.jsx'));
 const Extract = lazy(() => import('./Extract.jsx'));
 const Convert = lazy(() => import('./Convert.jsx'));
 const Translate = lazy(() => import('./Translate.jsx'));
+const LibraryScan = lazy(() => import('./LibraryScan.jsx'));
 const Scheduling = lazy(() => import('./Scheduling.jsx'));
 const Setup = lazy(() => import('./Setup.jsx'));
 const ConfigEditor = lazy(() => import('./ConfigEditor.jsx'));
@@ -415,6 +417,12 @@ function App() {
       label: 'Translate',
       icon: <TranslateIcon />,
       path: '/tools/translate',
+    },
+    {
+      id: 'scan',
+      label: 'Library Scan',
+      icon: <RefreshIcon />,
+      path: '/tools/scan',
     },
     {
       id: 'scheduling',
@@ -1000,6 +1008,10 @@ function App() {
               <Route
                 path="/tools/translate"
                 element={<Translate backendAvailable={backendAvailable} />}
+              />
+              <Route
+                path="/tools/scan"
+                element={<LibraryScan backendAvailable={backendAvailable} />}
               />
               <Route
                 path="/tools/scheduling"

--- a/webui/src/Dashboard.jsx
+++ b/webui/src/Dashboard.jsx
@@ -76,9 +76,9 @@ export default function Dashboard({ backendAvailable = true }) {
       setError(null);
       const response = await apiService.get('/api/providers');
       if (response.ok) {
-        const data = await response.json();
+        const data = typeof response.json === 'function' ? await response.json() : [];
         // Only show enabled providers
-        const enabledProviders = data.filter(p => p.enabled);
+        const enabledProviders = (data || []).filter(p => p.enabled);
         setAvailableProviders(enabledProviders);
 
         // Set default provider to first enabled one
@@ -106,7 +106,8 @@ export default function Dashboard({ backendAvailable = true }) {
     try {
       const resp = await apiService.get('/api/system');
       if (resp.ok) {
-        setSystemInfo(await resp.json());
+        const data = typeof resp.json === 'function' ? await resp.json() : {};
+        setSystemInfo(data);
       }
     } catch (err) {
       console.error('Failed to load system info:', err);
@@ -147,7 +148,7 @@ export default function Dashboard({ backendAvailable = true }) {
         `/api/library/browse?path=${encodeURIComponent(parent)}`
       );
       if (resp.ok) {
-        const data = await resp.json();
+        const data = typeof resp.json === 'function' ? await resp.json() : { items: [] };
         const dirs = (data.items || [])
           .filter(item => item.isDirectory)
           .map(item => item.path)
@@ -167,7 +168,7 @@ export default function Dashboard({ backendAvailable = true }) {
     try {
       const response = await apiService.get('/api/scan/status');
       if (response.ok) {
-        const data = await response.json();
+        const data = typeof response.json === 'function' ? await response.json() : {};
         // Ensure files is always an array to prevent null reference errors
         setStatus({
           running: data.running || false,

--- a/webui/src/LibraryScan.jsx
+++ b/webui/src/LibraryScan.jsx
@@ -1,0 +1,153 @@
+// file: webui/src/LibraryScan.jsx
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import FolderIcon from '@mui/icons-material/Folder';
+import { useEffect, useState } from 'react';
+import { apiService } from './services/api.js';
+import DirectoryChooser from './components/DirectoryChooser.jsx';
+
+export default function LibraryScan({ backendAvailable = true }) {
+  const [dir, setDir] = useState('');
+  const [status, setStatus] = useState({
+    running: false,
+    completed: 0,
+    files: [],
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [chooserOpen, setChooserOpen] = useState(false);
+
+  const poll = async () => {
+    try {
+      const resp = await apiService.get('/api/library/scan/status');
+      if (resp.ok) {
+        const data = await resp.json();
+        setStatus({
+          running: data.running || false,
+          completed: data.completed || 0,
+          files: data.files || [],
+        });
+        if (data.running) {
+          setTimeout(poll, 1000);
+        }
+      }
+    } catch (err) {
+      setError('Failed to get scan status');
+    }
+  };
+
+  const start = async () => {
+    if (!dir) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await apiService.post('/api/library/scan', { path: dir });
+      if (resp.ok) {
+        poll();
+      } else {
+        setError('Failed to start scan');
+      }
+    } catch {
+      setError('Failed to start scan');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    poll();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Library Scan
+      </Typography>
+      {!backendAvailable && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Backend service is not available.
+        </Alert>
+      )}
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      <Card sx={{ maxWidth: 600 }}>
+        <CardContent>
+          <Box sx={{ '& > :not(style)': { m: 1 } }}>
+            <TextField
+              fullWidth
+              label="Directory Path"
+              placeholder="/path/to/library"
+              value={dir}
+              onChange={e => setDir(e.target.value)}
+              disabled={status.running}
+              InputProps={{
+                startAdornment: (
+                  <FolderIcon
+                    onClick={() => setChooserOpen(true)}
+                    sx={{ mr: 1 }}
+                  />
+                ),
+              }}
+            />
+            <Button
+              variant="contained"
+              startIcon={
+                loading || status.running ? (
+                  <CircularProgress size={20} />
+                ) : null
+              }
+              onClick={start}
+              disabled={!dir || loading || status.running || !backendAvailable}
+              fullWidth
+            >
+              {status.running ? 'Scanning...' : 'Start Scan'}
+            </Button>
+          </Box>
+          {status.running && (
+            <Box sx={{ mt: 2 }}>
+              <LinearProgress />
+              <Typography variant="body2" color="text.secondary" mt={1}>
+                Processed {status.completed} files
+              </Typography>
+            </Box>
+          )}
+          {status.files.length > 0 && (
+            <Paper sx={{ mt: 2, maxHeight: 200, overflow: 'auto' }}>
+              <List dense>
+                {status.files.map((f, i) => (
+                  <ListItem key={i} divider>
+                    <ListItemText
+                      primary={f}
+                      sx={{ fontFamily: 'monospace' }}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Paper>
+          )}
+        </CardContent>
+      </Card>
+      <DirectoryChooser
+        open={chooserOpen}
+        onClose={() => setChooserOpen(false)}
+        onSelect={p => setDir(p)}
+      />
+    </Box>
+  );
+}

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -35,7 +35,7 @@ export function getBasePath() {
 }
 
 const API_BASE_URL =
-  import.meta?.env?.VITE_API_URL || `${window.location.origin}${getBasePath()}`;
+  import.meta?.env?.VITE_API_URL || getBasePath();
 
 /**
  * Enhanced fetch wrapper with error handling and logging


### PR DESCRIPTION
## Description
Adds library scanning endpoint with Sonarr/Radarr sync and new React tool page.
Restores dashboard scan widget per review feedback.

## Motivation
Users can add a folder to the library and generate metadata across all providers while keeping existing dashboard functionality.

## Changes
- Added `ScanLibraryProgress` and new `/api/library/scan` endpoints
- Created Library Scan React tool and menu entry
- Restored Dashboard scanning widget
- Updated API service base URL logic

## Testing
- `make test`
- `make webui-test` *(fails: hydration errors in React tests)*

## Screenshots
N/A

## Related Issues
Related to optimize library scanning progress callback issue

------
https://chatgpt.com/codex/tasks/task_e_6859a6bfceac83219ad83e6c6d62d1de