### PR TITLE
Plan gcommon refactor

### DIFF
--- a/.github/issue-updates/025e231d-48b6-4a87-bbe7-c337f2adcbe7.json
+++ b/.github/issue-updates/025e231d-48b6-4a87-bbe7-c337f2adcbe7.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Use gcommon config",
+  "body": "Replace local config loader with gcommon/config and migrate environment variables.",
+  "labels": ["codex", "refactor"],
+  "guid": "025e231d-48b6-4a87-bbe7-c337f2adcbe7",
+  "legacy_guid": "create-use-gcommon-config-2025-07-05"
+}

--- a/.github/issue-updates/0927ae0b-1052-4ef1-b180-e849d2676873.json
+++ b/.github/issue-updates/0927ae0b-1052-4ef1-b180-e849d2676873.json
@@ -1,0 +1,12 @@
+{
+  "action": "create",
+  "title": "gcommon provider metadata",
+  "body": "Propose standard provider metadata fields shared across services.
+
+<!-- GCOMMON ISSUE JSON
+{"action": "create", "title": "Add provider metadata fields", "body": "Define proto messages describing provider information such as rate limits and capabilities for use by Subtitle Manager.", "labels": ["enhancement"]}
+-->",
+  "labels": ["codex", "gcommon"],
+  "guid": "0927ae0b-1052-4ef1-b180-e849d2676873",
+  "legacy_guid": "create-gcommon-provider-metadata-2025-07-05"
+}

--- a/.github/issue-updates/0ce398d3-7d4b-4e2e-847e-a59655059141.json
+++ b/.github/issue-updates/0ce398d3-7d4b-4e2e-847e-a59655059141.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Integrate gcommon modules",
+  "body": "Refactor codebase to use gcommon packages for config, auth, metrics, queue, and health. Replace local implementations and update imports.",
+  "labels": ["refactor"],
+  "guid": "0ce398d3-7d4b-4e2e-847e-a59655059141",
+  "legacy_guid": "create-integrate-gcommon-modules-2025-07-05"
+}

--- a/.github/issue-updates/1a4213e9-266f-4dbf-b937-ff3545b62e94.json
+++ b/.github/issue-updates/1a4213e9-266f-4dbf-b937-ff3545b62e94.json
@@ -1,0 +1,12 @@
+{
+  "action": "create",
+  "title": "gcommon translation protos",
+  "body": "Request translation service proto definitions for cross-repo use.
+
+<!-- GCOMMON ISSUE JSON
+{"action": "create", "title": "Add translation service protos", "body": "Add proto definitions for translation requests and responses used by Subtitle Manager.", "labels": ["enhancement"]}
+-->",
+  "labels": ["codex", "gcommon"],
+  "guid": "1a4213e9-266f-4dbf-b937-ff3545b62e94",
+  "legacy_guid": "create-gcommon-translation-protos-2025-07-05"
+}

--- a/.github/issue-updates/21553fc5-8c51-4d7c-9d33-f1c507900551.json
+++ b/.github/issue-updates/21553fc5-8c51-4d7c-9d33-f1c507900551.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Document queue config",
+  "body": "Add README section for configuring gcommon queue",
+  "labels": ["codex", "docs"],
+  "guid": "21553fc5-8c51-4d7c-9d33-f1c507900551",
+  "legacy_guid": "create-document-queue-config-2025-07-05"
+}

--- a/.github/issue-updates/27e3381a-6565-432a-96f4-b82aeb7df01e.json
+++ b/.github/issue-updates/27e3381a-6565-432a-96f4-b82aeb7df01e.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Integrate gcommon metrics",
+  "body": "Use gcommon/metrics for Prometheus instrumentation",
+  "labels": ["codex", "refactor"],
+  "guid": "27e3381a-6565-432a-96f4-b82aeb7df01e",
+  "legacy_guid": "create-integrate-gcommon-metrics-2025-07-05"
+}

--- a/.github/issue-updates/29be2de4-a7e4-4080-892b-d279149d5dc6.json
+++ b/.github/issue-updates/29be2de4-a7e4-4080-892b-d279149d5dc6.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Use gcommon health",
+  "body": "Replace existing health endpoints with gcommon/health handlers",
+  "labels": ["codex", "refactor"],
+  "guid": "29be2de4-a7e4-4080-892b-d279149d5dc6",
+  "legacy_guid": "create-use-gcommon-health-2025-07-05"
+}

