### PR TITLE
Add tag management CLI

### DIFF
--- a/.github/issue-updates/c0da4c95-97d2-4c3e-b50c-1ee8668f3b8a.json
+++ b/.github/issue-updates/c0da4c95-97d2-4c3e-b50c-1ee8668f3b8a.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 1288,
+  "body": "Begin implementing tag CLI with list/add/remove operations",
+  "guid": "c0da4c95-97d2-4c3e-b50c-1ee8668f3b8a",
+  "legacy_guid": "comment-issue-1288-2025-07-06"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.
 - History API now filters by video file path via `video` query parameter.
 - Self-test system verifies startup components and exits on failure.
 - **Azure Blob Storage provider**: Initial support for Microsoft Azure cloud storage.
+- Command-line `tag` management with list, add, and remove operations.
 - **Enhanced Issue Management Workflow**: Updated GitHub workflow configuration
   - Automatic triggering on merges to main branch when issue files change
   - Weekly scheduled maintenance on Sundays at 2 AM UTC

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ anti-captcha integration, and a polished React web interface.**
   database.
 - Manage accounts with `user add`, `user role`, `user token` and `user list`
   commands.
+- Manage tags with `tag list`, `tag add` and `tag remove` commands.
 - **Universal Tagging System**: Unified tagging interface supporting all entity
   types (media, users, providers, language profiles) with consistent API and
   advanced filtering capabilities.

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,8 @@ This approach will:
   - [x] Add tags table to the database and expose tag management in settings.
   - [x] Apply tags to media and users to drive language selection and provider
         behavior.
