### PR TITLE
Add continuous sync helpers

### DIFF
--- a/.github/issue-updates/176dca27-a455-42b3-b244-9185e49e6772.json
+++ b/.github/issue-updates/176dca27-a455-42b3-b244-9185e49e6772.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Fix rebase script when no remote",
+  "body": "The rebase script fails because 'git fetch origin' fails if no remote is configured. Implement a check to skip fetch when the remote doesn't exist.",
+  "labels": ["codex"],
+  "guid": "176dca27-a455-42b3-b244-9185e49e6772",
+  "legacy_guid": "create-fix-rebase-script-when-no-remote-2025-07-06"
+}

--- a/.github/issue-updates/5eee3854-d143-4d6c-9e29-118555542573.json
+++ b/.github/issue-updates/5eee3854-d143-4d6c-9e29-118555542573.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 1243,
+  "body": "Added provider configuration tests",
+  "labels": ["codex"],
+  "guid": "5eee3854-d143-4d6c-9e29-118555542573",
+  "legacy_guid": "update-issue-1243-2025-07-06"
+}

--- a/.github/issue-updates/61459ec1-54d1-4a9a-b81d-2f056813dc1e.json
+++ b/.github/issue-updates/61459ec1-54d1-4a9a-b81d-2f056813dc1e.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 1257,
+  "body": "Implement StartContinuousSync helper for Sonarr/Radarr background jobs",
+  "labels": ["codex", "enhancement"],
+  "guid": "61459ec1-54d1-4a9a-b81d-2f056813dc1e",
+  "legacy_guid": "update-issue-1257-2025-07-06"
+}

--- a/TODO.md
+++ b/TODO.md
@@ -47,11 +47,13 @@ This approach will:
         manage the service lifecycle.
 - [x] **Automated Maintenance Tasks**: Periodic database cleanup, metadata
       refresh, and disk scans. See [docs/SCHEDULING.md](docs/SCHEDULING.md).
