### PR TITLE
Add release group sanitization

### DIFF
--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -14,18 +14,18 @@ import (
 )
 
 func TestParseFileName(t *testing.T) {
-	m, err := ParseFileName("Show.Name.S01E02.mkv")
+	m, err := ParseFileName("Show.Name.S01E02-GRP!.mkv")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if m.Type != TypeEpisode || m.Title != "Show Name" || m.Season != 1 || m.Episode != 2 {
+	if m.Type != TypeEpisode || m.Title != "Show Name" || m.Season != 1 || m.Episode != 2 || m.ReleaseGroup != "GRP" {
 		t.Fatalf("unexpected result: %+v", m)
 	}
-	m, err = ParseFileName("Movie Title (2020).mp4")
+	m, err = ParseFileName("Movie Title (2020)-TEAM!.mp4")
 	if err != nil {
 		t.Fatalf("parse movie: %v", err)
 	}
-	if m.Type != TypeMovie || m.Title != "Movie Title" || m.Year != 2020 {
+	if m.Type != TypeMovie || m.Title != "Movie Title" || m.Year != 2020 || m.ReleaseGroup != "TEAM" {
 		t.Fatalf("unexpected movie: %+v", m)
 	}
 }
@@ -135,7 +135,7 @@ func TestScanLibraryProgress(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	video := filepath.Join(dir, "movie.mkv")
+	video := filepath.Join(dir, "movie-GRP.mkv")
 	if err := os.WriteFile(video, []byte("x"), 0644); err != nil {
 		t.Fatalf("create video: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestScanLibraryProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(items) != 1 || items[0].Path != video {
+	if len(items) != 1 || items[0].Path != video || items[0].ReleaseGroup != "GRP" {
 		t.Fatalf("items %+v", items)
 	}
 }

--- a/pkg/security/path_test.go
+++ b/pkg/security/path_test.go
@@ -136,3 +136,20 @@ func TestValidateSubtitleOutputPath(t *testing.T) {
 		t.Error("expected error for path traversal in video path")
 	}
 }
+
+func TestSanitizeLabel(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"Group", "Group"},
+		{"Bad!Group", "BadGroup"},
+		{" spaced name ", "spacedname"},
+		{"A_B-C", "A_B-C"},
+	}
+	for _, c := range cases {
+		if got := SanitizeLabel(c.in); got != c.out {
+			t.Errorf("SanitizeLabel(%q)=%q, want %q", c.in, got, c.out)
+		}
+	}
+}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -269,3 +269,11 @@ func ValidateSubtitleOutputPath(videoPath, lang string) (string, error) {
 
 	return subtitlePath, nil
 }
+
+var labelSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+
+// SanitizeLabel removes potentially dangerous characters from a short
+// identifier. Only letters, numbers, underscores and hyphens are retained.
+func SanitizeLabel(label string) string {
+	return labelSanitizer.ReplaceAllString(label, "")
+}


### PR DESCRIPTION
## Description
Sanitize release group names extracted from filenames using the security package.

## Motivation
Unsafe characters in release groups could leak into the database or UI. Sanitizing with a shared helper prevents this.

## Changes
- add `SanitizeLabel` to `pkg/security` with tests
- sanitize release group in `ParseFileName`
- update unit tests for sanitized filenames

## Testing
- `go test ./pkg/metadata -run TestParseFileName -v`
- `go test ./pkg/security -run TestSanitizeLabel -v`
- `go test ./...` *(fails: cmd and other packages)*


------
https://chatgpt.com/codex/tasks/task_e_6869ca10f3cc83218a96bbb4a207f04e