+  - [x] **Tag Management CLI**: List, add, and remove tags from the command
+        line. ([#1288](https://github.com/jdfalk/subtitle-manager/issues/1288))
 - [ ] **Whisper Container Integration**: Optional embedded Whisper service.
       ([#1132](https://github.com/jdfalk/subtitle-manager/issues/1132))
   - [x] Launch

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,27 +136,6 @@ func InitFlags() {
 	rootCmd.PersistentFlags().String("anticaptcha-api-url", "", "Anti-Captcha API base URL")
 	viper.BindPFlag("anticaptcha.api_url", rootCmd.PersistentFlags().Lookup("anticaptcha-api-url"))
 
-	// Cache configuration flags
-	rootCmd.PersistentFlags().String("cache-backend", "memory", "cache backend: memory or redis")
-	viper.BindPFlag("cache.backend", rootCmd.PersistentFlags().Lookup("cache-backend"))
-	rootCmd.PersistentFlags().String("cache-redis-address", "localhost:6379", "Redis server address")
-	viper.BindPFlag("cache.redis.address", rootCmd.PersistentFlags().Lookup("cache-redis-address"))
-	rootCmd.PersistentFlags().String("cache-redis-password", "", "Redis password")
-	viper.BindPFlag("cache.redis.password", rootCmd.PersistentFlags().Lookup("cache-redis-password"))
-	rootCmd.PersistentFlags().Int("cache-redis-database", 0, "Redis database number")
-	viper.BindPFlag("cache.redis.database", rootCmd.PersistentFlags().Lookup("cache-redis-database"))
-	rootCmd.PersistentFlags().String("cache-redis-key-prefix", "subtitle-manager:", "Redis key prefix")
-	viper.BindPFlag("cache.redis.key_prefix", rootCmd.PersistentFlags().Lookup("cache-redis-key-prefix"))
-	rootCmd.PersistentFlags().Int("cache-memory-max-entries", 10000, "Maximum number of memory cache entries")
-	viper.BindPFlag("cache.memory.max_entries", rootCmd.PersistentFlags().Lookup("cache-memory-max-entries"))
-	rootCmd.PersistentFlags().Int64("cache-memory-max-memory", 104857600, "Maximum memory cache size in bytes (100MB)")
-	viper.BindPFlag("cache.memory.max_memory", rootCmd.PersistentFlags().Lookup("cache-memory-max-memory"))
-
-	// Cloud storage configuration
-	rootCmd.PersistentFlags().String("storage-provider", "local", "storage provider: local, s3, azure, gcs")
-	viper.BindPFlag("storage.provider", rootCmd.PersistentFlags().Lookup("storage-provider"))
-	rootCmd.PersistentFlags().String("storage-local-path", "subtitles", "local storage path")
-	viper.BindPFlag("storage.local_path", rootCmd.PersistentFlags().Lookup("storage-local-path"))
 	// S3 configuration
 	rootCmd.PersistentFlags().String("s3-region", "", "S3 region")
 	viper.BindPFlag("storage.s3_region", rootCmd.PersistentFlags().Lookup("s3-region"))
@@ -205,40 +184,6 @@ func InitFlags() {
 	viper.BindPFlag("cache.memory.max_entries", rootCmd.PersistentFlags().Lookup("cache-memory-max-entries"))
 	rootCmd.PersistentFlags().Int64("cache-memory-max-memory", 104857600, "Maximum memory cache size in bytes (100MB)")
 	viper.BindPFlag("cache.memory.max_memory", rootCmd.PersistentFlags().Lookup("cache-memory-max-memory"))
-
-	// Cloud storage configuration
-	rootCmd.PersistentFlags().String("storage-provider", "local", "storage provider: local, s3, azure, gcs")
-	viper.BindPFlag("storage.provider", rootCmd.PersistentFlags().Lookup("storage-provider"))
-	rootCmd.PersistentFlags().String("storage-local-path", "subtitles", "local storage path")
-	viper.BindPFlag("storage.local_path", rootCmd.PersistentFlags().Lookup("storage-local-path"))
-	// S3 configuration
-	rootCmd.PersistentFlags().String("s3-region", "", "S3 region")
-	viper.BindPFlag("storage.s3_region", rootCmd.PersistentFlags().Lookup("s3-region"))
-	rootCmd.PersistentFlags().String("s3-bucket", "", "S3 bucket name")
-	viper.BindPFlag("storage.s3_bucket", rootCmd.PersistentFlags().Lookup("s3-bucket"))
-	rootCmd.PersistentFlags().String("s3-endpoint", "", "S3 endpoint URL (for S3-compatible services)")
-	viper.BindPFlag("storage.s3_endpoint", rootCmd.PersistentFlags().Lookup("s3-endpoint"))
-	rootCmd.PersistentFlags().String("s3-access-key", "", "S3 access key")
-	viper.BindPFlag("storage.s3_access_key", rootCmd.PersistentFlags().Lookup("s3-access-key"))
-	rootCmd.PersistentFlags().String("s3-secret-key", "", "S3 secret key")
-	viper.BindPFlag("storage.s3_secret_key", rootCmd.PersistentFlags().Lookup("s3-secret-key"))
-	// Azure configuration
-	rootCmd.PersistentFlags().String("azure-account", "", "Azure storage account name")
-	viper.BindPFlag("storage.azure_account", rootCmd.PersistentFlags().Lookup("azure-account"))
-	rootCmd.PersistentFlags().String("azure-key", "", "Azure storage account key")
-	viper.BindPFlag("storage.azure_key", rootCmd.PersistentFlags().Lookup("azure-key"))
-	rootCmd.PersistentFlags().String("azure-container", "", "Azure blob container name")
-	viper.BindPFlag("storage.azure_container", rootCmd.PersistentFlags().Lookup("azure-container"))
-	// GCS configuration
-	rootCmd.PersistentFlags().String("gcs-bucket", "", "Google Cloud Storage bucket name")
-	viper.BindPFlag("storage.gcs_bucket", rootCmd.PersistentFlags().Lookup("gcs-bucket"))
-	rootCmd.PersistentFlags().String("gcs-credentials", "", "Google Cloud credentials JSON file path")
-	viper.BindPFlag("storage.gcs_credentials", rootCmd.PersistentFlags().Lookup("gcs-credentials"))
-	// Storage options
-	rootCmd.PersistentFlags().Bool("storage-enable-backup", false, "enable cloud backup of subtitle files")
-	viper.BindPFlag("storage.enable_backup", rootCmd.PersistentFlags().Lookup("storage-enable-backup"))
-	rootCmd.PersistentFlags().Bool("storage-backup-history", false, "enable cloud backup of history data")
-	viper.BindPFlag("storage.backup_history", rootCmd.PersistentFlags().Lookup("storage-backup-history"))
 
 	rootCmd.AddCommand(convertCmd)
 	rootCmd.AddCommand(mergeCmd)

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,0 +1,93 @@
+// file: cmd/tag.go
+// version: 1.0.0
+// guid: 3796780f-7c51-4ad6-b073-43e3d5e9e837
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/tagging"
+)
+
+var (
+	tagTypeFlag   string
+	tagEntityType string
+	tagColor      string
+	tagDesc       string
+)
+
+var tagCmd = &cobra.Command{
+	Use:   "tag",
+	Short: "Manage tags",
+}
+
+var tagListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List tags",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := database.OpenSQLStore(database.GetDatabasePath())
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+		tags, err := store.ListTags()
+		if err != nil {
+			return err
+		}
+		for _, t := range tags {
+			cmd.Printf("%s\t%s\t%s\t%s\t%s\n", t.ID, t.Name, t.Type, t.Color, t.Description)
+		}
+		return nil
+	},
+}
+
+var tagAddCmd = &cobra.Command{
+	Use:   "add [name]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Create a tag",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := database.OpenSQLStore(database.GetDatabasePath())
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+		tm := tagging.NewTagManager(store.DB())
+		_, err = tm.CreateTag(args[0], tagTypeFlag, tagEntityType, tagColor, tagDesc)
+		return err
+	},
+}
+
+var tagRemoveCmd = &cobra.Command{
+	Use:   "remove [id]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Delete a tag",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := database.OpenSQLStore(database.GetDatabasePath())
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+		id, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid id: %w", err)
+		}
+		return store.DeleteTag(id)
+	},
+}
+
+func init() {
+	tagAddCmd.Flags().StringVar(&tagTypeFlag, "type", "user", "tag type")
+	tagAddCmd.Flags().StringVar(&tagEntityType, "entity", "all", "entity type")
+	tagAddCmd.Flags().StringVar(&tagColor, "color", "", "tag color")
+	tagAddCmd.Flags().StringVar(&tagDesc, "desc", "", "tag description")
+
+	tagCmd.AddCommand(tagListCmd)
+	tagCmd.AddCommand(tagAddCmd)
+	tagCmd.AddCommand(tagRemoveCmd)
+	rootCmd.AddCommand(tagCmd)
+}

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -1,0 +1,61 @@
+// file: cmd/tag_test.go
+// version: 1.0.0
+// guid: 1bcf09a8-2b3d-4a1d-9473-73f63af2dd14
+package cmd
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/testutil"
+)
+
+// TestTagCommands verifies tag add, list, and remove operations.
+func TestTagCommands(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	if err := testutil.CheckSQLiteSupport(); err != nil {
+		t.Skipf("SQLite support not available: %v", err)
+	}
+
+	dir := t.TempDir()
+	dbPath := dir + "/test.db"
+	viper.Set("db_path", dbPath)
+	defer viper.Reset()
+
+	store, err := database.OpenStore(dbPath, "sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	store.Close()
+
+	// Add tag
+	tagTypeFlag = "user"
+	tagEntityType = "all"
+	tagColor = "#ff0000"
+	tagDesc = "test"
+	if err := tagAddCmd.RunE(tagAddCmd, []string{"demo"}); err != nil {
+		t.Fatalf("tag add: %v", err)
+	}
+
+	// List tags
+	buf := &bytes.Buffer{}
+	tagListCmd.SetOut(buf)
+	if err := tagListCmd.RunE(tagListCmd, nil); err != nil {
+		t.Fatalf("tag list: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "demo") {
+		t.Fatalf("expected tag in list")
+	}
+
+	// Remove tag
+	if err := tagRemoveCmd.RunE(tagRemoveCmd, []string{"1"}); err != nil {
+		t.Fatalf("tag remove: %v", err)
+	}
+}


### PR DESCRIPTION
## Description
Introduce a new `tag` command for listing, adding and removing tags.

## Motivation
Completes outstanding feature for universal tagging system by exposing CLI operations.

## Changes
- add `tag` subcommand with list/add/remove
- create unit test for tag command
- remove duplicate flag registrations in root command
- document tag CLI and update TODO
- add changelog entry

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b0af496c88321ae4170731c521c27