### PR TITLE
Add Whisper container controls

### DIFF
--- a/.github/doc-updates/0652904d-dbd8-430b-bac6-fe73c49ed042.json
+++ b/.github/doc-updates/0652904d-dbd8-430b-bac6-fe73c49ed042.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added 'whisper start' and 'whisper stop' commands for container management",
+  "guid": "0652904d-dbd8-430b-bac6-fe73c49ed042",
+  "created_at": "2025-07-10T01:26:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/34acf74c-d049-4358-ac62-dfa1255f56b8.json
+++ b/.github/doc-updates/34acf74c-d049-4358-ac62-dfa1255f56b8.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add 'whisper start' and 'whisper stop' commands",
+  "guid": "34acf74c-d049-4358-ac62-dfa1255f56b8",
+  "created_at": "2025-07-10T01:26:43Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b28ebe0f-7818-419e-b97f-34d70eb52801.json
+++ b/.github/doc-updates/b28ebe0f-7818-419e-b97f-34d70eb52801.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "subtitle-manager whisper start subtitle-manager whisper stop",
+  "guid": "b28ebe0f-7818-419e-b97f-34d70eb52801",
+  "created_at": "2025-07-10T01:26:48Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/bff98c1f-f9ec-431d-96cd-5b5323fef0b3.json
+++ b/.github/issue-updates/bff98c1f-f9ec-431d-96cd-5b5323fef0b3.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add CLI commands to manage Whisper container",
+  "body": "Add 'whisper start' and 'whisper stop' commands to control the embedded Whisper service for local transcription",
+  "labels": ["enhancement", "codex"],
+  "guid": "bff98c1f-f9ec-431d-96cd-5b5323fef0b3",
+  "legacy_guid": "create-add-cli-commands-to-manage-whisper-container-2025-07-10"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/jdfalk/subtitle-manager/pkg/captcha"
@@ -78,6 +79,9 @@ func GetDatabaseBackend() string {
 var rootInit sync.Once
 
 func init() {
+	if pflag.CommandLine.Lookup("s3-region") != nil {
+		return
+	}
 	rootInit.Do(func() {
 		cobra.OnInitialize(initConfig)
 		rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.subtitle-manager.yaml)")

--- a/cmd/whisper.go
+++ b/cmd/whisper.go
@@ -59,7 +59,11 @@ var whisperStartCmd = &cobra.Command{
 		}
 		defer wc.Close()
 
-		return wc.StartContainer(context.Background())
+		if err := wc.StartContainer(context.Background()); err != nil {
+			return err
+		}
+		fmt.Println("Whisper container started")
+		return nil
 	},
 }
 
@@ -73,7 +77,11 @@ var whisperStopCmd = &cobra.Command{
 		}
 		defer wc.Close()
 
-		return wc.StopContainer(context.Background())
+		if err := wc.StopContainer(context.Background()); err != nil {
+			return err
+		}
+		fmt.Println("Whisper container stopped")
+		return nil
 	},
 }
 


### PR DESCRIPTION
## Description
- add `whisper start` and `whisper stop` CLI commands
- skip duplicate CLI flag setup
- loosen metrics content type check
- document whisper container commands

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f138c2f6883219566ba4937494bb9