### PR TITLE
Add sync batch endpoint tests

### DIFF
--- a/.github/issue-updates/92749e7f-6f24-47ac-b546-9d0bc7f9ed56.json
+++ b/.github/issue-updates/92749e7f-6f24-47ac-b546-9d0bc7f9ed56.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add tests for sync batch endpoint",
+  "body": "Implement unit tests for /api/sync/batch to verify successful processing and error handling.",
+  "labels": ["codex", "test"],
+  "guid": "92749e7f-6f24-47ac-b546-9d0bc7f9ed56",
+  "legacy_guid": "create-add-tests-for-sync-batch-endpoint-2025-07-06"
+}

--- a/TODO.md
+++ b/TODO.md
@@ -147,7 +147,7 @@ Current tag implementations will be migrated to the unified system:
       operations
 - [x] **Add provider configuration tests**: Test subtitle provider setup and
       validation
-- [ ] **Add bulk operations tests**: Test batch subtitle download and processing
+- [x] **Add bulk operations tests**: Test batch subtitle download and processing
 
 ## 🚨 High Priority UI/UX Improvements
 

--- a/pkg/database/language_profiles_test.go
+++ b/pkg/database/language_profiles_test.go
@@ -79,5 +79,6 @@ func TestLanguageProfileSQLiteIntegration(t *testing.T) {
 
 // hasSQLite checks if SQLite support is available
 func hasSQLite() bool {
-	return true // Assume SQLite is available for this test
+	_, err := OpenSQLStore(":memory:")
+	return err == nil
 }

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -143,6 +143,19 @@ func SanitizePath[T ~string](p T) (T, error) {
 	return T(sanitized), nil
 }
 
+// SanitizeRelativePath cleans a relative path and checks for traversal.
+// It returns a cleaned path using forward slashes.
+func SanitizeRelativePath(p string) (string, error) {
+	if filepath.IsAbs(p) || strings.HasPrefix(p, "\\") || strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path must be relative")
+	}
+	if strings.Contains(p, "..") {
+		return "", fmt.Errorf("path traversal detected: %s", p)
+	}
+	clean := filepath.ToSlash(filepath.Clean(p))
+	return clean, nil
+}
+
 // ValidateWebSocketOrigin validates the Origin header for WebSocket connections
 // to prevent cross-site WebSocket hijacking attacks. It allows connections from:
 // - Same origin (localhost with various ports for development)

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -49,11 +49,11 @@ func (lp *LocalProvider) Store(ctx context.Context, key string, content io.Reade
 	}
 
 	// Sanitize the key to prevent directory traversal
-	sanitized, err := security.SanitizePath(key)
+	sanitized, err := security.SanitizeRelativePath(key)
 	if err != nil {
 		return ErrInvalidKey
 	}
-	key = string(sanitized)
+	key = sanitized
 
 	fullPath := filepath.Join(lp.basePath, key)
 
@@ -85,11 +85,11 @@ func (lp *LocalProvider) Retrieve(ctx context.Context, key string) (io.ReadClose
 	}
 
 	// Sanitize the key to prevent directory traversal
-	sanitized, err := security.SanitizePath(key)
+	sanitized, err := security.SanitizeRelativePath(key)
 	if err != nil {
 		return nil, ErrInvalidKey
 	}
-	key = string(sanitized)
+	key = sanitized
 
 	fullPath := filepath.Join(lp.basePath, key)
 
@@ -111,11 +111,11 @@ func (lp *LocalProvider) Delete(ctx context.Context, key string) error {
 	}
 
 	// Sanitize the key to prevent directory traversal
-	sanitized, err := security.SanitizePath(key)
+	sanitized, err := security.SanitizeRelativePath(key)
 	if err != nil {
 		return ErrInvalidKey
 	}
-	key = string(sanitized)
+	key = sanitized
 
 	fullPath := filepath.Join(lp.basePath, key)
 
@@ -134,11 +134,11 @@ func (lp *LocalProvider) Exists(ctx context.Context, key string) (bool, error) {
 	}
 
 	// Sanitize the key to prevent directory traversal
-	sanitized, err := security.SanitizePath(key)
+	sanitized, err := security.SanitizeRelativePath(key)
 	if err != nil {
 		return false, ErrInvalidKey
 	}
-	key = string(sanitized)
+	key = sanitized
 
 	fullPath := filepath.Join(lp.basePath, key)
 
@@ -197,11 +197,11 @@ func (lp *LocalProvider) GetURL(ctx context.Context, key string, expiry time.Dur
 	}
 
 	// Sanitize the key to prevent directory traversal
-	sanitized, err := security.SanitizePath(key)
+	sanitized, err := security.SanitizeRelativePath(key)
 	if err != nil {
 		return "", ErrInvalidKey
 	}
-	key = string(sanitized)
+	key = sanitized
 
 	fullPath := filepath.Join(lp.basePath, key)
 	absPath, err := filepath.Abs(fullPath)

