### PR TITLE
Add history video filter

### DIFF
--- a/.github/issue-updates/f9f7b33f-f952-4f25-b3d3-0328da1ee63f.json
+++ b/.github/issue-updates/f9f7b33f-f952-4f25-b3d3-0328da1ee63f.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add video file filter to history API",
+  "body": "Extend /api/history to filter translation and download history by video file path. Provide database helpers and tests.",
+  "labels": ["enhancement", "api"],
+  "guid": "9230b988-bf02-44ac-afc1-cf118c5bbd44",
+  "legacy_guid": "create-add-video-file-filter-to-history-api-2025-06-26"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Automatic subtitle upgrade detection avoids replacing smaller files.
 - Dashboard Widgets API exposing available widgets and layout endpoints.
 - Security header `Referrer-Policy: no-referrer` to reduce referrer leakage.
+- History API now filters by video file path via `video` query parameter.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Convert subtitles from many formats to SRT.
 - Merge two subtitle tracks sorted by start time.
 - Translate subtitles via Google Translate or ChatGPT APIs.
-- Store translation history in SQLite, PebbleDB or PostgreSQL databases. Retrieve history via the `history` command or `/api/history` endpoint.
+- Store translation history in SQLite, PebbleDB or PostgreSQL databases. Retrieve history via the `history` command or `/api/history` endpoint with optional `lang` and `video` filters.
 - Per component logging with adjustable levels.
 - Extract subtitles from media containers using ffmpeg.
 - Convert uploaded subtitle files to SRT via `/api/convert`.
@@ -45,7 +45,7 @@ Subtitle Manager is a comprehensive subtitle management application written in G
 - Run a translation gRPC server.
 - Translate uploaded subtitles through `/api/translate` endpoint.
 - Delete subtitle files and remove history records.
-- Track subtitle download history and list with `downloads` command or `/api/history`.
+- Track subtitle download history and list with `downloads` command or `/api/history` using `lang` and `video` filters.
 - GitHub OAuth2 login enabled via `/api/oauth/github` endpoints.
 - Manually search for subtitles with `search` command.
 - Provider registry simplifies adding new sources.
@@ -339,7 +339,7 @@ The web server exposes a comprehensive REST API for all subtitle operations:
 
 #### History and Monitoring
 
-- `GET /api/history` - Retrieve translation and download history
+- `GET /api/history` - Retrieve translation and download history. Supports `lang` and `video` query parameters for filtering.
 - `GET /api/logs` - Get recent log entries
 - `GET /api/system` - System information (Go version, OS, architecture, goroutines)
 - `GET /api/tasks` - Current task status and progress
@@ -701,7 +701,7 @@ make proto-gen
 The generated files live in `pkg/translatorpb` and should be committed with your
 changes.
 
-The project is **mostly feature complete** with full Bazarr parity as the target. Remaining work includes a flexible tagging system and automated maintenance tasks. See `TODO.md` for details.
+The project is **mostly feature complete** with full Bazarr parity as the target. Remaining work focuses on Sonarr/Radarr sync improvements and the metadata editor. See `TODO.md` for details.
 Extensive architectural details and design decisions are documented in `docs/TECHNICAL_DESIGN.md`. For a package-by-package function reference see `docs/COMPLETE_DESIGN.md`. New contributors should review these documents to understand package responsibilities and completed features.
 For a detailed list of Bazarr features used as the parity target, see [docs/BAZARR_FEATURES.md](docs/BAZARR_FEATURES.md).
 Instructions for importing an existing Bazarr configuration are documented in [docs/BAZARR_SETTINGS_SYNC.md](docs/BAZARR_SETTINGS_SYNC.md).

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ This file tracks remaining work and implementation status for Subtitle Manager. 
 - [ ] **Media Metadata Editor**: Provide manual editing interface.
   - [ ] Allow manual metadata search and selection during import.
   - [ ] Store alternate titles for improved subtitle matching.
-  - [ ] Track release group and subtitle history per file.
+  - [x] Track release group and subtitle history per file via `/api/history?video=`.
   - [ ] Support field-level locks to prevent unwanted updates.
 
 ### Universal Tagging System Implementation

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -326,6 +326,26 @@ func (s *SQLStore) ListDownloads() ([]DownloadRecord, error) {
 	return recs, rows.Err()
 }
 
