### PR TITLE
Add translation caching to translator

### DIFF
--- a/.github/doc-updates/3cfacf5d-555b-4ac6-a315-b10ebc832be5.json
+++ b/.github/doc-updates/3cfacf5d-555b-4ac6-a315-b10ebc832be5.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Translation results now cached via global cache manager",
+  "guid": "3cfacf5d-555b-4ac6-a315-b10ebc832be5",
+  "created_at": "2025-07-10T01:23:17Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c508a8ce-22ef-44b7-a99d-12d83bcc3830.json
+++ b/.github/doc-updates/c508a8ce-22ef-44b7-a99d-12d83bcc3830.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Added translation result caching for translator",
+  "guid": "c508a8ce-22ef-44b7-a99d-12d83bcc3830",
+  "created_at": "2025-07-10T01:23:13Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ec6d47f6-6d8e-4360-9e08-247ca13b2954.json
+++ b/.github/doc-updates/ec6d47f6-6d8e-4360-9e08-247ca13b2954.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Implement translation result caching",
+  "guid": "ec6d47f6-6d8e-4360-9e08-247ca13b2954",
+  "created_at": "2025-07-10T01:23:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/d040a70d-11cf-4888-8578-4df6afca69dc.json
+++ b/.github/issue-updates/d040a70d-11cf-4888-8578-4df6afca69dc.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add translation caching",
+  "body": "Translator now caches results via global cache manager",
+  "labels": ["enhancement"],
+  "guid": "d040a70d-11cf-4888-8578-4df6afca69dc",
+  "legacy_guid": "create-add-translation-caching-2025-07-10"
+}


### PR DESCRIPTION
## Description
- cache translation results using global cache manager
- test translator caching
- adjust metrics test to accept additional content-type parameters
- update docs and TODO via doc-update script
- create issue for translation caching

## Motivation
Translations were repeatedly requested even when identical text was translated multiple times. Caching results improves efficiency and reduces API usage.

## Changes
- **Added**: translationCache variable and Set/Get functions
- **Added**: caching logic in `Translate` function
- **Added**: tests for cache manager usage
- **Modified**: metrics test to avoid failures from extra header parameters
- **Docs**: CHANGELOG, README, TODO updated via automation
- **Issue**: created issue update JSON

## Testing
- `go test ./...` *(fails: subtitle-manager flag redefined)*
- `npm test` *(fails: cannot find module '@testing-library/dom')*


------
https://chatgpt.com/codex/tasks/task_e_686f13b162908321b725e8c2c7ec8ad3