### PR TITLE
Fix path sanitization in findSubtitles

### DIFF
--- a/.github/issue-updates/f5ce2006-19d8-47ab-b413-14908c10da07.json
+++ b/.github/issue-updates/f5ce2006-19d8-47ab-b413-14908c10da07.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Sanitize paths in findSubtitles",
+  "body": "Use security.ValidateAndSanitizePath to validate media paths in webserver findSubtitles function",
+  "labels": ["codex"],
+  "guid": "f5ce2006-19d8-47ab-b413-14908c10da07",
+  "legacy_guid": "create-sanitize-paths-in-findsubtitles-2025-07-06"
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1188,8 +1188,12 @@ func isMediaFile(filename string) bool {
 
 // findSubtitles looks for subtitle files associated with a media file
 func findSubtitles(mediaPath string) []Subtitle {
-	dir := filepath.Clean(filepath.Dir(mediaPath))
-	baseName := strings.TrimSuffix(filepath.Base(mediaPath), filepath.Ext(mediaPath))
+	sanitized, err := security.ValidateAndSanitizePath(mediaPath)
+	if err != nil {
+		return nil
+	}
+	dir := filepath.Dir(sanitized)
+	baseName := strings.TrimSuffix(filepath.Base(sanitized), filepath.Ext(sanitized))
 
 	var subtitles []Subtitle
 


### PR DESCRIPTION
## Description
Add path sanitization to the `findSubtitles` helper.

## Motivation
Web server directory listings lacked validation for incoming paths. Using the security package prevents path traversal.

## Changes
- sanitize `mediaPath` in `findSubtitles`
- create issue update file for tracking

## Testing
- `go test ./...` *(fails: build errors)*
- `go fmt ./...`

## Related Issues
Related to issue created in `f5ce2006-19d8-47ab-b413-14908c10da07.json`


------
https://chatgpt.com/codex/tasks/task_e_686af52cc984832189cbf5737e9a0058