### PR TITLE
Add whisper docker integration test

### DIFF
--- a/.github/issue-updates/5830dfca-fc76-4fbb-a0f1-5c7b75c20d67.json
+++ b/.github/issue-updates/5830dfca-fc76-4fbb-a0f1-5c7b75c20d67.json
@@ -1,0 +1,7 @@
+{
+  "action": "close",
+  "number": 0,
+  "state_reason": "completed",
+  "guid": "920f820b-c0c7-40a0-9f4f-7f7fba515e1a",
+  "legacy_guid": "close-issue-0-2025-06-26"
+}

--- a/.github/issue-updates/78d2ed34-ae4c-49c3-9ab8-b6c4cb858f85.json
+++ b/.github/issue-updates/78d2ed34-ae4c-49c3-9ab8-b6c4cb858f85.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 0,
+  "body": "Implemented docker-init test verifying Whisper container launches and env vars exported",
+  "guid": "038a8e85-f1ca-4768-9dbe-54e88728a59d",
+  "legacy_guid": "comment-issue-0-2025-06-26"
+}

--- a/docker_init_test.go
+++ b/docker_init_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDockerInitWhisper verifies docker-init.sh launches a whisper container
+// and exports expected environment variables when ENABLE_WHISPER=1.
+func TestDockerInitWhisper(t *testing.T) {
+	tmp := t.TempDir()
+	dockerLog := filepath.Join(tmp, "docker.log")
+	envFile := filepath.Join(tmp, "env.txt")
+
+	// stub docker binary
+	dockerBin := filepath.Join(tmp, "docker")
+	if err := os.WriteFile(dockerBin, []byte("#!/bin/sh\necho \"$@\" >>$DOCKER_LOG\n[ \"$1\" = ps ] && exit 0\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+
+	// install subtitle-manager stub to /usr/local/bin
+	smBin := "/usr/local/bin/subtitle-manager"
+	if err := os.WriteFile(smBin, []byte("#!/bin/sh\nenv >$ENV_FILE\n"), 0755); err != nil {
+		t.Fatalf("install subtitle-manager stub: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(smBin) })
+
+	env := append(os.Environ(),
+		"PATH="+tmp+":"+os.Getenv("PATH"),
+		"DOCKER_LOG="+dockerLog,
+		"ENV_FILE="+envFile,
+		"ENABLE_WHISPER=1",
+		"WHISPER_CONTAINER_NAME=test-whisper",
+		"WHISPER_PORT=12345",
+		"WHISPER_DEVICE=cpu",
+	)
+
+	cmd := exec.Command("sh", "docker-init.sh")
+	cmd.Env = env
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker-init: %v\n%s", err, string(out))
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	envContent := string(data)
+	if !strings.Contains(envContent, "SM_PROVIDERS_WHISPER_API_URL=http://localhost:12345") {
+		t.Fatalf("missing whisper url: %s", envContent)
+	}
+	if !strings.Contains(envContent, "SM_OPENAI_API_URL=http://localhost:12345/v1") {
+		t.Fatalf("missing openai url: %s", envContent)
+	}
+
+	logData, err := os.ReadFile(dockerLog)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	if !strings.Contains(string(logData), "run -d --name test-whisper") {
+		t.Fatalf("docker run not executed: %s", string(logData))
+	}
+}


### PR DESCRIPTION
## Description
Add integration test for `docker-init.sh` verifying Whisper container startup and environment variable exports. Includes issue updates documenting completion.

## Motivation
Ensures the optional Whisper container is launched correctly when `ENABLE_WHISPER=1` and that configuration variables are set.

## Changes
- create `docker_init_test.go` with stubbed docker and subtitle-manager binaries
- add issue updates to comment and close related task

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685db09cb2108321ba50367484b5dd71