### PR TITLE
Fix cache backend default

### DIFF
--- a/.github/issue-updates/e016cfa6-0ecf-4c5c-9876-fe015ceecc71.json
+++ b/.github/issue-updates/e016cfa6-0ecf-4c5c-9876-fe015ceecc71.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Fix default cache backend",
+  "body": "Set default cache backend to memory if not configured.",
+  "labels": ["bug", "codex"],
+  "guid": "e016cfa6-0ecf-4c5c-9876-fe015ceecc71",
+  "legacy_guid": "create-fix-default-cache-backend-2025-07-03"
+}

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -18,6 +18,9 @@ func ConfigFromViper() (*Config, error) {
 
 	// Backend selection
 	config.Backend = viper.GetString("cache.backend")
+	if config.Backend == "" {
+		config.Backend = "memory"
+	}
 
 	// Memory cache configuration
 	config.Memory.MaxEntries = viper.GetInt("cache.memory.max_entries")


### PR DESCRIPTION
## Description
Set default cache backend to `memory` when configuration is missing.

## Motivation
Tests failed because `ConfigFromViper` returned an empty backend value.

## Changes
- default cache backend to `memory` when unset
- add issue update for new bug report

## Testing
- `go test ./...` *(fails: TestSearchHandlerPostValidRequest)*

------
https://chatgpt.com/codex/tasks/task_e_6865cfc99fdc8321b31b9d86b5e16085