### PR TITLE
Fix root command flag duplication

### DIFF
--- a/.github/doc-updates/082ab1c3-8864-4c7a-9cff-f6ca884c4ba2.json
+++ b/.github/doc-updates/082ab1c3-8864-4c7a-9cff-f6ca884c4ba2.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Verify root command flags are initialized only once",
+  "guid": "082ab1c3-8864-4c7a-9cff-f6ca884c4ba2",
+  "created_at": "2025-07-15T04:05:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/af83f0ca-16f8-4c12-a60f-166054ecea9b.json
+++ b/.github/doc-updates/af83f0ca-16f8-4c12-a60f-166054ecea9b.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Deduplicated persistent flag definitions in root command to prevent test panics",
+  "guid": "af83f0ca-16f8-4c12-a60f-166054ecea9b",
+  "created_at": "2025-07-15T04:05:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c2c4aac9-d21d-48dd-bfc8-f92b168bb681.json
+++ b/.github/doc-updates/c2c4aac9-d21d-48dd-bfc8-f92b168bb681.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Updated root command initialization notes about persistent flag deduplication",
+  "guid": "c2c4aac9-d21d-48dd-bfc8-f92b168bb681",
+  "created_at": "2025-07-15T04:05:41Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/00b7f48a-4489-4867-bb15-37642b85ebf1.json
+++ b/.github/issue-updates/00b7f48a-4489-4867-bb15-37642b85ebf1.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Deduplicate Persistent Flags",
+  "body": "Remove repeated persistent flag definitions in the root command to avoid panics",
+  "labels": ["bug"],
+  "guid": "00b7f48a-4489-4867-bb15-37642b85ebf1",
+  "legacy_guid": "create-deduplicate-persistent-flags-2025-07-15"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,6 @@
+// file: cmd/root.go
+// version: 1.0.2
+// guid: 537af48f-4b60-44b5-a4a1-76a2616b9ccb
 // Package cmd implements the CLI commands for subtitle-manager.
 // It provides the root command and subcommands for all user-facing operations.
 //
@@ -27,7 +30,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/jdfalk/subtitle-manager/pkg/captcha"
@@ -79,7 +81,7 @@ func GetDatabaseBackend() string {
 var rootInit sync.Once
 
 func init() {
-	if pflag.CommandLine.Lookup("s3-region") != nil {
+	if rootCmd.PersistentFlags().Lookup("s3-region") != nil {
 		return
 	}
 	rootInit.Do(func() {


### PR DESCRIPTION
## Summary
- deduplicate persistent flag registration in the root command
- note issue update for persistent flag deduplication

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875d1627b58832188bceba32e21ec8d