### PR TITLE
Implement manual search result caching

### DIFF
--- a/.github/doc-updates/4ce1f1fe-173f-4071-b371-30cf8498232d.json
+++ b/.github/doc-updates/4ce1f1fe-173f-4071-b371-30cf8498232d.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented manual search result caching for faster repeated queries",
+  "guid": "4ce1f1fe-173f-4071-b371-30cf8498232d",
+  "created_at": "2025-07-15T04:02:18Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a4b0b2fc-874a-4bfc-bc9c-f61e09242333.json
+++ b/.github/doc-updates/a4b0b2fc-874a-4bfc-bc9c-f61e09242333.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Manual search results are cached for 5 minutes",
+  "guid": "a4b0b2fc-874a-4bfc-bc9c-f61e09242333",
+  "created_at": "2025-07-15T04:02:21Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e6ad86f7-d523-4475-b9c7-822faae43790.json
+++ b/.github/doc-updates/e6ad86f7-d523-4475-b9c7-822faae43790.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Search Result Caching",
+  "guid": "e6ad86f7-d523-4475-b9c7-822faae43790",
+  "created_at": "2025-07-15T04:02:25Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/5715c6ac-9771-4692-8d7f-d2bb6aec0a99.json
+++ b/.github/issue-updates/5715c6ac-9771-4692-8d7f-d2bb6aec0a99.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Cache manual search results",
+  "body": "Add caching layer for manual search results to improve repeated query performance.",
+  "labels": ["enhancement", "backend"],
+  "guid": "5715c6ac-9771-4692-8d7f-d2bb6aec0a99",
+  "legacy_guid": "create-cache-manual-search-results-2025-07-15"
+}

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/config.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 123e4567-e89b-12d3-a456-426614174008
 
 package cache
@@ -102,6 +102,14 @@ func ConfigFromViper() (*Config, error) {
 			config.TTLs.ProviderSearchResults = duration
 		} else {
 			config.TTLs.ProviderSearchResults = 5 * time.Minute // fallback
+		}
+	}
+
+	if searchTTLStr := viper.GetString("cache.ttls.search_results"); searchTTLStr != "" {
+		if duration, err := time.ParseDuration(searchTTLStr); err == nil {
+			config.TTLs.SearchResults = duration
+		} else {
+			config.TTLs.SearchResults = 5 * time.Minute // fallback
 		}
 	}
 

--- a/pkg/cache/config_test.go
+++ b/pkg/cache/config_test.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/config_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 123e4567-e89b-12d3-a456-426614174009
 
 package cache
