### PR TITLE
Add one-time sonarr sync command

### DIFF
--- a/.github/issue-updates/22c97405-8ac5-43ab-9b78-33565d74172d.json
+++ b/.github/issue-updates/22c97405-8ac5-43ab-9b78-33565d74172d.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Config migration script",
+  "body": "Write script converting existing configs to gcommon format.",
+  "labels": ["codex", "refactor"],
+  "guid": "22c97405-8ac5-43ab-9b78-33565d74172d",
+  "legacy_guid": "create-config-migration-script-2025-07-06"
+}

--- a/.github/issue-updates/f02c2b37-d3f2-45c3-b210-7a8619ff0ddd.json
+++ b/.github/issue-updates/f02c2b37-d3f2-45c3-b210-7a8619ff0ddd.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add sonarr-sync command",
+  "body": "Implement CLI command to run a single Sonarr library sync for initial or manual use.",
+  "labels": ["codex", "enhancement"],
+  "guid": "f02c2b37-d3f2-45c3-b210-7a8619ff0ddd",
+  "legacy_guid": "create-add-sonarr-sync-command-2025-07-06"
+}

--- a/cmd/sonarrsync.go
+++ b/cmd/sonarrsync.go
@@ -1,0 +1,49 @@
+// file: cmd/sonarrsync.go
+// version: 1.0.0
+// guid: 1c9e3f2a-d0ff-4d6f-bd5a-385aaf8b9416
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
+)
+
+var sonarrSyncCmd = &cobra.Command{
+	Use:   "sonarr-sync",
+	Short: "Sync Sonarr library once",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("sonarr-sync")
+		url := viper.GetString("sonarr_url")
+		key := viper.GetString("sonarr_api_key")
+		if url == "" || key == "" {
+			logger.Warn("sonarr url or api key not configured")
+			return nil
+		}
+
+		c := sonarr.NewClient(url, key)
+		store, err := database.OpenStoreWithConfig()
+		if err != nil {
+			return fmt.Errorf("open db: %w", err)
+		}
+		defer store.Close()
+
+		ctx := context.Background()
+		if err := sonarr.Sync(ctx, c, store); err != nil {
+			return err
+		}
+		logger.Info("sonarr library sync complete")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sonarrSyncCmd)
+}


### PR DESCRIPTION
## Description
Add a CLI command `sonarr-sync` to run a single Sonarr library sync.

## Motivation
The server already runs continuous sync jobs. This command allows manual or initial syncs without starting a daemon.

## Changes
- Implement one-time sync in `cmd/sonarrsync.go`
- Create issue update for new feature

## Testing
- `go test ./...` *(fails: build errors in cmd and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca7a3ebc832199bc7219486fed51