--      ([#888](https://github.com/jdfalk/subtitle-manager/issues/888))
+      ([#888](https://github.com/jdfalk/subtitle-manager/issues/888))
 - [x] **Azure Blob Storage Support**: Initial Azure cloud storage provider.
 - [ ] **Sonarr/Radarr Sync Enhancements**: Continuous sync jobs and conflict
       resolution.
       ([#889](https://github.com/jdfalk/subtitle-manager/issues/889))
+  - [ ] Added `StartContinuousSync` helpers in radarr/sonarr packages for
+        scheduled background syncing.
 - [x] **Online Metadata Sources**: Fetch languages, ratings, and episode data
       from external APIs. `metadata fetch` command now supports `--id` for
       direct TMDB lookup.
@@ -242,8 +244,8 @@ Manager, cataloguing every feature from Bazarr's
 
 ### Executive Summary: Feature Parity Status
 
-| **Feature Category**   | **Bazarr Status**         | **Our Implementation**                                                               | **Gold Standard**             |
-| ---------------------- | ------------------------- | ------------------------------------------------------------------------------------ | ----------------------------- |
+| **Feature Category**   | **Bazarr Status**         | **Our Implementation**                                                              | **Gold Standard**            |
+| ---------------------- | ------------------------- | ----------------------------------------------------------------------------------- | ---------------------------- |
 | **Subtitle Providers** | 40+ providers supported   | ✅ 40+ providers ([registry.go](pkg/providers/registry.go))                          | ✅ Full parity achieved       |
 | **Web Interface**      | Modern React UI           | ✅ Complete React app ([webui/src/](webui/src/))                                     | ✅ Production ready           |
 | **Authentication**     | Basic auth + API keys     | ✅ Password, OAuth2, API keys, RBAC ([pkg/auth/](pkg/auth/))                         | ✅ Enterprise grade           |
@@ -262,28 +264,28 @@ Manager, cataloguing every feature from Bazarr's
 
 | Bazarr Feature               | Implementation Status | Code Reference                       |
 | ---------------------------- | --------------------- | ------------------------------------ |
-| Format conversion            | ✅ Complete           | [cmd/convert.go](cmd/convert.go)     |
-| Subtitle merging             | ✅ Complete           | [cmd/merge.go](cmd/merge.go)         |
-| Media extraction             | ✅ Complete           | [cmd/extract.go](cmd/extract.go)     |
-| Translation (Google/ChatGPT) | ✅ Complete           | [cmd/translate.go](cmd/translate.go) |
-| Batch processing             | ✅ Complete           | [cmd/batch.go](cmd/batch.go)         |
-| History tracking             | ✅ Complete           | [cmd/history.go](cmd/history.go)     |
+| Format conversion            | ✅ Complete            | [cmd/convert.go](cmd/convert.go)     |
+| Subtitle merging             | ✅ Complete            | [cmd/merge.go](cmd/merge.go)         |
+| Media extraction             | ✅ Complete            | [cmd/extract.go](cmd/extract.go)     |
+| Translation (Google/ChatGPT) | ✅ Complete            | [cmd/translate.go](cmd/translate.go) |
+| Batch processing             | ✅ Complete            | [cmd/batch.go](cmd/batch.go)         |
+| History tracking             | ✅ Complete            | [cmd/history.go](cmd/history.go)     |
 
 #### 2. Authentication & Authorization – Complete
 
 | Bazarr Feature            | Implementation Status | Code Reference                                   |
 | ------------------------- | --------------------- | ------------------------------------------------ |
-| Password authentication   | ✅ Complete           | [pkg/auth/auth.go](pkg/auth/auth.go)             |
-| API key management        | ✅ Complete           | [cmd/user.go](cmd/user.go)                       |
-| Session management        | ✅ Complete           | [pkg/webserver/auth.go](pkg/webserver/auth.go)   |
-| Role-based access control | ✅ Complete           | [pkg/auth/rbac.go](pkg/auth/rbac.go)             |
-| OAuth2 (GitHub)           | ✅ Complete           | [pkg/webserver/oauth.go](pkg/webserver/oauth.go) |
-| One-time tokens           | ✅ Complete           | [cmd/user.go](cmd/user.go)                       |
+| Password authentication   | ✅ Complete            | [pkg/auth/auth.go](pkg/auth/auth.go)             |
+| API key management        | ✅ Complete            | [cmd/user.go](cmd/user.go)                       |
+| Session management        | ✅ Complete            | [pkg/webserver/auth.go](pkg/webserver/auth.go)   |
+| Role-based access control | ✅ Complete            | [pkg/auth/rbac.go](pkg/auth/rbac.go)             |
+| OAuth2 (GitHub)           | ✅ Complete            | [pkg/webserver/oauth.go](pkg/webserver/oauth.go) |
+| One-time tokens           | ✅ Complete            | [cmd/user.go](cmd/user.go)                       |
 
 #### 3. Subtitle Providers – Complete - Full Bazarr Parity
 
-| Provider Category      | Bazarr Count | Our Implementation                                           | Status             |
-| ---------------------- | ------------ | ------------------------------------------------------------ | ------------------ |
+| Provider Category      | Bazarr Count | Our Implementation                                          | Status            |
+| ---------------------- | ------------ | ----------------------------------------------------------- | ----------------- |
 | Major providers        | ~40          | ✅ 40+ providers                                             | ✅ Parity achieved |
 | OpenSubtitles variants | 3            | ✅ Complete ([opensubtitles/](pkg/providers/opensubtitles/)) | ✅                 |
 | Regional providers     | ~25          | ✅ Complete (Greek, Turkish, etc.)                           | ✅                 |
@@ -293,8 +295,8 @@ Manager, cataloguing every feature from Bazarr's
 
 #### 4. Web Interface Pages – Complete
 
-| Bazarr Page         | Implementation Status     | Code Reference                                     |
-| ------------------- | ------------------------- | -------------------------------------------------- |
+| Bazarr Page         | Implementation Status    | Code Reference                                     |
+| ------------------- | ------------------------ | -------------------------------------------------- |
 | Dashboard           | ✅ Complete               | [webui/src/Dashboard.jsx](webui/src/Dashboard.jsx) |
 | Settings            | ✅ Complete               | [webui/src/Settings.jsx](webui/src/Settings.jsx)   |
 | History             | ✅ Complete               | [webui/src/History.jsx](webui/src/History.jsx)     |
@@ -307,26 +309,26 @@ Manager, cataloguing every feature from Bazarr's
 
 | Bazarr Feature     | Implementation Status | Code Reference                                     |
 | ------------------ | --------------------- | -------------------------------------------------- |
-| Sonarr integration | ✅ Complete           | [cmd/sonarr.go](cmd/sonarr.go)                     |
-| Radarr integration | ✅ Complete           | [cmd/radarr.go](cmd/radarr.go)                     |
-| Plex integration   | ✅ Complete           | [cmd/plex.go](cmd/plex.go), [pkg/plex/](pkg/plex/) |
-| Library scanning   | ✅ Complete           | [cmd/scan.go](cmd/scan.go)                         |
-| Directory watching | ✅ Complete           | [cmd/watch.go](cmd/watch.go)                       |
-| Webhooks           | ✅ Complete           | [pkg/webhooks](pkg/webhooks/)                      |
-| Notifications      | 🔶 Planned            | [TODO] Discord/Telegram/Email                      |
+| Sonarr integration | ✅ Complete            | [cmd/sonarr.go](cmd/sonarr.go)                     |
+| Radarr integration | ✅ Complete            | [cmd/radarr.go](cmd/radarr.go)                     |
+| Plex integration   | ✅ Complete            | [cmd/plex.go](cmd/plex.go), [pkg/plex/](pkg/plex/) |
+| Library scanning   | ✅ Complete            | [cmd/scan.go](cmd/scan.go)                         |
+| Directory watching | ✅ Complete            | [cmd/watch.go](cmd/watch.go)                       |
+| Webhooks           | ✅ Complete            | [pkg/webhooks](pkg/webhooks/)                      |
+| Notifications      | 🔶 Planned             | [TODO] Discord/Telegram/Email                      |
 
 #### 6. Advanced Features – Complete
 
 | Bazarr Feature        | Implementation Status | Code Reference                            |
 | --------------------- | --------------------- | ----------------------------------------- |
-| PostgreSQL support    | ✅ Complete           | SQLite, PebbleDB and PostgreSQL available |
-| Reverse proxy support | 🔶 Partial            | Basic configuration available             |
-| Anti-captcha service  | ✅ Complete           | [pkg/captcha/](pkg/captcha/)              |
-| Performance tuning    | ✅ Complete           | Concurrent workers, pools                 |
-| Custom scheduling     | ✅ Complete           | [pkg/scheduler/](pkg/scheduler/)          |
-| Bazarr config import  | ✅ Complete           | [cmd/import.go](cmd/import.go)            |
-| Webhook system        | ✅ Complete           | [pkg/webhooks/](pkg/webhooks/)            |
-| Notifications         | ✅ Complete           | [pkg/notifications/](pkg/notifications/)  |
+| PostgreSQL support    | ✅ Complete            | SQLite, PebbleDB and PostgreSQL available |
+| Reverse proxy support | 🔶 Partial             | Basic configuration available             |
+| Anti-captcha service  | ✅ Complete            | [pkg/captcha/](pkg/captcha/)              |
+| Performance tuning    | ✅ Complete            | Concurrent workers, pools                 |
+| Custom scheduling     | ✅ Complete            | [pkg/scheduler/](pkg/scheduler/)          |
+| Bazarr config import  | ✅ Complete            | [cmd/import.go](cmd/import.go)            |
+| Webhook system        | ✅ Complete            | [pkg/webhooks/](pkg/webhooks/)            |
+| Notifications         | ✅ Complete            | [pkg/notifications/](pkg/notifications/)  |
 
 ### Complete Provider Implementation Analysis
 
@@ -338,56 +340,56 @@ vs [Our Registry](pkg/providers/registry.go)
 
 | Provider                | Bazarr | Our Implementation | Documentation                                                               |
 | ----------------------- | ------ | ------------------ | --------------------------------------------------------------------------- |
-| Addic7ed                | ✅     | ✅                 | [addic7ed/](pkg/providers/addic7ed/)                                        |
-| AnimeKalesi             | ✅     | ✅                 | [animekalesi/](pkg/providers/animekalesi/)                                  |
-| Animetosho              | ✅     | ✅                 | [animetosho/](pkg/providers/animetosho/)                                    |
-| Assrt                   | ✅     | ✅                 | [assrt/](pkg/providers/assrt/)                                              |
-| AvistaZ/CinemaZ         | ✅     | ✅                 | [avistaz/](pkg/providers/avistaz/)                                          |
-| BetaSeries              | ✅     | ✅                 | [betaseries/](pkg/providers/betaseries/)                                    |
-| BSplayer                | ✅     | ✅                 | [bsplayer/](pkg/providers/bsplayer/)                                        |
-| Embedded Subtitles      | ✅     | ✅                 | [embedded/](pkg/providers/embedded/)                                        |
-| Gestdown.info           | ✅     | ✅                 | [gestdown/](pkg/providers/gestdown/)                                        |
-| GreekSubs               | ✅     | ✅                 | [greeksubs/](pkg/providers/greeksubs/)                                      |
-| GreekSubtitles          | ✅     | ✅                 | [greeksubtitles/](pkg/providers/greeksubtitles/)                            |
-| HDBits.org              | ✅     | ✅                 | [hdbits/](pkg/providers/hdbits/)                                            |
-| Hosszupuska             | ✅     | ✅                 | [hosszupuska/](pkg/providers/hosszupuska/)                                  |
-| Karagarga.in            | ✅     | ✅                 | [karagarga/](pkg/providers/karagarga/)                                      |
-| Ktuvit                  | ✅     | ✅                 | [ktuvit/](pkg/providers/ktuvit/)                                            |
-| LegendasDivx            | ✅     | ✅                 | [legendasdivx/](pkg/providers/legendasdivx/)                                |
-| Legendas.net            | ✅     | ✅                 | [legendasnet/](pkg/providers/legendasnet/)                                  |
-| Napiprojekt             | ✅     | ✅                 | [napiprojekt/](pkg/providers/napiprojekt/)                                  |
-| Napisy24                | ✅     | ✅                 | [napisy24/](pkg/providers/napisy24/)                                        |
-| Nekur                   | ✅     | ✅                 | [nekur/](pkg/providers/nekur/)                                              |
-| OpenSubtitles.com       | ✅     | ✅                 | [opensubtitlescom/](pkg/providers/opensubtitlescom/)                        |
-| OpenSubtitles.org (VIP) | ✅     | ✅                 | [opensubtitlesvip/](pkg/providers/opensubtitlesvip/)                        |
-| Podnapisi               | ✅     | ✅                 | [podnapisi/](pkg/providers/podnapisi/)                                      |
-| RegieLive               | ✅     | ✅                 | [regielive/](pkg/providers/regielive/)                                      |
-| Sous-Titres.eu          | ✅     | ✅                 | [soustitres/](pkg/providers/soustitres/)                                    |
-| Subdivx                 | ✅     | ✅                 | [subdivx/](pkg/providers/subdivx/)                                          |
-| subf2m.co               | ✅     | ✅                 | [subf2m/](pkg/providers/subf2m/)                                            |
-| Subs.sab.bz             | ✅     | ✅                 | [subssabbz/](pkg/providers/subssabbz/)                                      |
-| Subs4Free               | ✅     | ✅                 | [subs4free/](pkg/providers/subs4free/)                                      |
-| Subs4Series             | ✅     | ✅                 | [subs4series/](pkg/providers/subs4series/)                                  |
-| Subscene                | ✅     | ✅                 | [subscene/](pkg/providers/subscene/)                                        |
-| Subscenter              | ✅     | ✅                 | [subscenter/](pkg/providers/subscenter/)                                    |
-| Subsunacs.net           | ✅     | ✅                 | [subsunacs/](pkg/providers/subsunacs/)                                      |
-| SubSynchro              | ✅     | ✅                 | [subsynchro/](pkg/providers/subsynchro/)                                    |
-| Subtitrari-noi.ro       | ✅     | ✅                 | [subtitrarinoi/](pkg/providers/subtitrarinoi/)                              |
-| subtitri.id.lv          | ✅     | ✅                 | [subtitriidlv/](pkg/providers/subtitriidlv/)                                |
-| Subtitulamos.tv         | ✅     | ✅                 | [subtitulamos/](pkg/providers/subtitulamos/)                                |
-| Supersubtitles          | ✅     | ✅                 | [supersubtitles/](pkg/providers/supersubtitles/)                            |
-| Titlovi                 | ✅     | ✅                 | [titlovi/](pkg/providers/titlovi/)                                          |
-| Titrari.ro              | ✅     | ✅                 | [titrariro/](pkg/providers/titrariro/)                                      |
-| Titulky.com             | ✅     | ✅                 | [titulky/](pkg/providers/titulky/)                                          |
-| Turkcealtyazi.org       | ✅     | ✅                 | [turkcealtyazi/](pkg/providers/turkcealtyazi/)                              |
-| TuSubtitulo             | ✅     | ✅                 | [tusubtitulo/](pkg/providers/tusubtitulo/)                                  |
-| TVSubtitles             | ✅     | ✅                 | [tvsubtitles/](pkg/providers/tvsubtitles/)                                  |
-| Whisper                 | ✅     | ✅                 | [whisper/](pkg/providers/whisper/) + [cmd/transcribe.go](cmd/transcribe.go) |
-| Wizdom                  | ✅     | ✅                 | [wizdom/](pkg/providers/wizdom/)                                            |
-| XSubs                   | ✅     | ✅                 | [xsubs/](pkg/providers/xsubs/)                                              |
-| Yavka.net               | ✅     | ✅                 | [yavka/](pkg/providers/yavka/)                                              |
-| YIFY Subtitles          | ✅     | ✅                 | [yifysubtitles/](pkg/providers/yifysubtitles/)                              |
-| Zimuku                  | ✅     | ✅                 | [zimuku/](pkg/providers/zimuku/)                                            |
+| Addic7ed                | ✅      | ✅                  | [addic7ed/](pkg/providers/addic7ed/)                                        |
+| AnimeKalesi             | ✅      | ✅                  | [animekalesi/](pkg/providers/animekalesi/)                                  |
+| Animetosho              | ✅      | ✅                  | [animetosho/](pkg/providers/animetosho/)                                    |
+| Assrt                   | ✅      | ✅                  | [assrt/](pkg/providers/assrt/)                                              |
+| AvistaZ/CinemaZ         | ✅      | ✅                  | [avistaz/](pkg/providers/avistaz/)                                          |
+| BetaSeries              | ✅      | ✅                  | [betaseries/](pkg/providers/betaseries/)                                    |
+| BSplayer                | ✅      | ✅                  | [bsplayer/](pkg/providers/bsplayer/)                                        |
+| Embedded Subtitles      | ✅      | ✅                  | [embedded/](pkg/providers/embedded/)                                        |
+| Gestdown.info           | ✅      | ✅                  | [gestdown/](pkg/providers/gestdown/)                                        |
+| GreekSubs               | ✅      | ✅                  | [greeksubs/](pkg/providers/greeksubs/)                                      |
+| GreekSubtitles          | ✅      | ✅                  | [greeksubtitles/](pkg/providers/greeksubtitles/)                            |
+| HDBits.org              | ✅      | ✅                  | [hdbits/](pkg/providers/hdbits/)                                            |
+| Hosszupuska             | ✅      | ✅                  | [hosszupuska/](pkg/providers/hosszupuska/)                                  |
+| Karagarga.in            | ✅      | ✅                  | [karagarga/](pkg/providers/karagarga/)                                      |
+| Ktuvit                  | ✅      | ✅                  | [ktuvit/](pkg/providers/ktuvit/)                                            |
+| LegendasDivx            | ✅      | ✅                  | [legendasdivx/](pkg/providers/legendasdivx/)                                |
+| Legendas.net            | ✅      | ✅                  | [legendasnet/](pkg/providers/legendasnet/)                                  |
+| Napiprojekt             | ✅      | ✅                  | [napiprojekt/](pkg/providers/napiprojekt/)                                  |
+| Napisy24                | ✅      | ✅                  | [napisy24/](pkg/providers/napisy24/)                                        |
+| Nekur                   | ✅      | ✅                  | [nekur/](pkg/providers/nekur/)                                              |
+| OpenSubtitles.com       | ✅      | ✅                  | [opensubtitlescom/](pkg/providers/opensubtitlescom/)                        |
+| OpenSubtitles.org (VIP) | ✅      | ✅                  | [opensubtitlesvip/](pkg/providers/opensubtitlesvip/)                        |
+| Podnapisi               | ✅      | ✅                  | [podnapisi/](pkg/providers/podnapisi/)                                      |
+| RegieLive               | ✅      | ✅                  | [regielive/](pkg/providers/regielive/)                                      |
+| Sous-Titres.eu          | ✅      | ✅                  | [soustitres/](pkg/providers/soustitres/)                                    |
+| Subdivx                 | ✅      | ✅                  | [subdivx/](pkg/providers/subdivx/)                                          |
+| subf2m.co               | ✅      | ✅                  | [subf2m/](pkg/providers/subf2m/)                                            |
+| Subs.sab.bz             | ✅      | ✅                  | [subssabbz/](pkg/providers/subssabbz/)                                      |
+| Subs4Free               | ✅      | ✅                  | [subs4free/](pkg/providers/subs4free/)                                      |
+| Subs4Series             | ✅      | ✅                  | [subs4series/](pkg/providers/subs4series/)                                  |
+| Subscene                | ✅      | ✅                  | [subscene/](pkg/providers/subscene/)                                        |
+| Subscenter              | ✅      | ✅                  | [subscenter/](pkg/providers/subscenter/)                                    |
+| Subsunacs.net           | ✅      | ✅                  | [subsunacs/](pkg/providers/subsunacs/)                                      |
+| SubSynchro              | ✅      | ✅                  | [subsynchro/](pkg/providers/subsynchro/)                                    |
+| Subtitrari-noi.ro       | ✅      | ✅                  | [subtitrarinoi/](pkg/providers/subtitrarinoi/)                              |
+| subtitri.id.lv          | ✅      | ✅                  | [subtitriidlv/](pkg/providers/subtitriidlv/)                                |
+| Subtitulamos.tv         | ✅      | ✅                  | [subtitulamos/](pkg/providers/subtitulamos/)                                |
+| Supersubtitles          | ✅      | ✅                  | [supersubtitles/](pkg/providers/supersubtitles/)                            |
+| Titlovi                 | ✅      | ✅                  | [titlovi/](pkg/providers/titlovi/)                                          |
+| Titrari.ro              | ✅      | ✅                  | [titrariro/](pkg/providers/titrariro/)                                      |
+| Titulky.com             | ✅      | ✅                  | [titulky/](pkg/providers/titulky/)                                          |
+| Turkcealtyazi.org       | ✅      | ✅                  | [turkcealtyazi/](pkg/providers/turkcealtyazi/)                              |
+| TuSubtitulo             | ✅      | ✅                  | [tusubtitulo/](pkg/providers/tusubtitulo/)                                  |
+| TVSubtitles             | ✅      | ✅                  | [tvsubtitles/](pkg/providers/tvsubtitles/)                                  |
+| Whisper                 | ✅      | ✅                  | [whisper/](pkg/providers/whisper/) + [cmd/transcribe.go](cmd/transcribe.go) |
+| Wizdom                  | ✅      | ✅                  | [wizdom/](pkg/providers/wizdom/)                                            |
+| XSubs                   | ✅      | ✅                  | [xsubs/](pkg/providers/xsubs/)                                              |
+| Yavka.net               | ✅      | ✅                  | [yavka/](pkg/providers/yavka/)                                              |
+| YIFY Subtitles          | ✅      | ✅                  | [yifysubtitles/](pkg/providers/yifysubtitles/)                              |
+| Zimuku                  | ✅      | ✅                  | [zimuku/](pkg/providers/zimuku/)                                            |
 
 #### Bazarr Settings Comparison Analysis
 
@@ -396,33 +398,33 @@ vs [Our Registry](pkg/providers/registry.go)
 
 | Bazarr Setting Category      | Implementation Status | Our Location                     | Bazarr Reference                                                                                                                      |
 | ---------------------------- | --------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Host Settings**            | ✅ Complete           | [cmd/root.go](cmd/root.go)       | [Host](https://wiki.bazarr.media/Additional-Configuration/Settings/#host)                                                             |
-| - Bind Address               | ✅ Complete           | Viper config                     | -                                                                                                                                     |
-| - Port Number                | ✅ Complete           | Viper config                     | -                                                                                                                                     |
-| - URL Base                   | ✅ Complete           | Reverse proxy support            | [URL Base](https://wiki.bazarr.media/Additional-Configuration/Settings/#url-base)                                                     |
-| **Security Settings**        | ✅ Complete           | [pkg/auth/](pkg/auth/)           | [Security](https://wiki.bazarr.media/Additional-Configuration/Settings/#security)                                                     |
-| - Authentication             | ✅ Enhanced           | Multi-mode auth                  | [Authentication](https://wiki.bazarr.media/Additional-Configuration/Settings/#authentication)                                         |
-| - Username/Password          | ✅ Complete           | Hashed storage                   | -                                                                                                                                     |
-| - API Key                    | ✅ Enhanced           | Multiple keys                    | [API Key](https://wiki.bazarr.media/Additional-Configuration/Settings/#api-key)                                                       |
-| **Proxy Settings**           | ✅ Complete           | HTTP client config               | [Proxy](https://wiki.bazarr.media/Additional-Configuration/Settings/#proxy)                                                           |
-| **Sonarr Integration**       | ✅ Complete           | [cmd/sonarr.go](cmd/sonarr.go)   | [Sonarr](https://wiki.bazarr.media/Additional-Configuration/Settings/#sonarr)                                                         |
-| - Host Configuration         | ✅ Complete           | Viper config                     | -                                                                                                                                     |
-| - API Key                    | ✅ Complete           | Secure storage                   | -                                                                                                                                     |
-| - Path Mappings              | ✅ Complete           | Config mappings                  | [Path Mappings](https://wiki.bazarr.media/Additional-Configuration/Settings/#path-mappings)                                           |
-| **Radarr Integration**       | ✅ Complete           | [cmd/radarr.go](cmd/radarr.go)   | [Radarr](https://wiki.bazarr.media/Additional-Configuration/Settings/#radarr)                                                         |
-| **Subtitle Options**         | ✅ Complete           | [pkg/subtitles/](pkg/subtitles/) | [Subtitles](https://wiki.bazarr.media/Additional-Configuration/Settings/#subtitles)                                                   |
-| - Subtitle Folder            | ✅ Complete           | Config option                    | -                                                                                                                                     |
-| - Upgrade Logic              | ✅ Complete           | Auto-upgrade                     | [Upgrade Previously Downloaded](https://wiki.bazarr.media/Additional-Configuration/Settings/#upgrade-previously-downloaded-subtitles) |
-| **Anti-Captcha**             | ✅ Basic              | [pkg/captcha/](pkg/captcha/)     | [Anti-Captcha Options](https://wiki.bazarr.media/Additional-Configuration/Settings/#anti-captcha-options)                             |
-| **Performance/Optimization** | ✅ Complete           | Worker pools                     | [Performance](https://wiki.bazarr.media/Additional-Configuration/Settings/#performance-optimization)                                  |
-| - Adaptive Searching         | 🔶 Basic              | Simple scheduling                | [Adaptive Searching](https://wiki.bazarr.media/Additional-Configuration/Settings/#adaptive-searching)                                 |
-| - Simultaneous Search        | ✅ Complete           | Concurrent workers               | -                                                                                                                                     |
-| - Embedded Subtitles         | ✅ Complete           | Full support                     | [Use Embedded Subtitles](https://wiki.bazarr.media/Additional-Configuration/Settings/#use-embedded-subtitles)                         |
-| **Post-Processing**          | ✅ Complete           | UTF-8 encoding                   | [Post-Processing](https://wiki.bazarr.media/Additional-Configuration/Settings/#post-processing)                                       |
-| **Languages**                | ✅ Complete           | 180+ languages                   | [Languages](https://wiki.bazarr.media/Additional-Configuration/Settings/#languages)                                                   |
-| **Providers**                | ✅ Complete           | Full registry                    | [Providers](https://wiki.bazarr.media/Additional-Configuration/Settings/#providers)                                                   |
-| **Notifications**            | ✅ Basic              | Infrastructure ready             | [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)                                           |
-| **Scheduler**                | ✅ Basic              | Auto-scan available              | [Scheduler](https://wiki.bazarr.media/Additional-Configuration/Settings/#scheduler)                                                   |
+| **Host Settings**            | ✅ Complete            | [cmd/root.go](cmd/root.go)       | [Host](https://wiki.bazarr.media/Additional-Configuration/Settings/#host)                                                             |
+| - Bind Address               | ✅ Complete            | Viper config                     | -                                                                                                                                     |
+| - Port Number                | ✅ Complete            | Viper config                     | -                                                                                                                                     |
+| - URL Base                   | ✅ Complete            | Reverse proxy support            | [URL Base](https://wiki.bazarr.media/Additional-Configuration/Settings/#url-base)                                                     |
+| **Security Settings**        | ✅ Complete            | [pkg/auth/](pkg/auth/)           | [Security](https://wiki.bazarr.media/Additional-Configuration/Settings/#security)                                                     |
+| - Authentication             | ✅ Enhanced            | Multi-mode auth                  | [Authentication](https://wiki.bazarr.media/Additional-Configuration/Settings/#authentication)                                         |
+| - Username/Password          | ✅ Complete            | Hashed storage                   | -                                                                                                                                     |
+| - API Key                    | ✅ Enhanced            | Multiple keys                    | [API Key](https://wiki.bazarr.media/Additional-Configuration/Settings/#api-key)                                                       |
+| **Proxy Settings**           | ✅ Complete            | HTTP client config               | [Proxy](https://wiki.bazarr.media/Additional-Configuration/Settings/#proxy)                                                           |
+| **Sonarr Integration**       | ✅ Complete            | [cmd/sonarr.go](cmd/sonarr.go)   | [Sonarr](https://wiki.bazarr.media/Additional-Configuration/Settings/#sonarr)                                                         |
+| - Host Configuration         | ✅ Complete            | Viper config                     | -                                                                                                                                     |
+| - API Key                    | ✅ Complete            | Secure storage                   | -                                                                                                                                     |
+| - Path Mappings              | ✅ Complete            | Config mappings                  | [Path Mappings](https://wiki.bazarr.media/Additional-Configuration/Settings/#path-mappings)                                           |
+| **Radarr Integration**       | ✅ Complete            | [cmd/radarr.go](cmd/radarr.go)   | [Radarr](https://wiki.bazarr.media/Additional-Configuration/Settings/#radarr)                                                         |
+| **Subtitle Options**         | ✅ Complete            | [pkg/subtitles/](pkg/subtitles/) | [Subtitles](https://wiki.bazarr.media/Additional-Configuration/Settings/#subtitles)                                                   |
+| - Subtitle Folder            | ✅ Complete            | Config option                    | -                                                                                                                                     |
+| - Upgrade Logic              | ✅ Complete            | Auto-upgrade                     | [Upgrade Previously Downloaded](https://wiki.bazarr.media/Additional-Configuration/Settings/#upgrade-previously-downloaded-subtitles) |
+| **Anti-Captcha**             | ✅ Basic               | [pkg/captcha/](pkg/captcha/)     | [Anti-Captcha Options](https://wiki.bazarr.media/Additional-Configuration/Settings/#anti-captcha-options)                             |
+| **Performance/Optimization** | ✅ Complete            | Worker pools                     | [Performance](https://wiki.bazarr.media/Additional-Configuration/Settings/#performance-optimization)                                  |
+| - Adaptive Searching         | 🔶 Basic               | Simple scheduling                | [Adaptive Searching](https://wiki.bazarr.media/Additional-Configuration/Settings/#adaptive-searching)                                 |
+| - Simultaneous Search        | ✅ Complete            | Concurrent workers               | -                                                                                                                                     |
+| - Embedded Subtitles         | ✅ Complete            | Full support                     | [Use Embedded Subtitles](https://wiki.bazarr.media/Additional-Configuration/Settings/#use-embedded-subtitles)                         |
+| **Post-Processing**          | ✅ Complete            | UTF-8 encoding                   | [Post-Processing](https://wiki.bazarr.media/Additional-Configuration/Settings/#post-processing)                                       |
+| **Languages**                | ✅ Complete            | 180+ languages                   | [Languages](https://wiki.bazarr.media/Additional-Configuration/Settings/#languages)                                                   |
+| **Providers**                | ✅ Complete            | Full registry                    | [Providers](https://wiki.bazarr.media/Additional-Configuration/Settings/#providers)                                                   |
+| **Notifications**            | ✅ Basic               | Infrastructure ready             | [Notifications](https://wiki.bazarr.media/Additional-Configuration/Settings/#notifications)                                           |
+| **Scheduler**                | ✅ Basic               | Auto-scan available              | [Scheduler](https://wiki.bazarr.media/Additional-Configuration/Settings/#scheduler)                                                   |
 
 ### Missing Features Analysis
 
@@ -529,8 +531,8 @@ vs [Our Registry](pkg/providers/registry.go)
 
 ### 4. Three-Column Gold Standard Comparison
 
-| **Feature**                  | **Bazarr Implementation**    | **Subtitle Manager Status**         | **Gold Standard Target**            |
-| ---------------------------- | ---------------------------- | ----------------------------------- | ----------------------------------- |
+| **Feature**                  | **Bazarr Implementation**    | **Subtitle Manager Status**        | **Gold Standard Target**           |
+| ---------------------------- | ---------------------------- | ---------------------------------- | ---------------------------------- |
 | **Core Subtitle Operations** | Python-based processing      | ✅ Go with go-astisub               | ✅ **Superior performance**         |
 | **Subtitle Providers**       | 40+ providers via Subliminal | ✅ 40+ native Go clients            | ✅ **Direct API integration**       |
 | **Authentication**           | Basic/Forms auth             | ✅ Multi-mode + OAuth2 + RBAC       | ✅ **Enterprise grade**             |

--- a/pkg/radarr/scheduler.go
+++ b/pkg/radarr/scheduler.go
@@ -15,3 +15,13 @@ func StartSync(ctx context.Context, interval time.Duration, c *Client, store dat
 		return Sync(ctx, c, store)
 	})
 }
+
+// StartContinuousSync runs Sync on a fixed interval with optional jitter.
+// It wraps scheduler.RunWithOptions to allow smoother scheduling when multiple
+// services are enabled.
+func StartContinuousSync(ctx context.Context, interval, jitter time.Duration, c *Client, store database.SubtitleStore) {
+	opts := scheduler.Options{Interval: interval, Jitter: jitter}
+	go scheduler.RunWithOptions(ctx, opts, func(ctx context.Context) error {
+		return Sync(ctx, c, store)
+	})
+}

--- a/pkg/sonarr/scheduler.go
+++ b/pkg/sonarr/scheduler.go
@@ -22,3 +22,13 @@ func StartSync(ctx context.Context, interval time.Duration, c *Client, store dat
 		return Sync(ctx, c, store)
 	})
 }
+
+// StartContinuousSync runs Sync on a fixed interval with optional jitter.
+// It leverages scheduler.RunWithOptions so multiple sync jobs can stagger their
+// execution and avoid conflicts.
+func StartContinuousSync(ctx context.Context, interval, jitter time.Duration, c *Client, store database.SubtitleStore) {
+	opts := scheduler.Options{Interval: interval, Jitter: jitter}
+	go scheduler.RunWithOptions(ctx, opts, func(ctx context.Context) error {
+		return Sync(ctx, c, store)
+	})
+}


### PR DESCRIPTION
## Description
Introduce `StartContinuousSync` functions for Sonarr and Radarr schedulers and log the new work in TODO and issue updates.

## Motivation
Background sync jobs require configurable jitter so multiple services don't collide. These helpers pave the way for continuous sync enhancements.

## Changes
- new `StartContinuousSync` in Radarr and Sonarr schedulers
- documented progress in TODO
- recorded issue update for #1257

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: p.Providers undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca8397908321afaf14640dbfd329