### PR TITLE
Add registry and version tests

### DIFF
--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSetGetVersionInfo(t *testing.T) {
+	SetVersionInfo("1.2.3", "2024-01-02", "abcdef")
+	v, _, _ := GetVersionInfo()
+	if v != "1.2.3" {
+		t.Fatalf("unexpected version %q", v)
+	}
+}
+
+func TestPrintVersion(t *testing.T) {
+	SetVersionInfo("1.2.3", "2024-01-02", "abcdef")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	printVersion()
+	w.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "Subtitle Manager 1.2.3") {
+		t.Errorf("version missing: %s", s)
+	}
+	if !strings.Contains(s, "Build Time: 2024-01-02") {
+		t.Errorf("build time missing: %s", s)
+	}
+	if !strings.Contains(s, "Git Commit: abcdef") {
+		t.Errorf("commit missing: %s", s)
+	}
+	if !strings.Contains(s, runtime.Version()) {
+		t.Errorf("runtime missing: %s", s)
+	}
+}

--- a/pkg/providers/registry_test.go
+++ b/pkg/providers/registry_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+)
+
+func TestRegisterFactoryAndGet(t *testing.T) {
+	p := &mocks.Provider{}
+	RegisterFactory("mockreg", func() Provider { return p })
+	t.Cleanup(func() { delete(factories, "mockreg") })
+
+	got, err := Get("mockreg", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != p {
+		t.Fatalf("unexpected provider %+v", got)
+	}
+}
+
+func TestGetUnknownProvider(t *testing.T) {
+	if _, err := Get("unknown-provider", ""); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestAllIncludesRegisteredSorted(t *testing.T) {
+	base := All()
+	RegisterFactory("mocka", func() Provider { return nil })
+	RegisterFactory("mockz", func() Provider { return nil })
+	t.Cleanup(func() { delete(factories, "mocka"); delete(factories, "mockz") })
+
+	names := All()
+	if len(names) != len(base)+2 {
+		t.Fatalf("expected %d names, got %d", len(base)+2, len(names))
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Fatal("names not sorted")
+	}
+	foundA := false
+	foundZ := false
+	for _, n := range names {
+		if n == "mocka" {
+			foundA = true
+		}
+		if n == "mockz" {
+			foundZ = true
+		}
+	}
+	if !foundA || !foundZ {
+		t.Fatalf("registered names missing: %v", names)
+	}
+}


### PR DESCRIPTION
## Description
Add unit tests for provider registry functions and CLI version commands to improve coverage.

## Motivation
Provider registry operations and version info helpers lacked tests. Adding tests ensures stability for these components.

## Changes
- Added provider registry tests covering factory registration, retrieval, and listing
- Added CLI version command tests for SetVersionInfo and printVersion

## Testing
- `go test ./...`

## Related Issues
Fixes #1328

------
https://chatgpt.com/codex/tasks/task_e_6865f71718308321a946e952bfba35d4