### PR TITLE
Add video filter flag for history/downloads

### DIFF
--- a/.github/issue-updates/ca2dd777-79a6-4fb0-868a-abbfa5238949.json
+++ b/.github/issue-updates/ca2dd777-79a6-4fb0-868a-abbfa5238949.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add video filter to history command",
+  "body": "Allow filtering of subtitle history by video file via --video flag",
+  "labels": ["enhancement", "cli"],
+  "guid": "ca2dd777-79a6-4fb0-868a-abbfa5238949",
+  "legacy_guid": "create-add-video-filter-to-history-command-2025-07-06"
+}

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ tags, permissions, and subtitle history.
 \``` subtitle-manager convert [input] [output] subtitle-manager merge [sub1]
 [sub2] [output] subtitle-manager translate [input] [output] [lang]
 subtitle-manager sync [media] [subtitle] [output] [--use-audio] [--use-embedded]
-[--translate] subtitle-manager history subtitle-manager extract [media] [output]
+[--translate] subtitle-manager history [--video file] subtitle-manager extract [media] [output]
 subtitle-manager transcribe [media] [output] [lang] subtitle-manager fetch
 [media] [lang] [output] subtitle-manager fetch --tags tag1,tag2 [media] [lang]
 [output] subtitle-manager search [media] [lang] subtitle-manager batch [lang]

--- a/cmd/downloads.go
+++ b/cmd/downloads.go
@@ -12,6 +12,8 @@ import (
 )
 
 // downloadsCmd shows subtitle download history.
+var downloadsVideo string
+
 var downloadsCmd = &cobra.Command{
 	Use:   "downloads",
 	Short: "Show subtitle download history",
@@ -25,7 +27,12 @@ var downloadsCmd = &cobra.Command{
 		}
 		defer store.Close()
 
-		recs, err := store.ListDownloads()
+		var recs []database.DownloadRecord
+		if downloadsVideo != "" {
+			recs, err = store.ListDownloadsByVideo(downloadsVideo)
+		} else {
+			recs, err = store.ListDownloads()
+		}
 		if err != nil {
 			return err
 		}
@@ -38,5 +45,6 @@ var downloadsCmd = &cobra.Command{
 }
 
 func init() {
+	downloadsCmd.Flags().StringVar(&downloadsVideo, "video", "", "filter by video file")
 	rootCmd.AddCommand(downloadsCmd)
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 )
 
+var historyVideo string
+
 var historyCmd = &cobra.Command{
 	Use:   "history",
 	Short: "Show translation history",
@@ -23,7 +25,12 @@ var historyCmd = &cobra.Command{
 		}
 		defer store.Close()
 
-		recs, err := store.ListSubtitles()
+		var recs []database.SubtitleRecord
+		if historyVideo != "" {
+			recs, err = store.ListSubtitlesByVideo(historyVideo)
+		} else {
+			recs, err = store.ListSubtitles()
+		}
 		if err != nil {
 			return err
 		}
@@ -36,5 +43,6 @@ var historyCmd = &cobra.Command{
 }
 
 func init() {
+	historyCmd.Flags().StringVar(&historyVideo, "video", "", "filter by video file")
 	rootCmd.AddCommand(historyCmd)
 }


### PR DESCRIPTION
## Description
Implement CLI filter for history and download commands.

## Motivation
Allows users to view history for a specific video file from the command line.

## Changes
- Added `--video` flag to `history` command
- Added `--video` flag to `downloads` command
- Documented flag in README
- Created issue tracking the enhancement

## Testing
- `go test ./...` *(fails: build errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_6869cbca1bc48321800778a811f5e430