+// ListDownloadsByVideo retrieves download history for a specific video file.
+func (s *SQLStore) ListDownloadsByVideo(video string) ([]DownloadRecord, error) {
+	rows, err := s.db.Query(`SELECT id, file, video_file, provider, language, created_at FROM downloads WHERE video_file = ? ORDER BY id DESC`, video)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []DownloadRecord
+	for rows.Next() {
+		var r DownloadRecord
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Provider, &r.Language, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
 // DeleteDownload removes download records matching file from the database.
 func (s *SQLStore) DeleteDownload(file string) error {
 	_, err := s.db.Exec(`DELETE FROM downloads WHERE file = ?`, file)
@@ -348,6 +368,26 @@ func InsertDownload(db *sql.DB, file, video, provider, lang string) error {
 // ListDownloads retrieves download records using a raw *sql.DB.
 func ListDownloads(db *sql.DB) ([]DownloadRecord, error) {
 	rows, err := db.Query(`SELECT id, file, video_file, provider, language, created_at FROM downloads ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []DownloadRecord
+	for rows.Next() {
+		var r DownloadRecord
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Provider, &r.Language, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
+// ListDownloadsByVideo retrieves download history for a specific video file using a raw *sql.DB.
+func ListDownloadsByVideo(db *sql.DB, video string) ([]DownloadRecord, error) {
+	rows, err := db.Query(`SELECT id, file, video_file, provider, language, created_at FROM downloads WHERE video_file = ? ORDER BY id DESC`, video)
 	if err != nil {
 		return nil, err
 	}
@@ -496,6 +536,28 @@ func (s *SQLStore) ListSubtitles() ([]SubtitleRecord, error) {
 	return recs, rows.Err()
 }
 
+// ListSubtitlesByVideo retrieves subtitle history for a specific video file.
+func (s *SQLStore) ListSubtitlesByVideo(video string) ([]SubtitleRecord, error) {
+	rows, err := s.db.Query(`SELECT id, file, video_file, release, language, service, embedded, created_at FROM subtitles WHERE video_file = ? ORDER BY id DESC`, video)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []SubtitleRecord
+	for rows.Next() {
+		var r SubtitleRecord
+		var embedded int
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Release, &r.Language, &r.Service, &embedded, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		r.Embedded = embedded == 1
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
 // DeleteSubtitle removes subtitle records matching file from the database.
 func (s *SQLStore) DeleteSubtitle(file string) error {
 	_, err := s.db.Exec(`DELETE FROM subtitles WHERE file = ?`, file)
@@ -516,6 +578,28 @@ func ListSubtitles(db *sql.DB) ([]SubtitleRecord, error) {
 	}
 	defer rows.Close()
 
+	var recs []SubtitleRecord
+	for rows.Next() {
+		var r SubtitleRecord
+		var embedded int
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Release, &r.Language, &r.Service, &embedded, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		r.Embedded = embedded == 1
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
+// ListSubtitlesByVideo retrieves subtitle records for a specific video file using a raw *sql.DB.
+func ListSubtitlesByVideo(db *sql.DB, video string) ([]SubtitleRecord, error) {
+	rows, err := db.Query(`SELECT id, file, video_file, release, language, service, embedded, created_at FROM subtitles WHERE video_file = ? ORDER BY id DESC`, video)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 	var recs []SubtitleRecord
 	for rows.Next() {
 		var r SubtitleRecord

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -76,6 +76,23 @@ func TestDownloadHistory(t *testing.T) {
 	}
 }
 
+func TestHistoryByVideo(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_ = InsertSubtitle(db, "a.srt", "a.mkv", "en", "g", "", false)
+	_ = InsertSubtitle(db, "b.srt", "b.mkv", "en", "g", "", false)
+	recs, err := ListSubtitlesByVideo(db, "b.mkv")
+	if err != nil {
+		t.Fatalf("list by video: %v", err)
+	}
+	if len(recs) != 1 || recs[0].VideoFile != "b.mkv" {
+		t.Fatalf("unexpected result %+v", recs)
+	}
+}
+
 func TestMediaItems(t *testing.T) {
 	db, err := Open(":memory:")
 	if err != nil {

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -107,6 +107,21 @@ func (p *PebbleStore) ListSubtitles() ([]SubtitleRecord, error) {
 	return recs, nil
 }
 
+// ListSubtitlesByVideo filters subtitle records by video file path.
+func (p *PebbleStore) ListSubtitlesByVideo(video string) ([]SubtitleRecord, error) {
+	recs, err := p.ListSubtitles()
+	if err != nil {
+		return nil, err
+	}
+	out := recs[:0]
+	for _, r := range recs {
+		if r.VideoFile == video {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 // DeleteSubtitle removes all records matching file from the store.
 func (p *PebbleStore) DeleteSubtitle(file string) error {
 	iter, err := p.db.NewIter(nil)
@@ -173,6 +188,21 @@ func (p *PebbleStore) ListDownloads() ([]DownloadRecord, error) {
 		return recs[i].CreatedAt.After(recs[j].CreatedAt)
 	})
 	return recs, nil
+}
+
+// ListDownloadsByVideo filters download records by video file path.
+func (p *PebbleStore) ListDownloadsByVideo(video string) ([]DownloadRecord, error) {
+	recs, err := p.ListDownloads()
+	if err != nil {
+		return nil, err
+	}
+	out := recs[:0]
+	for _, r := range recs {
+		if r.VideoFile == video {
+			out = append(out, r)
+		}
+	}
+	return out, nil
 }
 
 // DeleteDownload removes download records for the given subtitle file.

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -103,6 +103,26 @@ func (p *PostgresStore) ListSubtitles() ([]SubtitleRecord, error) {
 	return recs, rows.Err()
 }
 
+// ListSubtitlesByVideo retrieves subtitle records for a specific video file.
+func (p *PostgresStore) ListSubtitlesByVideo(video string) ([]SubtitleRecord, error) {
+	rows, err := p.db.Query(`SELECT id, file, video_file, release, language, service, embedded, created_at FROM subtitles WHERE video_file = $1 ORDER BY id DESC`, video)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []SubtitleRecord
+	for rows.Next() {
+		var r SubtitleRecord
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Release, &r.Language, &r.Service, &r.Embedded, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
 // DeleteSubtitle removes subtitle records matching file.
 func (p *PostgresStore) DeleteSubtitle(file string) error {
 	_, err := p.db.Exec(`DELETE FROM subtitles WHERE file = $1`, file)
@@ -119,6 +139,26 @@ func (p *PostgresStore) InsertDownload(rec *DownloadRecord) error {
 // ListDownloads retrieves download records ordered by most recent.
 func (p *PostgresStore) ListDownloads() ([]DownloadRecord, error) {
 	rows, err := p.db.Query(`SELECT id, file, video_file, provider, language, created_at FROM downloads ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []DownloadRecord
+	for rows.Next() {
+		var r DownloadRecord
+		var id int64
+		if err := rows.Scan(&id, &r.File, &r.VideoFile, &r.Provider, &r.Language, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.ID = strconv.FormatInt(id, 10)
+		recs = append(recs, r)
+	}
+	return recs, rows.Err()
+}
+
+// ListDownloadsByVideo retrieves download records for a specific video file.
+func (p *PostgresStore) ListDownloadsByVideo(video string) ([]DownloadRecord, error) {
+	rows, err := p.db.Query(`SELECT id, file, video_file, provider, language, created_at FROM downloads WHERE video_file = $1 ORDER BY id DESC`, video)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -6,6 +6,8 @@ type SubtitleStore interface {
 	InsertSubtitle(rec *SubtitleRecord) error
 	// ListSubtitles retrieves all subtitle records sorted by creation time.
 	ListSubtitles() ([]SubtitleRecord, error)
+	// ListSubtitlesByVideo returns subtitle records for a video file.
+	ListSubtitlesByVideo(video string) ([]SubtitleRecord, error)
 	// CountSubtitles returns the total number of subtitle records.
 	CountSubtitles() (int, error)
 	// DeleteSubtitle removes all records for the specified file.
@@ -14,6 +16,8 @@ type SubtitleStore interface {
 	InsertDownload(rec *DownloadRecord) error
 	// ListDownloads retrieves all download records sorted by creation time.
 	ListDownloads() ([]DownloadRecord, error)
+	// ListDownloadsByVideo returns download records for a video file.
+	ListDownloadsByVideo(video string) ([]DownloadRecord, error)
 	// CountDownloads returns the total number of download records.
 	CountDownloads() (int, error)
 	// DeleteDownload removes download records for the specified subtitle file.

--- a/pkg/webserver/history.go
+++ b/pkg/webserver/history.go
@@ -22,12 +22,24 @@ func historyHandler(db *sql.DB) http.Handler {
 			return
 		}
 		lang := r.URL.Query().Get("lang")
-		subs, err := database.ListSubtitles(db)
+		video := r.URL.Query().Get("video")
+		var subs []database.SubtitleRecord
+		var downloads []database.DownloadRecord
+		var err error
+		if video != "" {
+			subs, err = database.ListSubtitlesByVideo(db, video)
+		} else {
+			subs, err = database.ListSubtitles(db)
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		downloads, err := database.ListDownloads(db)
+		if video != "" {
+			downloads, err = database.ListDownloadsByVideo(db, video)
+		} else {
+			downloads, err = database.ListDownloads(db)
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Description
Adds ability to filter translation and download history by video file via `video` query parameter. Database helpers and store interface are extended, along with updated web server handler and tests.

## Motivation
Provides more granular history tracking requested in issue. Enables users to inspect subtitle actions per media file.

## Changes
- Added `ListSubtitlesByVideo` and `ListDownloadsByVideo` database functions
- Updated `SubtitleStore` interface and all backends
- Extended `/api/history` handler and tests
- Documented new option and updated project status

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685db73303b0832192a4fa6a86758b35