### PR TITLE
Add whisper start/stop CLI

### DIFF
--- a/.github/doc-updates/07377037-a8ca-4385-aa26-ba35560b1217.json
+++ b/.github/doc-updates/07377037-a8ca-4385-aa26-ba35560b1217.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Whisper container start/stop CLI commands implemented",
+  "guid": "07377037-a8ca-4385-aa26-ba35560b1217",
+  "created_at": "2025-07-10T01:26:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/262e134a-2e85-4c67-a3f0-b552f0daec07.json
+++ b/.github/doc-updates/262e134a-2e85-4c67-a3f0-b552f0daec07.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added CLI commands to start and stop the Whisper container",
+  "guid": "262e134a-2e85-4c67-a3f0-b552f0daec07",
+  "created_at": "2025-07-10T01:25:35Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/70658146-8c32-4836-9cea-4ee7318da2b7.json
+++ b/.github/doc-updates/70658146-8c32-4836-9cea-4ee7318da2b7.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added `whisper start` and `whisper stop` commands",
+  "guid": "70658146-8c32-4836-9cea-4ee7318da2b7",
+  "created_at": "2025-07-10T01:25:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/adacdbac-7516-45c3-9ef7-8843dc7e1f92.json
+++ b/.github/issue-updates/adacdbac-7516-45c3-9ef7-8843dc7e1f92.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add CLI commands for Whisper container control",
+  "body": "Implemented start and stop commands for managing the local Whisper ASR container",
+  "labels": ["enhancement", "cli"],
+  "guid": "adacdbac-7516-45c3-9ef7-8843dc7e1f92",
+  "legacy_guid": "create-add-cli-commands-for-whisper-container-control-2025-07-10"
+}

--- a/cmd/whisper_cmd_test.go
+++ b/cmd/whisper_cmd_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeWhisperContainer struct {
+	started bool
+	stopped bool
+}
+
+func (f *fakeWhisperContainer) StartContainer(ctx context.Context) error {
+	f.started = true
+	return nil
+}
+
+func (f *fakeWhisperContainer) StopContainer(ctx context.Context) error {
+	f.stopped = true
+	return nil
+}
+
+func (f *fakeWhisperContainer) GetContainerStatus(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
+func (f *fakeWhisperContainer) IsContainerRunning(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeWhisperContainer) Close() error { return nil }
+
+func TestWhisperStartStopCmd(t *testing.T) {
+	fake := &fakeWhisperContainer{}
+	orig := newWhisperContainer
+	newWhisperContainer = func() (whisperContainer, error) { return fake, nil }
+	defer func() { newWhisperContainer = orig }()
+
+	if err := whisperStartCmd.RunE(whisperStartCmd, nil); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !fake.started {
+		t.Fatal("StartContainer not called")
+	}
+
+	if err := whisperStopCmd.RunE(whisperStopCmd, nil); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !fake.stopped {
+		t.Fatal("StopContainer not called")
+	}
+}


### PR DESCRIPTION
## Description
Add new `whisper start` and `whisper stop` CLI subcommands for controlling the optional Whisper ASR container. Updated command file now exposes a testable interface. Added unit test for these commands. Documentation updates added via helper scripts.

## Motivation
Provides basic management of the local Whisper container as requested in remaining TODO and issue tracker.

## Changes
- implemented start/stop commands in `cmd/whisper.go`
- added unit tests
- generated documentation and issue updates

## Testing
- `go test ./cmd -run TestWhisperStartStopCmd -count=1` *(fails: flag redefined)*

------
https://chatgpt.com/codex/tasks/task_e_686f14058810832195d1902553f0ae79