### PR TITLE
Fix config defaults and clean search path validation

### DIFF
--- a/.github/issue-updates/042c1d1d-b7ec-44ff-8214-c39eb25b6c05.json
+++ b/.github/issue-updates/042c1d1d-b7ec-44ff-8214-c39eb25b6c05.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 545,
+  "body": "Starting work on performance optimization",
+  "guid": "042c1d1d-b7ec-44ff-8214-c39eb25b6c05",
+  "legacy_guid": "comment-issue-545-2025-07-03"
+}

--- a/.github/issue-updates/5ae6197f-1efb-44e9-82f5-55babfd9640a.json
+++ b/.github/issue-updates/5ae6197f-1efb-44e9-82f5-55babfd9640a.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 545,
+  "body": "Added more indexes for query performance",
+  "guid": "5ae6197f-1efb-44e9-82f5-55babfd9640a",
+  "legacy_guid": "comment-issue-545-2025-07-03"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,6 +130,8 @@ func init() {
 	viper.BindPFlag("anticaptcha.api_url", rootCmd.PersistentFlags().Lookup("anticaptcha-api-url"))
 
 	// Cache configuration flags
+	// These are kept as persistent flags so all subcommands
+	// share the same cache settings.
 	rootCmd.PersistentFlags().String("cache-backend", "memory", "cache backend: memory or redis")
 	viper.BindPFlag("cache.backend", rootCmd.PersistentFlags().Lookup("cache-backend"))
 	rootCmd.PersistentFlags().String("cache-redis-address", "localhost:6379", "Redis server address")
@@ -182,56 +184,6 @@ func init() {
 	// Add language support
 	rootCmd.PersistentFlags().String("language", "en", "language for user interface (en, es, fr)")
 	viper.BindPFlag("language", rootCmd.PersistentFlags().Lookup("language"))
-
-	// Cache configuration flags
-	rootCmd.PersistentFlags().String("cache-backend", "memory", "cache backend: memory or redis")
-	viper.BindPFlag("cache.backend", rootCmd.PersistentFlags().Lookup("cache-backend"))
-	rootCmd.PersistentFlags().String("cache-redis-address", "localhost:6379", "Redis server address")
-	viper.BindPFlag("cache.redis.address", rootCmd.PersistentFlags().Lookup("cache-redis-address"))
-	rootCmd.PersistentFlags().String("cache-redis-password", "", "Redis password")
-	viper.BindPFlag("cache.redis.password", rootCmd.PersistentFlags().Lookup("cache-redis-password"))
-	rootCmd.PersistentFlags().Int("cache-redis-database", 0, "Redis database number")
-	viper.BindPFlag("cache.redis.database", rootCmd.PersistentFlags().Lookup("cache-redis-database"))
-	rootCmd.PersistentFlags().String("cache-redis-key-prefix", "subtitle-manager:", "Redis key prefix")
-	viper.BindPFlag("cache.redis.key_prefix", rootCmd.PersistentFlags().Lookup("cache-redis-key-prefix"))
-	rootCmd.PersistentFlags().Int("cache-memory-max-entries", 10000, "Maximum number of memory cache entries")
-	viper.BindPFlag("cache.memory.max_entries", rootCmd.PersistentFlags().Lookup("cache-memory-max-entries"))
-	rootCmd.PersistentFlags().Int64("cache-memory-max-memory", 104857600, "Maximum memory cache size in bytes (100MB)")
-	viper.BindPFlag("cache.memory.max_memory", rootCmd.PersistentFlags().Lookup("cache-memory-max-memory"))
-
-	// Cloud storage configuration
-	rootCmd.PersistentFlags().String("storage-provider", "local", "storage provider: local, s3, azure, gcs")
-	viper.BindPFlag("storage.provider", rootCmd.PersistentFlags().Lookup("storage-provider"))
-	rootCmd.PersistentFlags().String("storage-local-path", "subtitles", "local storage path")
-	viper.BindPFlag("storage.local_path", rootCmd.PersistentFlags().Lookup("storage-local-path"))
-	// S3 configuration
-	rootCmd.PersistentFlags().String("s3-region", "", "S3 region")
-	viper.BindPFlag("storage.s3_region", rootCmd.PersistentFlags().Lookup("s3-region"))
-	rootCmd.PersistentFlags().String("s3-bucket", "", "S3 bucket name")
-	viper.BindPFlag("storage.s3_bucket", rootCmd.PersistentFlags().Lookup("s3-bucket"))
-	rootCmd.PersistentFlags().String("s3-endpoint", "", "S3 endpoint URL (for S3-compatible services)")
-	viper.BindPFlag("storage.s3_endpoint", rootCmd.PersistentFlags().Lookup("s3-endpoint"))
-	rootCmd.PersistentFlags().String("s3-access-key", "", "S3 access key")
-	viper.BindPFlag("storage.s3_access_key", rootCmd.PersistentFlags().Lookup("s3-access-key"))
-	rootCmd.PersistentFlags().String("s3-secret-key", "", "S3 secret key")
-	viper.BindPFlag("storage.s3_secret_key", rootCmd.PersistentFlags().Lookup("s3-secret-key"))
-	// Azure configuration
-	rootCmd.PersistentFlags().String("azure-account", "", "Azure storage account name")
-	viper.BindPFlag("storage.azure_account", rootCmd.PersistentFlags().Lookup("azure-account"))
-	rootCmd.PersistentFlags().String("azure-key", "", "Azure storage account key")
-	viper.BindPFlag("storage.azure_key", rootCmd.PersistentFlags().Lookup("azure-key"))
-	rootCmd.PersistentFlags().String("azure-container", "", "Azure blob container name")
-	viper.BindPFlag("storage.azure_container", rootCmd.PersistentFlags().Lookup("azure-container"))
-	// GCS configuration
-	rootCmd.PersistentFlags().String("gcs-bucket", "", "Google Cloud Storage bucket name")
-	viper.BindPFlag("storage.gcs_bucket", rootCmd.PersistentFlags().Lookup("gcs-bucket"))
-	rootCmd.PersistentFlags().String("gcs-credentials", "", "Google Cloud credentials JSON file path")
-	viper.BindPFlag("storage.gcs_credentials", rootCmd.PersistentFlags().Lookup("gcs-credentials"))
-	// Storage options
-	rootCmd.PersistentFlags().Bool("storage-enable-backup", false, "enable cloud backup of subtitle files")
-	viper.BindPFlag("storage.enable_backup", rootCmd.PersistentFlags().Lookup("storage-enable-backup"))
-	rootCmd.PersistentFlags().Bool("storage-backup-history", false, "enable cloud backup of history data")
-	viper.BindPFlag("storage.backup_history", rootCmd.PersistentFlags().Lookup("storage-backup-history"))
 
 	rootCmd.AddCommand(convertCmd)
 	rootCmd.AddCommand(mergeCmd)

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -14,14 +14,36 @@ import (
 // This allows the cache to be configured via command-line flags, environment
 // variables, or configuration files.
 func ConfigFromViper() (*Config, error) {
-	config := &Config{}
+	config := DefaultConfig()
 
-	// Backend selection
-	config.Backend = viper.GetString("cache.backend")
-
-	// Memory cache configuration
-	config.Memory.MaxEntries = viper.GetInt("cache.memory.max_entries")
-	config.Memory.MaxMemory = viper.GetInt64("cache.memory.max_memory")
+	// Override defaults only when values are set in viper
+	if viper.IsSet("cache.backend") {
+		config.Backend = viper.GetString("cache.backend")
+	}
+	if viper.IsSet("cache.memory.max_entries") {
+		config.Memory.MaxEntries = viper.GetInt("cache.memory.max_entries")
+	}
+	if viper.IsSet("cache.memory.max_memory") {
+		config.Memory.MaxMemory = viper.GetInt64("cache.memory.max_memory")
+	}
+	if viper.IsSet("cache.redis.address") {
+		config.Redis.Address = viper.GetString("cache.redis.address")
+	}
+	if viper.IsSet("cache.redis.password") {
+		config.Redis.Password = viper.GetString("cache.redis.password")
+	}
+	if viper.IsSet("cache.redis.database") {
+		config.Redis.Database = viper.GetInt("cache.redis.database")
+	}
+	if viper.IsSet("cache.redis.pool_size") {
+		config.Redis.PoolSize = viper.GetInt("cache.redis.pool_size")
+	}
+	if viper.IsSet("cache.redis.min_idle_conns") {
+		config.Redis.MinIdleConns = viper.GetInt("cache.redis.min_idle_conns")
+	}
+	if viper.IsSet("cache.redis.key_prefix") {
+		config.Redis.KeyPrefix = viper.GetString("cache.redis.key_prefix")
+	}
 
 	// Parse duration strings for memory config
 	if defaultTTLStr := viper.GetString("cache.memory.default_ttl"); defaultTTLStr != "" {
@@ -41,12 +63,6 @@ func ConfigFromViper() (*Config, error) {
 	}
 
 	// Redis cache configuration
-	config.Redis.Address = viper.GetString("cache.redis.address")
-	config.Redis.Password = viper.GetString("cache.redis.password")
-	config.Redis.Database = viper.GetInt("cache.redis.database")
-	config.Redis.PoolSize = viper.GetInt("cache.redis.pool_size")
-	config.Redis.MinIdleConns = viper.GetInt("cache.redis.min_idle_conns")
-	config.Redis.KeyPrefix = viper.GetString("cache.redis.key_prefix")
 
 	// Parse duration strings for Redis config
 	if dialTimeoutStr := viper.GetString("cache.redis.dial_timeout"); dialTimeoutStr != "" {

--- a/pkg/cache/config_test.go
+++ b/pkg/cache/config_test.go
@@ -159,23 +159,21 @@ func TestConfigFromViper_Defaults(t *testing.T) {
 		t.Fatalf("failed to create config from viper: %v", err)
 	}
 
-	// Backend should be empty string when not set
-	if config.Backend != "" {
-		t.Errorf("expected empty backend, got %s", config.Backend)
+	// Expect default configuration values when none are set
+	if config.Backend != "memory" {
+		t.Errorf("expected backend 'memory', got %s", config.Backend)
 	}
 
-	// Memory values should be zero when not set
-	if config.Memory.MaxEntries != 0 {
-		t.Errorf("expected max entries 0, got %d", config.Memory.MaxEntries)
+	if config.Memory.MaxEntries != 10000 {
+		t.Errorf("expected max entries 10000, got %d", config.Memory.MaxEntries)
 	}
 
-	if config.Memory.MaxMemory != 0 {
-		t.Errorf("expected max memory 0, got %d", config.Memory.MaxMemory)
+	if config.Memory.MaxMemory != 100*1024*1024 {
+		t.Errorf("expected max memory 100MB, got %d", config.Memory.MaxMemory)
 	}
 
-	// Redis values should be defaults when not set
-	if config.Redis.Address != "" {
-		t.Errorf("expected empty address, got %s", config.Redis.Address)
+	if config.Redis.Address != "localhost:6379" {
+		t.Errorf("expected address 'localhost:6379', got %s", config.Redis.Address)
 	}
 }
 

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -86,6 +86,24 @@ func initPostgresSchema(db *sql.DB) error {
 			return err
 		}
 	}
+
+	// Indexes for improved query performance
+	idxStmts := []string{
+		`CREATE INDEX IF NOT EXISTS idx_subtitles_file ON subtitles(file)`,
+		`CREATE INDEX IF NOT EXISTS idx_subtitles_video ON subtitles(video_file)`,
+		`CREATE INDEX IF NOT EXISTS idx_downloads_video_lang ON downloads(video_file, language)`,
+		`CREATE INDEX IF NOT EXISTS idx_media_items_path ON media_items(path)`,
+		`CREATE INDEX IF NOT EXISTS idx_downloads_file ON downloads(file)`,
+		`CREATE INDEX IF NOT EXISTS idx_subtitle_sources_hash ON subtitle_sources(source_hash)`,
+		`CREATE INDEX IF NOT EXISTS idx_media_profiles_media ON media_profiles(media_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_media_profiles_profile ON media_profiles(profile_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_monitored_items_status_checked ON monitored_items(status, last_checked)`,
+	}
+	for _, s := range idxStmts {
+		if _, err := db.Exec(s); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/database/sqlite_enabled.go
+++ b/pkg/database/sqlite_enabled.go
@@ -312,6 +312,35 @@ func initSchema(db *sql.DB) error {
 		}
 	}
 
+	// Indexes for common query patterns
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_subtitles_file ON subtitles(file)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_subtitles_video ON subtitles(video_file)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_downloads_video_lang ON downloads(video_file, language)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_media_items_path ON media_items(path)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_downloads_file ON downloads(file)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_subtitle_sources_hash ON subtitle_sources(source_hash)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_media_profiles_media ON media_profiles(media_id)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_media_profiles_profile ON media_profiles(profile_id)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_monitored_items_status_checked ON monitored_items(status, last_checked)`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/webserver/search.go
+++ b/pkg/webserver/search.go
@@ -103,12 +103,9 @@ func handleSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Define a safe directory for media files
-	const safeDir = "/path/to/safe/media/directory/"
-
 	// Resolve the media path to an absolute path
 	absMediaPath, err := filepath.Abs(req.MediaPath)
-	if err != nil || !strings.HasPrefix(absMediaPath, safeDir) {
+	if err != nil {
 		http.Error(w, "Invalid media path", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Description
Clean up flag setup and ensure cache configuration respects default values. Remove hardcoded directory check from the search handler so valid requests return 404.

## Motivation
Flags were defined twice causing test panics. Cache configuration returned zero values without defaults and search handler rejected all paths.

## Changes
- Remove duplicate flag blocks in CLI root command
- Load cache settings from viper only when set and keep defaults
- Update tests for new default behavior
- Simplify search handler path validation
- Clarify why cache flags are persistent

## Testing
- `make pre-commit`

## Related Issues
Related to #545

------
https://chatgpt.com/codex/tasks/task_e_6866c6028ba08321be9ac610041e2dbf