### PR TITLE
Clarify workflow requirements resolution

### DIFF
--- a/.github/issue-updates/338ca4c2-9adc-4aab-aa97-de14ee16136b.json
+++ b/.github/issue-updates/338ca4c2-9adc-4aab-aa97-de14ee16136b.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 1249,
+  "body": "The missing requirements file has been added to the ghcommon repository. This resolves the failure in the unified issue management workflow.",
+  "guid": "338ca4c2-9adc-4aab-aa97-de14ee16136b",
+  "legacy_guid": "comment-issue-1249-2025-07-03"
+}

--- a/.github/issue-updates/38ccf004-fb3a-44fb-af8d-3d1ecd87a9e4.json
+++ b/.github/issue-updates/38ccf004-fb3a-44fb-af8d-3d1ecd87a9e4.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 1251,
+  "body": "The missing requirements file has been added to the ghcommon repository. This resolves the workflow setup issue.",
+  "guid": "38ccf004-fb3a-44fb-af8d-3d1ecd87a9e4",
+  "legacy_guid": "comment-issue-1251-2025-07-03"
+}

--- a/.github/issue-updates/84224f2a-8111-4ba9-944c-1c945dedd8b4.json
+++ b/.github/issue-updates/84224f2a-8111-4ba9-944c-1c945dedd8b4.json
@@ -1,0 +1,7 @@
+{
+  "action": "close",
+  "number": 1249,
+  "state_reason": "completed",
+  "guid": "84224f2a-8111-4ba9-944c-1c945dedd8b4",
+  "legacy_guid": "close-issue-1249-2025-07-03"
+}

--- a/.github/issue-updates/95b317fe-ee56-4bd5-a602-c0fa7570e231.json
+++ b/.github/issue-updates/95b317fe-ee56-4bd5-a602-c0fa7570e231.json
@@ -1,0 +1,7 @@
+{
+  "action": "close",
+  "number": 1251,
+  "state_reason": "completed",
+  "guid": "95b317fe-ee56-4bd5-a602-c0fa7570e231",
+  "legacy_guid": "close-issue-1251-2025-07-03"
+}

--- a/README.md
+++ b/README.md
@@ -887,6 +887,8 @@ To bypass any hook temporarily, use `git commit --no-verify`.
 
 **Legacy Support**: Pushing an `issue_updates.json` file to the repository root still works for backward compatibility. The unified issue management workflow processes both formats.
 
+Note: If the unified issue management workflow fails due to a missing `requirements.txt` file, update to the latest version of [ghcommon](https://github.com/jdfalk/ghcommon) which now provides this file. This resolves issues #1249 and #1251.
+
 The new format uses individual files with this structure:
 \```json
 {


### PR DESCRIPTION
## Description
Document that the reusable workflow's requirements.txt now lives in ghcommon and that this resolves the previous failures.

## Motivation
Developers were unsure why the unified issue management workflow failed. The README note clarifies the fix and points to the ghcommon repository.

## Changes
- Mention issues #1249 and #1251 in the README note
- Add comment update for issue #1251
- Close issue #1251 as completed

## Testing
- `go test ./...` *(fails: undefined profiles.DefaultLanguageProfile)*

## Related Issues
Fixes #1249
Closes #1251

------
https://chatgpt.com/codex/tasks/task_e_686573bcb23483219d9abf7ca9742da3