### PR TITLE
Standardize on Dockerfile.hybrid

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Subtitle Manager Development",
-  "dockerFile": "Dockerfile",
+  "dockerFile": "Dockerfile.hybrid",
   "context": "..",
   "workspaceFolder": "/workspace",
 

--- a/.github/doc-updates/17387c82-0c47-43e8-aef0-e686a1fc9676.json
+++ b/.github/doc-updates/17387c82-0c47-43e8-aef0-e686a1fc9676.json
@@ -1,0 +1,16 @@
+{
+  "file": "docs/ISSUE_MANAGEMENT_AND_DEVELOPMENT_SUMMARY.md",
+  "mode": "replace-section",
+  "content": "#### File Type Based Resolution\n\n| File Type                                | Strategy    | Reasoning |\n| ---------------------------------------- | ----------- | ---------- |\n| Documentation (`.md`, `docs/`)           | Incoming    | Main branch docs are usually current |\n| Build files (`.github/`, `Dockerfile.hybrid`)   | Incoming    | Build config should match main |\n| Package files (`go.mod`, `package.json`) | Incoming    | Dependencies should match main |\n| Configuration (`.json`, `.yml`)          | Smart Merge | Configs need careful merging |\n| Source code (`.go`, `.js`, `.py`)        | Save Both   | Code needs manual review |\n| Test files (`*_test.go`, `test/`)        | Save Both   | Tests need careful review |\n| Data files (`.sql`, `data/`)             | Current     | Data is often environment-specific |",
+  "guid": "17387c82-0c47-43e8-aef0-e686a1fc9676",
+  "created_at": "2025-07-15T04:08:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/406e54bc-b5df-426c-8eeb-380423dd7472.json
+++ b/.github/doc-updates/406e54bc-b5df-426c-8eeb-380423dd7472.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Standardized on Dockerfile.hybrid for all builds",
+  "guid": "406e54bc-b5df-426c-8eeb-380423dd7472",
+  "created_at": "2025-07-15T04:08:14Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/56144b20-7c05-445c-8170-6d752d27fdd5.json
+++ b/.github/doc-updates/56144b20-7c05-445c-8170-6d752d27fdd5.json
@@ -1,0 +1,16 @@
+{
+  "file": "docs/CODE_OVERVIEW.md",
+  "mode": "append",
+  "content": "- `Dockerfile.hybrid`        | Hybrid build producing the container image.",
+  "guid": "56144b20-7c05-445c-8170-6d752d27fdd5",
+  "created_at": "2025-07-15T04:08:34Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a3c996d4-d008-43f5-8ae5-781508be4fc1.json
+++ b/.github/doc-updates/a3c996d4-d008-43f5-8ae5-781508be4fc1.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "- Dockerfile.hybrid and workflow for container builds.",
+  "guid": "a3c996d4-d008-43f5-8ae5-781508be4fc1",
+  "created_at": "2025-07-15T04:08:06Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a6130f6d-2927-481a-8cc5-a31134f9bd20.json
+++ b/.github/doc-updates/a6130f6d-2927-481a-8cc5-a31134f9bd20.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Standardize on `Dockerfile.hybrid` for development and CI.",
+  "guid": "a6130f6d-2927-481a-8cc5-a31134f9bd20",
+  "created_at": "2025-07-15T04:08:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/5a944fb5-373d-4904-8b0e-ed79fcd07dfe.json
+++ b/.github/issue-updates/5a944fb5-373d-4904-8b0e-ed79fcd07dfe.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Finalize Dockerfile.hybrid migration",
+  "body": "Switch build scripts and docs to Dockerfile.hybrid",
+  "labels": ["documentation", "build"],
+  "guid": "5a944fb5-373d-4904-8b0e-ed79fcd07dfe",
+  "legacy_guid": "create-finalize-dockerfile-hybrid-migration-2025-07-15"
+}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       image-name: subtitle-manager
       registry: ghcr.io
-      dockerfile: ./Dockerfile
+      dockerfile: ./Dockerfile.hybrid
       context: .
       platforms: linux/amd64,linux/arm64
       build-args: |

--- a/Makefile
+++ b/Makefile
@@ -433,17 +433,17 @@ docker-push-assets: docker-assets
 docker-fast:
 	@echo "🚀 Fast Docker build using pre-built assets..."
 	@if docker pull $(DOCKER_IMAGE)/assets:latest; then \
-		docker build -f Dockerfile.fast -t $(DOCKER_IMAGE):$(VERSION)-fast .; \
+	docker build -f Dockerfile.hybrid -t $(DOCKER_IMAGE):$(VERSION)-fast .; \
 	else \
-		echo "⚠️  Pre-built assets not available, falling back to optimized build"; \
-		$(MAKE) docker-optimized; \
+	echo "⚠️  Pre-built assets not available, falling back to standard build"; \
+	$(MAKE) docker-optimized; \
 	fi
 
 # Optimized multi-stage build
 docker-optimized:
-	@echo "🔧 Optimized Docker build with caching..."
+	@echo "🔧 Standard Docker build using Dockerfile.hybrid..."
 	DOCKER_BUILDKIT=1 docker build \
-		-f Dockerfile.optimized \
+		-f Dockerfile.hybrid \
 		-t $(DOCKER_IMAGE):$(VERSION) \
 		-t $(DOCKER_IMAGE):latest \
 		--build-arg VERSION=$(VERSION) \
@@ -452,16 +452,16 @@ docker-optimized:
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from $(DOCKER_IMAGE):latest \
 		.
-
+	
 # Benchmark build times
 docker-benchmark:
-	@echo "⏱️  Benchmarking Docker build methods..."
-	@echo "Building with original Dockerfile..."
-	@time docker build -f Dockerfile -t $(DOCKER_IMAGE):original . &>/dev/null || echo "Original build failed"
-	@echo "Building with optimized Dockerfile..."
-	@time docker build -f Dockerfile.optimized -t $(DOCKER_IMAGE):optimized . &>/dev/null || echo "Optimized build failed"
-	@echo "Building with fast method (if assets available)..."
-	@time docker build -f Dockerfile.fast -t $(DOCKER_IMAGE):fast . &>/dev/null || echo "Fast build failed (assets not available)"
+		@echo "⏱️  Benchmarking Docker build methods..."
+		@echo "Building with original Dockerfile..."
+		@time docker build -f Dockerfile -t $(DOCKER_IMAGE):original . &>/dev/null || echo "Original build failed"
+		@echo "Building with hybrid Dockerfile..."
+		@time docker build -f Dockerfile.hybrid -t $(DOCKER_IMAGE):hybrid . &>/dev/null || echo "Hybrid build failed"
+		@echo "Building with fast method (if assets available)..."
+		@time docker build -f Dockerfile.hybrid -t $(DOCKER_IMAGE):fast . &>/dev/null || echo "Fast build failed (assets not available)"
 
 #
 # Protocol Buffers

--- a/scripts/fast-docker-build.sh
+++ b/scripts/fast-docker-build.sh
@@ -8,16 +8,16 @@ echo "🚀 Starting optimized Docker build..."
 
 # Check if we should use pre-built assets
 USE_PREBUILT=${USE_PREBUILT:-false}
-DOCKERFILE=${DOCKERFILE:-Dockerfile.optimized}
+DOCKERFILE=${DOCKERFILE:-Dockerfile.hybrid}
 
 if [ "$USE_PREBUILT" = "true" ]; then
     echo "📦 Using pre-built assets from GitHub Packages..."
-    DOCKERFILE="Dockerfile.fast"
+    DOCKERFILE="Dockerfile.hybrid"
 
     # Pull latest assets image
     docker pull ghcr.io/jdfalk/subtitle-manager/assets:latest || {
-        echo "⚠️  Failed to pull pre-built assets, falling back to local build"
-        DOCKERFILE="Dockerfile.optimized"
+        echo "⚠️  Failed to pull pre-built assets, falling back to standard build"
+        DOCKERFILE="Dockerfile.hybrid"
     }
 fi
 


### PR DESCRIPTION
## Summary
- switch devcontainer, workflows and build scripts to use Dockerfile.hybrid
- update docs via automation
- create issue to track Dockerfile.hybrid migration

## Issues Addressed

### chore(issues): open task to finalize Dockerfile.hybrid switch

**Description:** Added an issue update file to create an issue for completing the Dockerfile.hybrid migration.

**Files Modified:**
- [`.github/issue-updates/5a944fb5-373d-4904-8b0e-ed79fcd07dfe.json`](./.github/issue-updates/5a944fb5-373d-4904-8b0e-ed79fcd07dfe.json) - New issue file

## Testing
- `make go-fmt`
- `make go-vet`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6875d13546288321bab7e21a8e831ba7