### PR TITLE
Add sync batch invalid JSON test

### DIFF
--- a/.github/doc-updates/1ca0d749-2401-464d-832f-5827db529107.json
+++ b/.github/doc-updates/1ca0d749-2401-464d-832f-5827db529107.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added unit test documentation for /api/sync/batch endpoint",
+  "guid": "1ca0d749-2401-464d-832f-5827db529107",
+  "created_at": "2025-07-15T04:06:51Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/561f1923-f4f8-4d0b-a896-ad26ee549f54.json
+++ b/.github/doc-updates/561f1923-f4f8-4d0b-a896-ad26ee549f54.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added unit test for /api/sync/batch endpoint",
+  "guid": "561f1923-f4f8-4d0b-a896-ad26ee549f54",
+  "created_at": "2025-07-15T04:06:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/6896e188-49c1-4cd6-acd2-4879f3c2e32c.json
+++ b/.github/doc-updates/6896e188-49c1-4cd6-acd2-4879f3c2e32c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add regression test for sync batch endpoint",
+  "guid": "6896e188-49c1-4cd6-acd2-4879f3c2e32c",
+  "created_at": "2025-07-15T04:06:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -1005,6 +1005,36 @@ func TestSyncBatchEndpoint(t *testing.T) {
 	}
 }
 
+// TestSyncBatchEndpointInvalid verifies that invalid JSON results in
+// a 400 Bad Request response.
+func TestSyncBatchEndpointInvalid(t *testing.T) {
+	skipIfNoSQLite(t)
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	key := setupTestUser(t, db)
+
+	h, err := Handler(db)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/api/sync/batch", strings.NewReader("invalid"))
+	req.Header.Set("X-API-Key", key)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
 // TestProvidersUpdateInvalid verifies that invalid JSON results in 400 Bad Request.
 func TestProvidersUpdateInvalid(t *testing.T) {
 	skipIfNoSQLite(t)


### PR DESCRIPTION
## Summary
- test invalid JSON behavior for POST /api/sync/batch endpoint
- update documentation via doc update system

## Issues Addressed

- N/A

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875d1ca0b0c8321877f0ba418239714