### PR TITLE
feat(translator): add SupportedServices helper

### DIFF
--- a/.github/doc-updates/869ea3da-f007-4d94-b9fa-98ed423b951d.json
+++ b/.github/doc-updates/869ea3da-f007-4d94-b9fa-98ed423b951d.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added note about SupportedServices function in translator package",
+  "guid": "869ea3da-f007-4d94-b9fa-98ed423b951d",
+  "created_at": "2025-07-10T01:20:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a218448d-64ab-4720-b113-dcb7a82af924.json
+++ b/.github/doc-updates/a218448d-64ab-4720-b113-dcb7a82af924.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add SupportedServices helper and gRPC dial fix",
+  "guid": "a218448d-64ab-4720-b113-dcb7a82af924",
+  "created_at": "2025-07-10T01:20:07Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/da4d7696-86e4-461c-922e-8a71434f425f.json
+++ b/.github/doc-updates/da4d7696-86e4-461c-922e-8a71434f425f.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement SupportedServices helper in translator package",
+  "guid": "da4d7696-86e4-461c-922e-8a71434f425f",
+  "created_at": "2025-07-10T01:20:12Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b2b20c3b-fd5b-400b-acf6-174fad77e426.json
+++ b/.github/issue-updates/b2b20c3b-fd5b-400b-acf6-174fad77e426.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add SupportedServices helper",
+  "body": "Expose translator providers list",
+  "labels": ["enhancement"],
+  "guid": "b2b20c3b-fd5b-400b-acf6-174fad77e426",
+  "legacy_guid": "create-add-supportedservices-helper-2025-07-10"
+}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -1,9 +1,14 @@
+// file: pkg/translator/translator.go
+// version: 1.0.0
+// guid: 3bf0f8c4-18e8-4d30-a0f6-8e4a4f3f0f62
+
 package translator
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	translate "cloud.google.com/go/translate"
@@ -166,7 +171,7 @@ func GRPCTranslate(text, targetLang, addr string) (string, error) {
 // GRPCSetConfig sends configuration key/value pairs to a remote gRPC server.
 // The addr parameter specifies the server address (host:port).
 func GRPCSetConfig(settings map[string]string, addr string) error {
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}
@@ -181,6 +186,16 @@ var providers = map[string]TranslateFunc{
 	"gpt":     GPTTranslate,
 	"chatgpt": GPTTranslate,
 	"grpc":    GRPCTranslate,
+}
+
+// SupportedServices returns the list of available translation providers.
+func SupportedServices() []string {
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // Translate selects a provider and performs translation.

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -1,3 +1,7 @@
+// file: pkg/translator/translator_test.go
+// version: 1.0.0
+// guid: 8ae1f81d-0b31-49e8-bc2f-22e6b0a058d4
+
 package translator
 
 import (
@@ -167,4 +171,18 @@ func TestSetOpenAIModel(t *testing.T) {
 		t.Fatalf("expected test-model, got %s", openAIModel)
 	}
 	SetOpenAIModel(orig)
+}
+
+// TestSupportedServices ensures the provider list is returned alphabetically.
+func TestSupportedServices(t *testing.T) {
+	expected := []string{"chatgpt", "google", "gpt", "grpc"}
+	got := SupportedServices()
+	if len(got) != len(expected) {
+		t.Fatalf("expected %d services, got %d", len(expected), len(got))
+	}
+	for i, name := range expected {
+		if got[i] != name {
+			t.Fatalf("expected %s at index %d, got %s", name, i, got[i])
+		}
+	}
 }


### PR DESCRIPTION
## Description
Add helper to list available translation providers and update gRPC configuration handling.

## Motivation
Provider discovery was missing and gRPC client creation used a deprecated helper.

## Changes
- added file headers
- switched to `grpc.Dial`
- added `SupportedServices` with test
- generated documentation updates
- created issue update file

## Testing
- `go test ./...` *(one test failure in metrics endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_686f13c9b6a48321b564ce0138155f5a