### PR TITLE
Fix local dependencies for issue workflow

### DIFF
--- a/.github/issue-updates/d92fa4b1-ae1a-430e-96e7-a34f370a92f1.json
+++ b/.github/issue-updates/d92fa4b1-ae1a-430e-96e7-a34f370a92f1.json
@@ -1,0 +1,12 @@
+{
+  "action": "create",
+  "title": "Workflow fails to fetch requirements.txt",
+  "body": "Unified issue management fails because it tries to fetch requirements.txt from ghcommon, but that file is missing. Blocked by ghcommon issue \"Add missing requirements.txt for workflow\".",
+  "labels": [
+    "bug",
+    "codex",
+    "dependency"
+  ],
+  "guid": "3468a582-ec80-4ea9-a2ba-835e8db4cc97",
+  "legacy_guid": "create-workflow-fails-to-fetch-requirements-txt-2025-06-26"
+}

--- a/.github/issue-updates/fbfc0da4-2369-4ddb-b5e9-d1fd628fbb67.json
+++ b/.github/issue-updates/fbfc0da4-2369-4ddb-b5e9-d1fd628fbb67.json
@@ -1,0 +1,11 @@
+{
+  "action": "create",
+  "title": "Add missing requirements.txt for workflow",
+  "body": "The unified issue management workflow downloads requirements.txt from ghcommon but the file is missing. Please add the file or update the script. The script should also allow creating tickets in other repositories.",
+  "labels": [
+    "bug",
+    "codex"
+  ],
+  "guid": "9bbb720d-6c5b-45af-9b7c-a8f4bc1f9397",
+  "legacy_guid": "create-add-missing-requirements-txt-for-workflow-2025-06-26"
+}

--- a/.github/workflows/unified-issue-management.yml
+++ b/.github/workflows/unified-issue-management.yml
@@ -65,7 +65,7 @@ permissions:
 jobs:
   # Use the centralized reusable workflow from ghcommon
   issue-management:
-    uses: jdfalk/ghcommon/.github/workflows/unified-issue-management.yml@main
+    uses: jdfalk/ghcommon/.github/workflows/unified-issue-management.yml
     with:
       operations: ${{ github.event.inputs.operations || 'auto' }}
       dry_run: ${{ github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
## Description
Reverts to the centralized unified issue management workflow and files issues for the missing requirements error.

## Motivation
The previous commit replaced the remote workflow with a local copy. The centralized script is preferred even though it currently fails due to a missing `requirements.txt` file.

## Changes
- Restored reference to ghcommon reusable workflow
- Removed the local `universal-version-management.yml`
- Added issue updates describing the missing file problem and linking this repo to the ghcommon fix

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685dade05cf48321ae4c9d779ceb81f9