### PR TITLE
Fix eslint warnings in scan poller

### DIFF
--- a/.github/issue-updates/185014a3-8b0f-4057-b7bf-12432d29e2de.json
+++ b/.github/issue-updates/185014a3-8b0f-4057-b7bf-12432d29e2de.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Fix lint errors in LibraryScan and NotificationSettings",
+  "body": "ESLint flagged unused variables in the poller and notification components. Use these variables so lint passes.",
+  "labels": ["codex"],
+  "guid": "d43397b6-b186-4f9e-8534-ee1a7962495d",
+  "legacy_guid": "create-fix-lint-errors-in-libraryscan-and-notificationsettings-2025-06-28"
+}

--- a/webui/src/LibraryScan.jsx
+++ b/webui/src/LibraryScan.jsx
@@ -45,6 +45,8 @@ export default function LibraryScan({ backendAvailable = true }) {
         }
       }
     } catch (err) {
+      // Log poll failure before notifying user
+      console.error(err);
       setError('Failed to get scan status');
     }
   };

--- a/webui/src/components/NotificationSettings.jsx
+++ b/webui/src/components/NotificationSettings.jsx
@@ -250,6 +250,13 @@ export default function NotificationSettings({
         </Alert>
       )}
 
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
+          {/* Display backend error from notification update */}
+          {error}
+        </Alert>
+      )}
+
       <Grid container spacing={3}>
         {/* Email Notifications */}
         <Grid item xs={12} md={6}>


### PR DESCRIPTION
## Description
Resolve eslint no-unused-vars errors for the library scan poller and notification settings.

## Motivation
Lint failures broke CI runs and obscured real issues.

## Changes
- log poller errors before setting UI state
- surface backend notification errors in UI
- open GitHub issue for ESLint cleanup

## Testing
- `npm run lint --prefix webui`
- `go test ./...`
- `npm run test --prefix webui` *(fails: 4 failed, 37 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ec53f5b5c832190357c2562b5af9a