### PR TITLE
use PAT for merge conflict workflow

### DIFF
--- a/.github/doc-updates/1896fe55-de9a-48cc-a9c5-0c2f43d7f6be.json
+++ b/.github/doc-updates/1896fe55-de9a-48cc-a9c5-0c2f43d7f6be.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Our fix-merge-conflicts workflow now uses the JF_CI_GH_PAT secret instead of the default GITHUB_TOKEN for better permissions.",
+  "guid": "1896fe55-de9a-48cc-a9c5-0c2f43d7f6be",
+  "created_at": "2025-07-10T16:54:36Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b11b6c28-9852-4f3b-8565-acdd07fc52c0.json
+++ b/.github/doc-updates/b11b6c28-9852-4f3b-8565-acdd07fc52c0.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Verify PAT-based merge conflict workflow",
+  "guid": "b11b6c28-9852-4f3b-8565-acdd07fc52c0",
+  "created_at": "2025-07-10T16:54:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b6b3f5e3-1442-457e-98fd-60180a80dcb2.json
+++ b/.github/doc-updates/b6b3f5e3-1442-457e-98fd-60180a80dcb2.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- use PAT secret for fix-merge-conflicts workflow",
+  "guid": "b6b3f5e3-1442-457e-98fd-60180a80dcb2",
+  "created_at": "2025-07-10T16:54:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/workflows/fix-merge-conflicts.yml
+++ b/.github/workflows/fix-merge-conflicts.yml
@@ -16,4 +16,4 @@ jobs:
       base-branch: 'main'
       model: 'openai/gpt-4o'
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.JF_CI_GH_PAT }}


### PR DESCRIPTION
## Summary
Switch fix-merge-conflicts workflow to use the JF_CI_GH_PAT secret and document the change.

## Issues Addressed

### fix(ci): use PAT for merge conflict workflow

**Description:**
- updated workflow secret from `GITHUB_TOKEN` to `JF_CI_GH_PAT`
- added doc updates for README, CHANGELOG and TODO

**Files Modified:**
- [`.github/workflows/fix-merge-conflicts.yml`](./.github/workflows/fix-merge-conflicts.yml) - reference PAT secret [[diff](../../pull/PR_NUMBER/files#diff-)] [[repo](../../blob/main/.github/workflows/fix-merge-conflicts.yml)]
- [`.github/doc-updates/1896fe55-de9a-48cc-a9c5-0c2f43d7f6be.json`](./.github/doc-updates/1896fe55-de9a-48cc-a9c5-0c2f43d7f6be.json) - README update [[diff](../../pull/PR_NUMBER/files#diff-)] [[repo](../../blob/main/.github/doc-updates/1896fe55-de9a-48cc-a9c5-0c2f43d7f6be.json)]
- [`.github/doc-updates/b11b6c28-9852-4f3b-8565-acdd07fc52c0.json`](./.github/doc-updates/b11b6c28-9852-4f3b-8565-acdd07fc52c0.json) - TODO task [[diff](../../pull/PR_NUMBER/files#diff-)] [[repo](../../blob/main/.github/doc-updates/b11b6c28-9852-4f3b-8565-acdd07fc52c0.json)]
- [`.github/doc-updates/b6b3f5e3-1442-457e-98fd-60180a80dcb2.json`](./.github/doc-updates/b6b3f5e3-1442-457e-98fd-60180a80dcb2.json) - changelog entry [[diff](../../pull/PR_NUMBER/files#diff-)] [[repo](../../blob/main/.github/doc-updates/b6b3f5e3-1442-457e-98fd-60180a80dcb2.json)]

## Testing
- `go test ./pkg/...`


------
https://chatgpt.com/codex/tasks/task_e_686feee2ffc48321b33e50abea86685a