### PR TITLE
Add provider list persistence test

### DIFF
--- a/.github/issue-updates/5eee3854-d143-4d6c-9e29-118555542573.json
+++ b/.github/issue-updates/5eee3854-d143-4d6c-9e29-118555542573.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 1243,
+  "body": "Added provider configuration tests",
+  "labels": ["codex"],
+  "guid": "5eee3854-d143-4d6c-9e29-118555542573",
+  "legacy_guid": "update-issue-1243-2025-07-06"
+}

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -885,9 +885,9 @@ func TestProvidersDefault(t *testing.T) {
 	}
 }
 
-// TestProvidersUpdate verifies that provider configuration updates via POST
+// TestProviderConfigUpdate verifies that provider configuration updates via POST
 // /api/providers are persisted in viper and the config file.
-func TestProvidersUpdate(t *testing.T) {
+func TestProviderConfigUpdate(t *testing.T) {
 	skipIfNoSQLite(t)
 	db, err := database.Open(":memory:")
 	if err != nil {
@@ -962,6 +962,76 @@ func TestProvidersUpdateInvalid(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+// TestProvidersListAfterUpdate ensures that provider changes persist
+// when fetching the provider list via GET /api/providers.
+func TestProvidersListAfterUpdate(t *testing.T) {
+	skipIfNoSQLite(t)
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	key := setupTestUser(t, db)
+
+	tmp := filepath.Join(t.TempDir(), "cfg.yaml")
+	viper.SetConfigFile(tmp)
+	viper.Set("providers.generic.enabled", false)
+	viper.Set("providers.generic.config", map[string]interface{}{"api_url": ""})
+	testutil.MustNoError(t, "write config", viper.WriteConfig())
+	defer viper.Reset()
+
+	h, err := Handler(db)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"name":"generic","enabled":true,"config":{"api_url":"http://example.com"}}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/providers", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", key)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+
+	req2, _ := http.NewRequest("GET", srv.URL+"/api/providers", nil)
+	req2.Header.Set("X-API-Key", key)
+	resp2, err := srv.Client().Do(req2)
+	if err != nil {
+		t.Fatalf("get providers: %v", err)
+	}
+	defer resp2.Body.Close()
+	var list []struct {
+		Name    string                 `json:"name"`
+		Enabled bool                   `json:"enabled"`
+		Config  map[string]interface{} `json:"config"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, p := range list {
+		if p.Name == "generic" {
+			found = true
+			if !p.Enabled {
+				t.Fatalf("provider should be enabled")
+			}
+			if p.Config["api_url"] != "http://example.com" {
+				t.Fatalf("config not returned: %v", p.Config["api_url"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("generic provider missing in list")
 	}
 }
 


### PR DESCRIPTION
## Description
Add a test ensuring provider configuration persists when fetching the provider list.

## Motivation
Provider settings need to be verified after updates. The new test confirms that configuration changes are returned by `GET /api/providers`.

## Changes
- Added `TestProvidersListAfterUpdate`
- Updated issue #1243 with progress

## Testing
- `go test ./pkg/webserver -run TestProvidersListAfterUpdate -v`

## Related Issues
Related to #1243

------
https://chatgpt.com/codex/tasks/task_e_6869ca8397908321afaf14640dbfd329