### PR TITLE
Implement GetSubtitleHistory hierarchy sorting

### DIFF
--- a/.github/issue-updates/716e18b2-a655-45fc-8ee9-addc813da702.json
+++ b/.github/issue-updates/716e18b2-a655-45fc-8ee9-addc813da702.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Display subtitle history hierarchy",
+  "body": "Sort subtitle records by parent-child relationships in GetSubtitleHistory",
+  "labels": ["codex"],
+  "guid": "716e18b2-a655-45fc-8ee9-addc813da702",
+  "legacy_guid": "create-display-subtitle-history-hierarchy-2025-07-06"
+}


### PR DESCRIPTION
## Description
Add sorting of subtitle history by parent-child relationships and introduce tests.

## Motivation
Without hierarchy sorting, subtitle history listings were confusing. This change orders subtitles so modifications follow their source.

## Changes
- Added hierarchical sorting logic in `GetSubtitleHistory`
- Added unit test covering the new ordering
- Logged work via issue update file

## Testing
- `go test ./pkg/database -run GetSubtitleHistoryHierarchy -v`
- `go test ./pkg/...` *(fails: translate path validation and other packages)*


------
https://chatgpt.com/codex/tasks/task_e_686af3c265d083218bb70e1ad85be24c