### PR TITLE
Implement Referrer-Policy header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Experimental minimum display time mode that delays subtitles and catches up during silence.
 - Automatic subtitle upgrade detection avoids replacing smaller files.
 - Dashboard Widgets API exposing available widgets and layout endpoints.
+- Security header `Referrer-Policy: no-referrer` to reduce referrer leakage.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Additional references include [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md)
 
 ## Security
 
-Subtitle Manager applies strict security headers and sanitizes HTML content in the web interface using DOMPurify. When contributing UI or API code, ensure all user-provided data is properly validated and sanitized.
+Subtitle Manager applies strict security headers, including `Referrer-Policy: no-referrer`, and sanitizes HTML content in the web interface using DOMPurify. When contributing UI or API code, ensure all user-provided data is properly validated and sanitized.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -159,7 +159,7 @@ Current tag implementations will be migrated to the unified system:
 
 ### Security Enhancements
 
-- [ ] **[nitpick] Consider adding a Referrer-Policy header** (e.g., no-referrer or strict-origin-when-cross-origin) to enhance privacy and reduce referrer leakage
+- [x] **[nitpick] Add a Referrer-Policy header** (`no-referrer`) to enhance privacy and reduce referrer leakage
 
 ### Development Tools
 

--- a/pkg/webserver/security.go
+++ b/pkg/webserver/security.go
@@ -11,6 +11,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Referrer-Policy", "no-referrer")
 
 		// Content Security Policy that allows:
 		// - Self-hosted content (scripts, styles, images, etc.)

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -873,7 +873,7 @@ func TestSecurityHeaders(t *testing.T) {
 	resp := testutil.MustGet(t, "request", func() (*http.Response, error) { return srv.Client().Do(req) })
 
 	headers := resp.Header
-	for _, name := range []string{"X-Frame-Options", "X-Content-Type-Options", "Content-Security-Policy", "Strict-Transport-Security"} {
+	for _, name := range []string{"X-Frame-Options", "X-Content-Type-Options", "Content-Security-Policy", "Strict-Transport-Security", "Referrer-Policy"} {
 		if headers.Get(name) == "" {
 			t.Fatalf("%s header missing", name)
 		}


### PR DESCRIPTION
## Description
Adds a `Referrer-Policy: no-referrer` header to all HTTP responses and updates tests and documentation accordingly.

## Motivation
Strengthens privacy by preventing referrer leakage as noted in TODO.md.

## Changes
- Set `Referrer-Policy` header in `securityHeadersMiddleware`
- Validate new header in `TestSecurityHeaders`
- Document header in README and CHANGELOG
- Mark TODO item as complete

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685db4fdb2cc83219772b45847f365cb