### PR TITLE
Add CLI search caching

### DIFF
--- a/.github/doc-updates/844c4c00-e395-4340-8f75-5b9b6af5708d.json
+++ b/.github/doc-updates/844c4c00-e395-4340-8f75-5b9b6af5708d.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "CLI search command now caches results for faster repeats",
+  "guid": "844c4c00-e395-4340-8f75-5b9b6af5708d",
+  "created_at": "2025-07-10T01:19:14Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c9dee2b0-6919-4adf-8578-31db090a148b.json
+++ b/.github/doc-updates/c9dee2b0-6919-4adf-8578-31db090a148b.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "search result caching completed",
+  "guid": "c9dee2b0-6919-4adf-8578-31db090a148b",
+  "created_at": "2025-07-10T01:20:21Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/cbac96a1-5d7e-43c9-b638-a4d068b0d6e8.json
+++ b/.github/doc-updates/cbac96a1-5d7e-43c9-b638-a4d068b0d6e8.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added caching to CLI search command",
+  "guid": "cbac96a1-5d7e-43c9-b638-a4d068b0d6e8",
+  "created_at": "2025-07-10T01:19:07Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/a39a0988-bfa8-4cfa-b1ec-893b054f8f51.json
+++ b/.github/issue-updates/a39a0988-bfa8-4cfa-b1ec-893b054f8f51.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "CLI search caching",
+  "body": "Implement caching for CLI search command to speed up repeated queries",
+  "labels": ["enhancement"],
+  "guid": "a39a0988-bfa8-4cfa-b1ec-893b054f8f51",
+  "legacy_guid": "create-cli-search-caching-2025-07-10"
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,14 +2,18 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/jdfalk/subtitle-manager/pkg/cache"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	"github.com/jdfalk/subtitle-manager/pkg/providers"
+	web "github.com/jdfalk/subtitle-manager/pkg/webserver"
 )
 
 // searchCmd lists available subtitles from a provider.
@@ -22,6 +26,35 @@ var searchCmd = &cobra.Command{
 		media, lang := args[0], args[1]
 		key := viper.GetString("opensubtitles.api_key")
 		names := providers.All()
+
+		mgr, err := cache.NewManagerFromViper()
+		if err != nil {
+			logger.Warnf("cache disabled: %v", err)
+			mgr = nil
+		}
+
+		req := web.SearchRequest{
+			Providers: names,
+			MediaPath: media,
+			Language:  lang,
+		}
+		data, _ := json.Marshal(req)
+		cacheKey := fmt.Sprintf("%x", sha1.Sum(data))
+
+		ctx := context.Background()
+		if mgr != nil {
+			if cached, err := mgr.GetProviderSearchResults(ctx, cacheKey); err == nil && cached != nil {
+				var urls []string
+				if err := json.Unmarshal(cached, &urls); err == nil {
+					for _, u := range urls {
+						fmt.Println(u)
+					}
+					logger.Infof("found %d results (cached)", len(urls))
+					return nil
+				}
+			}
+		}
+
 		var all []string
 		for i, name := range names {
 			p, err := providers.Get(name, key)
@@ -32,12 +65,19 @@ var searchCmd = &cobra.Command{
 			if !ok {
 				continue
 			}
-			urls, err := s.Search(context.Background(), media, lang)
+			urls, err := s.Search(ctx, media, lang)
 			if err == nil {
 				all = append(all, urls...)
 			}
 			time.Sleep(time.Duration(i+1) * time.Second)
 		}
+
+		if mgr != nil && len(all) > 0 {
+			if encoded, err := json.Marshal(all); err == nil {
+				mgr.SetProviderSearchResults(ctx, cacheKey, encoded)
+			}
+		}
+
 		for _, u := range all {
 			fmt.Println(u)
 		}


### PR DESCRIPTION
## Description
- cache CLI search results using cache manager
- add doc updates and issue update

## Motivation
- speed up repeated CLI searches using existing caching system

## Changes
- use cache manager in `cmd/search.go`
- add changelog entry and readme note
- mark TODO item complete
- create new issue tracking CLI search caching

## Testing
- `go test ./...` *(fails: TestMetricsEndpointContentType)*

------
https://chatgpt.com/codex/tasks/task_e_686f13629a148321bfd5ca34acaf439b