--- a/pkg/subtitles/translatefile_test.go
+++ b/pkg/subtitles/translatefile_test.go
@@ -25,18 +25,21 @@ func TestTranslateFileToSRT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	inPath := filepath.Join(wd, "../../testdata/simple.srt")
+	src := filepath.Join(wd, "../../testdata/simple.srt")
+	inPath := filepath.Join(t.TempDir(), "in.srt")
+	inData, _ := os.ReadFile(src)
+	os.WriteFile(inPath, inData, 0644)
 	out := filepath.Join(t.TempDir(), "out.srt")
 	err = TranslateFileToSRT(inPath, out, "es", "google", "k", "", "")
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
-	data, err := os.ReadFile(out)
+	outData, err := os.ReadFile(out)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if !strings.Contains(string(data), "hola") {
-		t.Fatalf("expected translated text, got %s", data)
+	if !strings.Contains(string(outData), "hola") {
+		t.Fatalf("expected translated text, got %s", outData)
 	}
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -14,12 +14,12 @@ import (
 // APIError represents an error response from the API.
 type APIError struct {
 	StatusCode int    `json:"-"`
-	Error      string `json:"error"`
+	Code       string `json:"error"`
 	Message    string `json:"message"`
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("API error (%d): %s - %s", e.StatusCode, e.Error, e.Message)
+	return fmt.Sprintf("API error (%d): %s - %s", e.StatusCode, e.Code, e.Message)
 }
 
 // IsAuthenticationError returns true if the error is an authentication error (401).

--- a/pkg/webserver/syncbatch_test.go
+++ b/pkg/webserver/syncbatch_test.go
@@ -1,0 +1,86 @@
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/subtitle-manager/pkg/syncer"
+)
+
+func TestSyncBatchHandler(t *testing.T) {
+	dir := t.TempDir()
+	data, err := os.ReadFile("../../testdata/simple.srt")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	in1 := filepath.Join(dir, "a.srt")
+	in2 := filepath.Join(dir, "b.srt")
+	if err := os.WriteFile(in1, data, 0644); err != nil {
+		t.Fatalf("write in1: %v", err)
+	}
+	if err := os.WriteFile(in2, data, 0644); err != nil {
+		t.Fatalf("write in2: %v", err)
+	}
+	out1 := filepath.Join(dir, "out1.srt")
+	out2 := filepath.Join(dir, "out2.srt")
+
+	reqBody := struct {
+		Items   []syncer.BatchItem `json:"items"`
+		Options syncer.Options     `json:"options"`
+	}{
+		Items: []syncer.BatchItem{
+			{Media: "dummy1.mkv", Subtitle: in1, Output: out1},
+			{Media: "dummy2.mkv", Subtitle: in2, Output: out2},
+		},
+		Options: syncer.Options{},
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	handler := syncBatchHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/batch", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d", w.Code)
+	}
+	var resp struct {
+		Results []struct {
+			Output string `json:"output"`
+			Error  string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("results len %d", len(resp.Results))
+	}
+	for i, p := range []string{out1, out2} {
+		if resp.Results[i].Error != "" {
+			t.Fatalf("item %d err %s", i, resp.Results[i].Error)
+		}
+		fi, err := os.Stat(p)
+		if err != nil || fi.Size() == 0 {
+			t.Fatalf("output %s missing", p)
+		}
+	}
+}
+
+func TestSyncBatchHandlerInvalidJSON(t *testing.T) {
+	handler := syncBatchHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/batch", bytes.NewReader([]byte("invalid")))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/sdks/go/subtitleclient/client_test.go
+++ b/sdks/go/subtitleclient/client_test.go
@@ -312,7 +312,7 @@ func TestAPIError(t *testing.T) {
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
 	assert.Equal(t, 401, apiErr.StatusCode)
-	assert.Equal(t, "unauthorized", apiErr.Error)
+	assert.Equal(t, "unauthorized", apiErr.Code)
 	assert.Equal(t, "Authentication required", apiErr.Message)
 	assert.True(t, apiErr.IsAuthenticationError())
 	assert.False(t, apiErr.IsAuthorizationError())


### PR DESCRIPTION
## Description
Add unit tests for the webserver's batch synchronization handler. Updated
security utilities and local storage provider to handle relative paths. Fixed
test helpers for SQLite and translation utilities.

## Motivation
Bulk operations lacked test coverage. New tests verify successful batch
processing and error handling.

## Changes
- created `syncbatch_test.go` for `/api/sync/batch`
- added `SanitizeRelativePath` helper and adjusted local storage
- fixed existing tests to use temporary files
- updated API error struct field name
- marked bulk operations tests as completed in TODO
- created issue update file for tracking work

## Testing
- `go test ./pkg/...`


------
https://chatgpt.com/codex/tasks/task_e_686af3baf2e88321a350c0fe74903af3