--- a/.github/issue-updates/2d89a77d-1a9d-460f-8fe8-e3fa12b50850.json
+++ b/.github/issue-updates/2d89a77d-1a9d-460f-8fe8-e3fa12b50850.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Config migration script",
+  "body": "Write script converting existing configs to gcommon format.",
+  "labels": ["codex", "refactor"],
+  "guid": "2d89a77d-1a9d-460f-8fe8-e3fa12b50850",
+  "legacy_guid": "create-config-migration-script-2025-07-05"
+}

--- a/.github/issue-updates/425eced9-6176-4b6c-a512-a2b684da7501.json
+++ b/.github/issue-updates/425eced9-6176-4b6c-a512-a2b684da7501.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Adopt gcommon queue",
+  "body": "Replace local queue with gcommon/queue implementation",
+  "labels": ["codex", "refactor"],
+  "guid": "425eced9-6176-4b6c-a512-a2b684da7501",
+  "legacy_guid": "create-adopt-gcommon-queue-2025-07-05"
+}

--- a/.github/issue-updates/46f4d540-3aee-4e23-9bc3-21f0edcf8e25.json
+++ b/.github/issue-updates/46f4d540-3aee-4e23-9bc3-21f0edcf8e25.json
@@ -1,0 +1,12 @@
+{
+  "action": "create",
+  "title": "gcommon proto enhancements",
+  "body": "Request provider and subtitle service protos in gcommon.
+
+<!-- GCOMMON ISSUE JSON
+{"action": "create", "title": "Add provider and subtitle service protos", "body": "Add proto definitions for provider management and subtitle operations for use by Subtitle Manager.", "labels": ["enhancement"]}
+-->",
+  "labels": ["gcommon", "enhancement"],
+  "guid": "46f4d540-3aee-4e23-9bc3-21f0edcf8e25",
+  "legacy_guid": "create-gcommon-proto-enhancements-2025-07-05"
+}

--- a/.github/issue-updates/4925e95e-15fb-4985-b386-66edbe63eba7.json
+++ b/.github/issue-updates/4925e95e-15fb-4985-b386-66edbe63eba7.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Vendor gcommon",
+  "body": "Vendor gcommon modules for deterministic builds.",
+  "labels": ["codex", "refactor"],
+  "guid": "4925e95e-15fb-4985-b386-66edbe63eba7",
+  "legacy_guid": "create-vendor-gcommon-2025-07-05"
+}

--- a/.github/issue-updates/5e1e4312-0d29-4a69-996a-9013179429fa.json
+++ b/.github/issue-updates/5e1e4312-0d29-4a69-996a-9013179429fa.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Replace auth middleware",
+  "body": "Use gcommon/auth for token validation and OAuth2",
+  "labels": ["codex", "refactor"],
+  "guid": "5e1e4312-0d29-4a69-996a-9013179429fa",
+  "legacy_guid": "create-replace-auth-middleware-2025-07-05"
+}

--- a/.github/issue-updates/5fdc3661-0208-4d56-979f-c19bc956488d.json
+++ b/.github/issue-updates/5fdc3661-0208-4d56-979f-c19bc956488d.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Align CLI flags",
+  "body": "Update CLI flags to pass configuration options through gcommon",
+  "labels": ["codex", "refactor"],
+  "guid": "5fdc3661-0208-4d56-979f-c19bc956488d",
+  "legacy_guid": "create-align-cli-flags-2025-07-05"
+}

--- a/.github/issue-updates/67fbaefb-fc90-47a2-a455-d17fbced9c72.json
+++ b/.github/issue-updates/67fbaefb-fc90-47a2-a455-d17fbced9c72.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Update dev scripts",
+  "body": "Modify helper scripts to use gcommon tools",
+  "labels": ["codex", "refactor"],
+  "guid": "67fbaefb-fc90-47a2-a455-d17fbced9c72",
+  "legacy_guid": "create-update-dev-scripts-2025-07-05"
+}

--- a/.github/issue-updates/6ab058a4-5e4c-4a0a-a503-6e4d3d38d79f.json
+++ b/.github/issue-updates/6ab058a4-5e4c-4a0a-a503-6e4d3d38d79f.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Prometheus setup",
+  "body": "Configure Prometheus scraping using gcommon metrics",
+  "labels": ["codex", "refactor"],
+  "guid": "6ab058a4-5e4c-4a0a-a503-6e4d3d38d79f",
+  "legacy_guid": "create-prometheus-setup-2025-07-05"
+}

--- a/.github/issue-updates/772a64ad-846b-4cf3-a036-7014ff785261.json
+++ b/.github/issue-updates/772a64ad-846b-4cf3-a036-7014ff785261.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Use gcommon protos",
+  "body": "Adopt shared proto messages from gcommon",
+  "labels": ["codex", "refactor"],
+  "guid": "772a64ad-846b-4cf3-a036-7014ff785261",
+  "legacy_guid": "create-use-gcommon-protos-2025-07-05"
+}

