### PR TITLE
Fix SQLite migration test skip and doc updates

### DIFF
--- a/.github/doc-updates/00df5927-470e-43a8-bc44-fc11ca1aebd3.json
+++ b/.github/doc-updates/00df5927-470e-43a8-bc44-fc11ca1aebd3.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Ensure SQLite integration tests run in CI with sqlite build tag",
+  "guid": "00df5927-470e-43a8-bc44-fc11ca1aebd3",
+  "created_at": "2025-07-13T23:28:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/457acba1-0f7b-4499-8604-21b950143564.json
+++ b/.github/doc-updates/457acba1-0f7b-4499-8604-21b950143564.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Skip SQLite migration test when SQLite support is not built",
+  "guid": "457acba1-0f7b-4499-8604-21b950143564",
+  "created_at": "2025-07-13T23:28:18Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e2bed45e-8dd7-494f-83fc-67fed1130796.json
+++ b/.github/doc-updates/e2bed45e-8dd7-494f-83fc-67fed1130796.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Note: SQLite-related tests are skipped automatically when the binary is built without SQLite support.",
+  "guid": "e2bed45e-8dd7-494f-83fc-67fed1130796",
+  "created_at": "2025-07-13T23:28:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/database/migration_language_profiles_test.go
+++ b/pkg/database/migration_language_profiles_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestMigration_LanguageProfileAssignments_SQLite(t *testing.T) {
+	if !HasSQLite() {
+		t.Skip("SQLite not available")
+	}
+
 	path := "test_migration_sqlite.db"
 	_ = os.Remove(path)
 	store, err := OpenSQLStore(path)


### PR DESCRIPTION
## Summary

Skip SQLite migration test when the binary is built without SQLite support and record documentation updates.

## Issues Addressed

### fix(database): skip SQLite migration test when SQLite disabled

**Description:** Added a check using `HasSQLite()` in `TestMigration_LanguageProfileAssignments_SQLite` to skip the test when SQLite support isn't included.

**Files Modified:**

- [`pkg/database/migration_language_profiles_test.go`](./pkg/database/migration_language_profiles_test.go) - Added skip logic

### docs: record updates for sqlite test handling

**Description:** Added automated documentation updates noting the new behavior and tracking a TODO for CI improvements.

**Files Modified:**

- [`.github/doc-updates/457acba1-0f7b-4499-8604-21b950143564.json`](./.github/doc-updates/457acba1-0f7b-4499-8604-21b950143564.json) - CHANGELOG entry
- [`.github/doc-updates/e2bed45e-8dd7-494f-83fc-67fed1130796.json`](./.github/doc-updates/e2bed45e-8dd7-494f-83fc-67fed1130796.json) - README note
- [`.github/doc-updates/00df5927-470e-43a8-bc44-fc11ca1aebd3.json`](./.github/doc-updates/00df5927-470e-43a8-bc44-fc11ca1aebd3.json) - TODO task

## Testing

- `go test ./pkg/database -run TestMigration_LanguageProfileAssignments_SQLite -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743e5d110c832192a30bf4fa322ce5