### PR TITLE
Fix docker stack port mapping

### DIFF
--- a/.github/doc-updates/3259661f-69f7-49a2-b14e-8e5903643257.json
+++ b/.github/doc-updates/3259661f-69f7-49a2-b14e-8e5903643257.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### Custom Port\\nUse '-p HOSTPORT:8080' to expose a different port. Example:\\n```bash\\ndocker run -p 9555:8080 ghcr.io/jdfalk/subtitle-manager:latest\\n```",
+  "guid": "3259661f-69f7-49a2-b14e-8e5903643257",
+  "created_at": "2025-07-13T23:22:36Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/48ec308c-b493-4771-998d-1c9158473880.json
+++ b/.github/doc-updates/48ec308c-b493-4771-998d-1c9158473880.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Corrected Docker stack port mapping",
+  "guid": "48ec308c-b493-4771-998d-1c9158473880",
+  "created_at": "2025-07-13T23:22:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/884907d1-ba78-464e-a0da-79f81cf1ae07.json
+++ b/.github/doc-updates/884907d1-ba78-464e-a0da-79f81cf1ae07.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Verify custom port mapping works in stack",
+  "guid": "884907d1-ba78-464e-a0da-79f81cf1ae07",
+  "created_at": "2025-07-13T23:22:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -6,7 +6,8 @@ services:
   subtitle-manager:
     image: ghcr.io/jdfalk/subtitle-manager:latest
     ports:
-      - "78080:8080"
+      # Map port 9555 on the host to the application's default port 8080
+      - "9555:8080"
     volumes:
       # Configuration and database storage (use named volumes in production)
       - subtitle-manager-config:/config


### PR DESCRIPTION
## Summary
Correct docker stack mapping for web port and add documentation updates via doc update system.

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/dom')*
- `go test ./...` *(interrupted after package build)*

------
https://chatgpt.com/codex/tasks/task_e_68743de8f0c083218e318b223a20ad70