### PR TITLE
Add base URL flag for reverse proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1747,6 +1747,7 @@ Configure Subtitle Manager using environment variables with the `SM_` prefix:
 - `SM_CONFIG_FILE` - Path to configuration file - Default: `/config/subtitle-manager.yaml`
 - `SM_DB_PATH` - Database file path - Default: `/config/subtitle-manager.db`
 - `SM_DB_BACKEND` - Database backend (sqlite, pebble, postgres) - Default: `sqlite`
+- `SM_BASE_URL` - Base URL path when behind a reverse proxy
 
 **API Keys:**
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,6 +156,10 @@ func init() {
 		rootCmd.PersistentFlags().String("language", "en", "language for user interface (en, es, fr)")
 		viper.BindPFlag("language", rootCmd.PersistentFlags().Lookup("language"))
 
+		// Base URL configuration for reverse proxy support
+		rootCmd.PersistentFlags().String("base-url", "", "base URL path when behind a reverse proxy")
+		viper.BindPFlag("base_url", rootCmd.PersistentFlags().Lookup("base-url"))
+
 		// Cloud storage configuration
 		rootCmd.PersistentFlags().String("storage-provider", "local", "storage provider: local, s3, azure, gcs")
 		viper.BindPFlag("storage.provider", rootCmd.PersistentFlags().Lookup("storage-provider"))


### PR DESCRIPTION
## Description
Adds a `--base-url` flag bound to `SM_BASE_URL` for configuring the application path behind a reverse proxy. Updated README to document the new variable.

## Motivation
Reverse proxy deployments require specifying a base path so routes resolve correctly.

## Changes
- Introduced `--base-url` flag in the CLI
- Documented `SM_BASE_URL` environment variable

## Testing
- `make test-all` *(fails: SQLite support not available)*
- `make test-all-sqlite` *(fails: SQLite support not available)*

## Related Issues
Issue creation via script failed due to network restrictions.

------
https://chatgpt.com/codex/tasks/task_e_686af3d8ad44832189e90503eb97ff67