### PR TITLE
Fix provider dialog state reset

### DIFF
--- a/.github/issue-updates/1408a3de-4e2b-4a9f-9e60-1f6434b77448.json
+++ b/.github/issue-updates/1408a3de-4e2b-4a9f-9e60-1f6434b77448.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Provider config fails when clicking configuration required",
+  "body": "Error: b is not a function when selecting provider configuration. Reset state and use apiService to fetch providers.",
+  "labels": ["bug", "codex"],
+  "guid": "d1f49555-bea9-4e6e-afdd-e42909d34d2d",
+  "legacy_guid": "create-provider-config-fails-when-clicking-configuration-required-2025-06-26"
+}

--- a/.github/issue-updates/94e8aa13-967d-41ac-9bf1-d46177a6938f.json
+++ b/.github/issue-updates/94e8aa13-967d-41ac-9bf1-d46177a6938f.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Provider config dialog fails to load",
+  "body": "Error when opening provider config: 'b is not a function'. Use apiService for fetching available providers and handle errors gracefully.",
+  "labels": ["bug", "codex"],
+  "guid": "c515ad5e-8d97-417e-9561-a9482f25f066",
+  "legacy_guid": "create-provider-config-dialog-fails-to-load-2025-06-24"
+}

--- a/webui/src/components/ProviderConfigDialog.jsx
+++ b/webui/src/components/ProviderConfigDialog.jsx
@@ -17,6 +17,7 @@ import {
   Switch,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
+import { apiService } from '../services/api.js';
 
 /**
  * Fixed ProviderConfigDialog with proper provider selection and configuration options
@@ -38,23 +39,30 @@ export default function ProviderConfigDialog({
 
   // Load available providers when dialog opens
   useEffect(() => {
-    if (open && !provider) {
-      loadAvailableProviders();
-    } else if (provider) {
+    if (!open) return;
+
+    if (provider) {
       setSelectedProvider(provider.name);
       setConfig(provider.config || {});
+    } else {
+      setSelectedProvider('');
+      setConfig({});
+      loadAvailableProviders();
     }
   }, [open, provider]);
 
   const loadAvailableProviders = async () => {
     try {
-      const response = await fetch('/api/providers/available');
+      const response = await apiService.get('/api/providers/available');
       if (response.ok) {
         const providers = await response.json();
         setAvailableProviders(providers);
+      } else {
+        setAvailableProviders([]);
       }
     } catch (error) {
       console.error('Failed to load available providers:', error);
+      setAvailableProviders([]);
     }
   };
 


### PR DESCRIPTION
## Description
Reset provider configuration dialog when no provider is preselected and log the related bug.

## Motivation
Prevents stale selections that led to runtime errors and ensures the issue is tracked.

## Changes
- reset provider selection and configuration on open
- fetch providers via `apiService` with better error handling
- add GitHub issue update file

## Testing
- `npm run lint` *(fails: @eslint/js not found)*
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859d72756ec8321bd5da7dd25a6b606