### PR TITLE
Fix dev container Node ENOENT error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get update \
     # Install additional development tools
     && apt-get install -y curl wget unzip zip jq \
     #
+    # Install Node.js 20 for devcontainer
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    #
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,7 +7,7 @@ all necessary tools and dependencies pre-installed.
 ## Features
 
 - **Go 1.24+** with development tools (golangci-lint, goimports, dlv, etc.)
-- **Node.js 20** for React frontend development
+- **Node.js 20** for React frontend development (installed via apt-get)
 - **FFmpeg** for subtitle processing
 - **SQLite** with CGO support enabled
 - **VS Code extensions** for Go and React development

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,10 +68,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
   "forwardPorts": [8080, 3000],


### PR DESCRIPTION
## Description
Install Node.js directly via apt to prevent ENOENT error during dev container startup. Remove the node feature and update documentation accordingly.

## Motivation
VS Code dev containers failed with `ENOENT` while setting up Node. Preinstalling Node resolves the issue.

## Changes
- Install Node.js 20 in Dockerfile
- Remove Node feature from configuration
- Document apt-based Node install

## Testing
- `pre-commit` not available – skipped


------
https://chatgpt.com/codex/tasks/task_e_686c786e833883218bf5113132f2be50