### PR TITLE
Add provider config dialog tests

### DIFF
--- a/.github/issue-updates/4564c967-942a-41a5-8902-f98587572830.json
+++ b/.github/issue-updates/4564c967-942a-41a5-8902-f98587572830.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Provider configuration tests",
+  "body": "Add tests for provider configuration dialog to ensure proper validation and API calls.",
+  "labels": ["codex", "test"],
+  "guid": "4564c967-942a-41a5-8902-f98587572830",
+  "legacy_guid": "create-provider-configuration-tests-2025-07-06"
+}

--- a/TODO.md
+++ b/TODO.md
@@ -145,7 +145,7 @@ Current tag implementations will be migrated to the unified system:
   - Enhanced login test robustness in `app.spec.js`
 - [ ] **Add media library E2E tests**: Test file upload, scanning, and subtitle
       operations
-- [ ] **Add provider configuration tests**: Test subtitle provider setup and
+- [x] **Add provider configuration tests**: Test subtitle provider setup and
       validation
 - [ ] **Add bulk operations tests**: Test batch subtitle download and processing
 

--- a/webui/src/__tests__/ProviderConfigDialog.test.jsx
+++ b/webui/src/__tests__/ProviderConfigDialog.test.jsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, test, vi } from 'vitest';
+import ProviderConfigDialog from '../components/ProviderConfigDialog.jsx';
+
+vi.mock('../services/api.js', () => ({
+  apiService: {
+    get: vi.fn(),
+  },
+  getBasePath: () => '',
+}));
+
+describe('ProviderConfigDialog', () => {
+  test('loads available providers when opened', async () => {
+    const { apiService } = await import('../services/api.js');
+    apiService.get.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'opensubtitles' }]),
+    });
+
+    render(
+      <ProviderConfigDialog open provider={null} onClose={() => {}} onSave={() => {}} />
+    );
+
+    await waitFor(() => {
+      expect(apiService.get).toHaveBeenCalledWith('/api/providers/available');
+    });
+
+    // Open dropdown to verify option
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    expect(await screen.findByText('OpenSubtitles.org')).toBeInTheDocument();
+  });
+
+  test('calls onSave with entered configuration', async () => {
+    const { apiService } = await import('../services/api.js');
+    apiService.get.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'opensubtitles' }]),
+    });
+
+    const onSave = vi.fn();
+    render(
+      <ProviderConfigDialog open provider={null} onClose={() => {}} onSave={onSave} />
+    );
+
+    // select provider
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByText('OpenSubtitles.org'));
+
+    // fill required fields
+    fireEvent.change(screen.getByLabelText('API Key *'), { target: { value: 'k' } });
+    fireEvent.change(screen.getByLabelText('User Agent *'), { target: { value: 'ua' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Configuration' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'opensubtitles',
+          config: expect.objectContaining({ api_key: 'k', user_agent: 'ua' }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
Add unit tests for ProviderConfigDialog component and mark TODO item complete.

## Motivation
Provider configuration lacked test coverage. These tests verify provider loading and save behavior.

## Changes
- Add ProviderConfigDialog.test.jsx
- Update TODO list
- Record issue creation for provider configuration tests

## Testing
- `make test-all` *(fails: compile errors)*


------
https://chatgpt.com/codex/tasks/task_e_6869cb358a4083218687ed680c6a6383