### PR TITLE
Add provider config tests

### DIFF
--- a/.github/issue-updates/2c25d2e5-3408-4209-8610-8fbb39cb8b2a.json
+++ b/.github/issue-updates/2c25d2e5-3408-4209-8610-8fbb39cb8b2a.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add provider config tests",
+  "body": "Implement tests for the providers API to verify listing and updating configuration",
+  "labels": ["codex", "test"],
+  "guid": "2c25d2e5-3408-4209-8610-8fbb39cb8b2a",
+  "legacy_guid": "create-add-provider-config-tests-2025-07-06"
+}

--- a/.github/issue-updates/c8b665a1-c666-49a4-8125-3bac63077ad4.json
+++ b/.github/issue-updates/c8b665a1-c666-49a4-8125-3bac63077ad4.json
@@ -1,0 +1,8 @@
+{
+  "action": "comment",
+  "number": 0,
+  "body": "Implemented provider config tests",
+  "guid": "c8b665a1-c666-49a4-8125-3bac63077ad4",
+  "legacy_guid": "comment-issue-0-2025-07-06" ,
+  "parent": "2c25d2e5-3408-4209-8610-8fbb39cb8b2a"
+}

--- a/pkg/webserver/providers_test.go
+++ b/pkg/webserver/providers_test.go
@@ -1,0 +1,64 @@
+// file: pkg/webserver/providers_test.go
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestProvidersHandlerGet verifies that the handler lists providers
+func TestProvidersHandlerGet(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/providers", nil)
+	rr := httptest.NewRecorder()
+	providersHandler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp []ProviderInfo
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp) == 0 {
+		t.Fatalf("expected providers list")
+	}
+}
+
+// TestProvidersHandlerInvalidJSON verifies bad JSON returns 400
+func TestProvidersHandlerInvalidJSON(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/providers", bytes.NewBufferString("bad"))
+	rr := httptest.NewRecorder()
+	providersHandler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+}
+
+// TestProvidersHandlerUpdate verifies POST updates configuration
+func TestProvidersHandlerUpdate(t *testing.T) {
+	tmp := t.TempDir() + "/config.yaml"
+	viper.SetConfigFile(tmp)
+	defer viper.Reset()
+
+	body := `{"name":"generic","enabled":true,"config":{"api_url":"http://example.com"}}`
+	req := httptest.NewRequest("POST", "/api/providers", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	providersHandler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rr.Code)
+	}
+
+	if !viper.GetBool("providers.generic.enabled") {
+		t.Fatalf("config not updated")
+	}
+	if viper.GetString("providers.generic.config.api_url") != "http://example.com" {
+		t.Fatalf("value not written")
+	}
+}


### PR DESCRIPTION
## Description
Add tests for the providers API listing and configuration update endpoints.

## Motivation
Provider configuration tests were missing from the suite, leaving gaps in coverage.

## Changes
- Added `providers_test.go` for new handlers
- Created issue update and progress comment

## Testing
- `go test ./pkg/webserver/... -run ProvidersHandler -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6869cb2cce4083218fbf76143e519f63