@@ -32,6 +32,7 @@ func TestConfigFromViper(t *testing.T) {
 	v.Set("cache.redis.read_timeout", "5s")
 	v.Set("cache.redis.write_timeout", "5s")
 	v.Set("cache.ttls.provider_search_results", "10m")
+	v.Set("cache.ttls.search_results", "10m")
 	v.Set("cache.ttls.tmdb_metadata", "48h")
 	v.Set("cache.ttls.translation_results", "1h")
 	v.Set("cache.ttls.user_sessions", "12h")
@@ -121,6 +122,10 @@ func TestConfigFromViper(t *testing.T) {
 		t.Errorf("expected provider search results TTL 10m, got %v", config.TTLs.ProviderSearchResults)
 	}
 
+	if config.TTLs.SearchResults != 10*time.Minute {
+		t.Errorf("expected search results TTL 10m, got %v", config.TTLs.SearchResults)
+	}
+
 	if config.TTLs.TMDBMetadata != 48*time.Hour {
 		t.Errorf("expected TMDB metadata TTL 48h, got %v", config.TTLs.TMDBMetadata)
 	}
@@ -187,6 +192,7 @@ func TestConfigFromViper_InvalidDurations(t *testing.T) {
 	v.Set("cache.memory.cleanup_interval", "not-a-duration")
 	v.Set("cache.redis.dial_timeout", "bad-timeout")
 	v.Set("cache.ttls.provider_search_results", "malformed")
+	v.Set("cache.ttls.search_results", "bad")
 
 	// Replace the global viper instance temporarily
 	originalViper := viper.GetViper()
@@ -224,5 +230,9 @@ func TestConfigFromViper_InvalidDurations(t *testing.T) {
 
 	if config.TTLs.ProviderSearchResults != 5*time.Minute {
 		t.Errorf("expected fallback provider search results TTL 5m, got %v", config.TTLs.ProviderSearchResults)
+	}
+
+	if config.TTLs.SearchResults != 5*time.Minute {
+		t.Errorf("expected fallback search results TTL 5m, got %v", config.TTLs.SearchResults)
 	}
 }

--- a/pkg/cache/factory.go
+++ b/pkg/cache/factory.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/factory.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 123e4567-e89b-12d3-a456-426614174003
 
 package cache
@@ -83,6 +83,16 @@ func (m *Manager) GetProviderSearchResults(ctx context.Context, key string) ([]b
 // SetProviderSearchResults caches provider search results with configured TTL.
 func (m *Manager) SetProviderSearchResults(ctx context.Context, key string, data []byte) error {
 	return m.cache.Set(ctx, "provider:"+key, data, m.config.TTLs.ProviderSearchResults)
+}
+
+// GetSearchResults retrieves cached manual search results.
+func (m *Manager) GetSearchResults(ctx context.Context, key string) ([]byte, error) {
+	return m.cache.Get(ctx, "search:"+key)
+}
+
+// SetSearchResults caches manual search results with configured TTL.
+func (m *Manager) SetSearchResults(ctx context.Context, key string, data []byte) error {
+	return m.cache.Set(ctx, "search:"+key, data, m.config.TTLs.SearchResults)
 }
 
 // GetTMDBMetadata retrieves cached TMDB/OMDb metadata.

--- a/pkg/cache/factory_test.go
+++ b/pkg/cache/factory_test.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/factory_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 123e4567-e89b-12d3-a456-426614174006
 
 package cache
@@ -88,6 +88,7 @@ func TestNewManager(t *testing.T) {
 		},
 		TTLs: TTLConfig{
 			ProviderSearchResults: 5 * time.Minute,
+			SearchResults:         5 * time.Minute,
 			TMDBMetadata:          24 * time.Hour,
 			TranslationResults:    0, // permanent
 			UserSessions:          24 * time.Hour,
@@ -115,6 +116,20 @@ func TestNewManager(t *testing.T) {
 	}
 	if string(data) != "provider-data" {
 		t.Errorf("expected 'provider-data', got %s", string(data))
+	}
+
+	// Test manual search results
+	err = manager.SetSearchResults(ctx, "search1", []byte("search-data"))
+	if err != nil {
+		t.Fatalf("failed to set search results: %v", err)
+	}
+
+	data, err = manager.GetSearchResults(ctx, "search1")
+	if err != nil {
+		t.Fatalf("failed to get search results: %v", err)
+	}
+	if string(data) != "search-data" {
+		t.Errorf("expected 'search-data', got %s", string(data))
 	}
 
 	// Test TMDB metadata
@@ -186,6 +201,7 @@ func TestManager_ClearByPrefix(t *testing.T) {
 		},
 		TTLs: TTLConfig{
 			ProviderSearchResults: 5 * time.Minute,
+			SearchResults:         5 * time.Minute,
 			TMDBMetadata:          24 * time.Hour,
 		},
 	}

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/interface.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 123e4567-e89b-12d3-a456-426614174000
 
 package cache
@@ -140,6 +140,9 @@ type TTLConfig struct {
 	// ProviderSearchResults caches subtitle provider search results.
 	ProviderSearchResults time.Duration `json:"provider_search_results" yaml:"provider_search_results" mapstructure:"provider_search_results"`
 
+	// SearchResults caches manual search results.
+	SearchResults time.Duration `json:"search_results" yaml:"search_results" mapstructure:"search_results"`
+
 	// TMDBMetadata caches TMDB/OMDb metadata.
 	TMDBMetadata time.Duration `json:"tmdb_metadata" yaml:"tmdb_metadata" mapstructure:"tmdb_metadata"`
 
@@ -175,6 +178,7 @@ func DefaultConfig() *Config {
 		},
 		TTLs: TTLConfig{
 			ProviderSearchResults: 5 * time.Minute,
+			SearchResults:         5 * time.Minute,
 			TMDBMetadata:          24 * time.Hour,
 			TranslationResults:    0, // permanent
 			UserSessions:          24 * time.Hour,

--- a/pkg/cache/interface_test.go
+++ b/pkg/cache/interface_test.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/interface_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 123e4567-e89b-12d3-a456-426614174004
 
 package cache
@@ -43,6 +43,10 @@ func TestDefaultConfig(t *testing.T) {
 
 	if config.TTLs.ProviderSearchResults != 5*time.Minute {
 		t.Errorf("expected provider search results TTL to be 5 minutes, got %v", config.TTLs.ProviderSearchResults)
+	}
+
+	if config.TTLs.SearchResults != 5*time.Minute {
+		t.Errorf("expected search results TTL to be 5 minutes, got %v", config.TTLs.SearchResults)
 	}
 
 	if config.TTLs.TMDBMetadata != 24*time.Hour {

--- a/pkg/webserver/search.go
+++ b/pkg/webserver/search.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/search.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e49aff0-0057-49b4-b507-1a57a5f8a923
 
 package webserver
@@ -505,6 +505,12 @@ func fetchSearchResults(ctx context.Context, req SearchRequest) ([]SearchResult,
 	mgr := GetCacheManager()
 	key := searchCacheKey(req)
 	if mgr != nil {
+		if data, err := mgr.GetSearchResults(ctx, key); err == nil && data != nil {
+			var cached []SearchResult
+			if err := json.Unmarshal(data, &cached); err == nil {
+				return cached, nil
+			}
+		}
 		if data, err := mgr.GetProviderSearchResults(ctx, key); err == nil && data != nil {
 			var cached []SearchResult
 			if err := json.Unmarshal(data, &cached); err == nil {
@@ -519,6 +525,7 @@ func fetchSearchResults(ctx context.Context, req SearchRequest) ([]SearchResult,
 	if mgr != nil {
 		if data, err := json.Marshal(scored); err == nil {
 			mgr.SetProviderSearchResults(ctx, key, data)
+			mgr.SetSearchResults(ctx, key, data)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Adds caching for manual subtitle search results and exposes new cache TTL configuration. Manual searches now use cached results for faster repeated queries.

## Issues Addressed
### feat(search): cache manual search results
**Description:** Implemented new `SearchResults` cache and updated webserver logic to store and retrieve manual search results. Updated configuration to include a separate TTL for search results.

**Files Modified:**
- [`pkg/cache/factory.go`](./pkg/cache/factory.go) - Added methods to get/set cached search results | [[diff]](../../pull/PR_NUMBER/files#diff-eba4c55) [[repo]](../../blob/main/pkg/cache/factory.go)
- [`pkg/cache/config.go`](./pkg/cache/config.go) - Added `SearchResults` TTL parsing | [[diff]](../../pull/PR_NUMBER/files#diff-450463b) [[repo]](../../blob/main/pkg/cache/config.go)
- [`pkg/cache/interface.go`](./pkg/cache/interface.go) - Extended `TTLConfig` with `SearchResults` | [[diff]](../../pull/PR_NUMBER/files#diff-6b5a991) [[repo]](../../blob/main/pkg/cache/interface.go)
- [`pkg/webserver/search.go`](./pkg/webserver/search.go) - Cached manual search results | [[diff]](../../pull/PR_NUMBER/files#diff-2d03f06) [[repo]](../../blob/main/pkg/webserver/search.go)
- Documentation updates in `.github/doc-updates/`
- Issue created: `.github/issue-updates/5715c6ac-9771-4692-8d7f-d2bb6aec0a99.json`

## Testing
- ✅ `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875d0818c8883218dd067bfe473a485