--- a/.github/issue-updates/7a1e6d11-1615-4942-8957-bbff743e4802.json
+++ b/.github/issue-updates/7a1e6d11-1615-4942-8957-bbff743e4802.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Update handlers",
+  "body": "Refactor gRPC and REST handlers to use new gcommon proto messages",
+  "labels": ["codex", "refactor"],
+  "guid": "7a1e6d11-1615-4942-8957-bbff743e4802",
+  "legacy_guid": "create-update-handlers-2025-07-05"
+}

--- a/.github/issue-updates/8a9c5adf-7c71-4e42-8d7c-9870f428bdfd.json
+++ b/.github/issue-updates/8a9c5adf-7c71-4e42-8d7c-9870f428bdfd.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Document hybrid build",
+  "body": "Update README with hybrid Docker workflow",
+  "labels": ["codex", "docs"],
+  "guid": "8a9c5adf-7c71-4e42-8d7c-9870f428bdfd",
+  "legacy_guid": "create-document-hybrid-build-2025-07-05"
+}

--- a/.github/issue-updates/934df791-41f8-4c7f-90bb-c3f1a89d7b75.json
+++ b/.github/issue-updates/934df791-41f8-4c7f-90bb-c3f1a89d7b75.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add gcommon module",
+  "body": "Add github.com/jdfalk/gcommon to go.mod and run go mod tidy.",
+  "labels": ["codex", "refactor"],
+  "guid": "934df791-41f8-4c7f-90bb-c3f1a89d7b75",
+  "legacy_guid": "create-add-gcommon-module-2025-07-05"
+}

--- a/.github/issue-updates/96b54b64-7f7f-4491-815a-59a00ef9ad87.json
+++ b/.github/issue-updates/96b54b64-7f7f-4491-815a-59a00ef9ad87.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Generate proto bindings",
+  "body": "Run protoc to generate Go code for gcommon protos",
+  "labels": ["codex", "refactor"],
+  "guid": "96b54b64-7f7f-4491-815a-59a00ef9ad87",
+  "legacy_guid": "create-generate-proto-bindings-2025-07-05"
+}

--- a/.github/issue-updates/9e997e7b-5cdf-47a7-9f6c-299857b87644.json
+++ b/.github/issue-updates/9e997e7b-5cdf-47a7-9f6c-299857b87644.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Remove old packages",
+  "body": "Delete local modules superseded by gcommon",
+  "labels": ["codex", "refactor"],
+  "guid": "9e997e7b-5cdf-47a7-9f6c-299857b87644",
+  "legacy_guid": "create-remove-old-packages-2025-07-05"
+}

--- a/.github/issue-updates/b6e77851-5e09-4d26-af91-682598416e4d.json
+++ b/.github/issue-updates/b6e77851-5e09-4d26-af91-682598416e4d.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Migrate job types",
+  "body": "Refactor existing jobs to work with gcommon queue",
+  "labels": ["codex", "refactor"],
+  "guid": "b6e77851-5e09-4d26-af91-682598416e4d",
+  "legacy_guid": "create-migrate-job-types-2025-07-05"
+}

--- a/.github/issue-updates/baa94c16-1f3b-417f-9252-3172c95bd1cd.json
+++ b/.github/issue-updates/baa94c16-1f3b-417f-9252-3172c95bd1cd.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Record migration",
+  "body": "Add CHANGELOG entry describing gcommon migration",
+  "labels": ["codex", "docs"],
+  "guid": "baa94c16-1f3b-417f-9252-3172c95bd1cd",
+  "legacy_guid": "create-record-migration-2025-07-05"
+}

--- a/.github/issue-updates/c05d3edd-f594-4cac-9364-f2eb7c14b4c3.json
+++ b/.github/issue-updates/c05d3edd-f594-4cac-9364-f2eb7c14b4c3.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Test token validation",
+  "body": "Add unit tests for gcommon/auth token handling",
+  "labels": ["codex", "test"],
+  "guid": "c05d3edd-f594-4cac-9364-f2eb7c14b4c3",
+  "legacy_guid": "create-test-token-validation-2025-07-05"
+}

--- a/.github/issue-updates/db026c4a-0a9d-469f-a59d-cfe07aab23ce.json
+++ b/.github/issue-updates/db026c4a-0a9d-469f-a59d-cfe07aab23ce.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Configure session store",
+  "body": "Initialize session storage through gcommon/auth packages",
+  "labels": ["codex", "refactor"],
+  "guid": "db026c4a-0a9d-469f-a59d-cfe07aab23ce",
+  "legacy_guid": "create-configure-session-store-2025-07-05"
+}

