### PR TITLE
Implement search history persistence

### DIFF
--- a/.github/issue-updates/7d897827-f504-412a-955c-215809c28919.json
+++ b/.github/issue-updates/7d897827-f504-412a-955c-215809c28919.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement search history persistence",
+  "body": "Add search_history table and API handlers for storing and retrieving search queries",
+  "labels": ["codex", "feat"],
+  "guid": "7d897827-f504-412a-955c-215809c28919",
+  "legacy_guid": "create-implement-search-history-persistence-2025-07-06"
+}

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -49,6 +49,12 @@ func initPostgresSchema(db *sql.DB) error {
             language TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL
         )`,
+		`CREATE TABLE IF NOT EXISTS search_history (
+            id SERIAL PRIMARY KEY,
+            query TEXT NOT NULL,
+            results INTEGER NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        )`,
 		`CREATE TABLE IF NOT EXISTS media_items (
             id SERIAL PRIMARY KEY,
             path TEXT NOT NULL,

--- a/pkg/database/sqlite_enabled.go
+++ b/pkg/database/sqlite_enabled.go
@@ -71,6 +71,15 @@ func initSchema(db *sql.DB) error {
 		return err
 	}
 
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS search_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        query TEXT NOT NULL,
+        results INTEGER NOT NULL,
+        created_at TIMESTAMP NOT NULL
+    )`); err != nil {
+		return err
+	}
+
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS media_items (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         path TEXT NOT NULL,

--- a/pkg/webserver/search_history_test.go
+++ b/pkg/webserver/search_history_test.go
@@ -1,0 +1,85 @@
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+)
+
+func TestSearchHistoryHandlerCycle(t *testing.T) {
+	skipIfNoSQLite(t)
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	handler := searchHistoryHandler(db)
+
+	// Initial GET should return empty slice
+	req, _ := http.NewRequest("GET", "/api/search/history", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get status %d", rr.Code)
+	}
+	var items []SearchHistoryItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty history")
+	}
+
+	// Save a history item
+	hist := SearchHistoryItem{
+		Query:     SearchRequest{Providers: []string{"opensubtitles"}, MediaPath: "a.mkv", Language: "en"},
+		Results:   2,
+		Timestamp: time.Now(),
+	}
+	data, _ := json.Marshal(hist)
+	req2, _ := http.NewRequest("POST", "/api/search/history", bytes.NewBuffer(data))
+	req2.Header.Set("Content-Type", "application/json")
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("post status %d", rr2.Code)
+	}
+
+	// Verify item saved
+	req3, _ := http.NewRequest("GET", "/api/search/history", nil)
+	rr3 := httptest.NewRecorder()
+	handler.ServeHTTP(rr3, req3)
+	if rr3.Code != http.StatusOK {
+		t.Fatalf("get after post status %d", rr3.Code)
+	}
+	if err := json.NewDecoder(rr3.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 history item, got %d", len(items))
+	}
+
+	// Delete history
+	req4, _ := http.NewRequest("DELETE", "/api/search/history", nil)
+	rr4 := httptest.NewRecorder()
+	handler.ServeHTTP(rr4, req4)
+	if rr4.Code != http.StatusOK {
+		t.Fatalf("delete status %d", rr4.Code)
+	}
+
+	req5, _ := http.NewRequest("GET", "/api/search/history", nil)
+	rr5 := httptest.NewRecorder()
+	handler.ServeHTTP(rr5, req5)
+	if err := json.NewDecoder(rr5.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty history after delete")
+	}
+}


### PR DESCRIPTION
## Description
Add persistent search history support using new `search_history` table.

## Motivation
Manual search feature lacked storage for past searches. This implements database tables and API handlers so recent queries can be viewed later.

## Changes
- add `search_history` table creation to SQLite and Postgres schemas
- implement search history API handlers
- add unit test verifying save/list/delete cycle
- generate issue update tracking this work

## Testing
- `go test ./pkg/webserver -run TestSearchHistoryHandlerCycle -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686af3b392408321b9e132be72aa8506