--- a/.github/issue-updates/e578f4ea-cb2a-4c5e-999a-8af38a7217b1.json
+++ b/.github/issue-updates/e578f4ea-cb2a-4c5e-999a-8af38a7217b1.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Example gcommon config",
+  "body": "Provide sample config file showing gcommon settings",
+  "labels": ["codex", "docs"],
+  "guid": "e578f4ea-cb2a-4c5e-999a-8af38a7217b1",
+  "legacy_guid": "create-example-gcommon-config-2025-07-05"
+}

--- a/.github/issue-updates/f1278378-944f-4999-bfae-7f22a862ba2e.json
+++ b/.github/issue-updates/f1278378-944f-4999-bfae-7f22a862ba2e.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Use hybrid Dockerfile",
+  "body": "Adopt Dockerfile.hybrid for all builds",
+  "labels": ["codex", "build"],
+  "guid": "f1278378-944f-4999-bfae-7f22a862ba2e",
+  "legacy_guid": "create-use-hybrid-dockerfile-2025-07-05"
+}

--- a/.github/issue-updates/fe8d8c81-bb85-42a4-a700-92e89276d79d.json
+++ b/.github/issue-updates/fe8d8c81-bb85-42a4-a700-92e89276d79d.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Plan gcommon refactor",
+  "body": "Investigate gcommon repo and outline integration steps in TODO.md. Create follow-up issues for implementation.",
+  "labels": ["planning"],
+  "guid": "fe8d8c81-bb85-42a4-a700-92e89276d79d",
+  "legacy_guid": "create-plan-gcommon-refactor-2025-07-05"
+}

--- a/TODO.md
+++ b/TODO.md
@@ -669,6 +669,50 @@ into the binary and served by the `web` command.
 
 ## Additional Documentation
 
+## GCommon Refactor Plan
+
+This refactor will replace several internal packages with the shared modules provided by [gcommon](https://github.com/jdfalk/gcommon). The migration follows the hybrid Docker build approach defined in `Dockerfile.hybrid` which installs Node.js in the Go builder stage so `go generate` can embed the pre-built React UI.
+
+### Planned Steps
+
+#### Phase 1: Dependency Setup
+- Add `github.com/jdfalk/gcommon` to `go.mod` and run `go mod tidy`.
+- Vendor the module to ensure consistent builds.
+- Confirm CI passes with the new dependency.
+
+#### Phase 2: Configuration Service
+- Replace the local config loader with `gcommon/config`.
+- Write a migration script to convert existing configs to the new format.
+- Update CLI flags to pass configuration values through `gcommon`.
+- Provide an example configuration file documenting new options.
+
+#### Phase 3: Auth & Sessions
+- Swap authentication middleware to `gcommon/auth` for JWT and OAuth2 flows.
+- Configure session storage using the shared session manager.
+- Add unit tests covering token validation and session creation.
+- Remove deprecated local auth code.
+
+#### Phase 4: Metrics & Health
+- Integrate `gcommon/metrics` for Prometheus instrumentation.
+- Replace existing health endpoints with `gcommon/health` handlers.
+- Document Prometheus scraping configuration.
+
+#### Phase 5: Queue System
+- Replace the internal queue with `gcommon/queue`.
+- Migrate all job types to the new system.
+- Document queue configuration in the README.
+
+#### Phase 6: Proto Updates
+- Adopt gcommon protobuf messages for shared types.
+- Run `protoc` to generate updated Go bindings.
+- Refactor gRPC and REST handlers to use the new messages.
+
+#### Phase 7: Docker Hybrid Build
+- Standardize on `Dockerfile.hybrid` for development and CI.
+- Update build scripts and documentation for the hybrid workflow.
+
+Each step should be tracked with a dedicated issue so multiple teams can work in parallel. The issues are organized to let developers tackle setup, auth, metrics, and other areas independently.
+
 For detailed architecture and design decisions, see `docs/TECHNICAL_DESIGN.md`.
 The file `docs/BAZARR_FEATURES.md` enumerates all Bazarr features - parity has
 been achieved for providers and core functionality.


### PR DESCRIPTION
## Description
Expand the gcommon refactor section and generate granular issues for each migration task.

## Motivation
Breaking the migration into many small issues lets new developers tackle work in parallel.

## Changes
- document phased migration plan in `TODO.md`
- create 25 issue update files for individual tasks and cross-repo requests

## Testing
- `go test ./...` *(fails: build errors)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68693525bbe08321af092716fe8deb22