### PR TITLE
Integrate gcommon metrics and health

### DIFF
--- a/.github/doc-updates/142d09d7-3e2e-4bcd-b3a8-d3cee2bc166c.json
+++ b/.github/doc-updates/142d09d7-3e2e-4bcd-b3a8-d3cee2bc166c.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Document gcommon metrics and health integration",
+  "guid": "142d09d7-3e2e-4bcd-b3a8-d3cee2bc166c",
+  "created_at": "2025-07-15T04:12:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/272303ce-61ee-4b74-8ec0-0a99e2055b4a.json
+++ b/.github/doc-updates/272303ce-61ee-4b74-8ec0-0a99e2055b4a.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "- Expose /metrics and /health endpoints using gcommon",
+  "guid": "272303ce-61ee-4b74-8ec0-0a99e2055b4a",
+  "created_at": "2025-07-15T12:05:17Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/2768ac23-6f5f-4a9f-98c2-a0de095f4fca.json
+++ b/.github/doc-updates/2768ac23-6f5f-4a9f-98c2-a0de095f4fca.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Integrated gcommon metrics and health system",
+  "guid": "2768ac23-6f5f-4a9f-98c2-a0de095f4fca",
+  "created_at": "2025-07-15T12:05:13Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9044fb33-c45f-443a-80d5-b862616481ee.json
+++ b/.github/doc-updates/9044fb33-c45f-443a-80d5-b862616481ee.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Integrated gcommon metrics and health modules",
+  "guid": "9044fb33-c45f-443a-80d5-b862616481ee",
+  "created_at": "2025-07-15T04:12:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/94241344-1820-4d2e-85f7-701a07c8762c.json
+++ b/.github/doc-updates/94241344-1820-4d2e-85f7-701a07c8762c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Integrated gcommon metrics and health modules",
+  "guid": "94241344-1820-4d2e-85f7-701a07c8762c",
+  "created_at": "2025-07-15T04:12:31Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ce1d3053-0111-4ebc-9027-7e35a15df584.json
+++ b/.github/doc-updates/ce1d3053-0111-4ebc-9027-7e35a15df584.json
@@ -1,0 +1,16 @@
+{
+  "file": "docs/ERROR_HANDLING.md",
+  "mode": "replace-section",
+  "content": "- `/health` - Application health status",
+  "guid": "ce1d3053-0111-4ebc-9027-7e35a15df584",
+  "created_at": "2025-07-15T04:12:51Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/eeac082c-8ab9-4f83-9620-8200e4f16be2.json
+++ b/.github/doc-updates/eeac082c-8ab9-4f83-9620-8200e4f16be2.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Verify Prometheus metrics via new provider",
+  "guid": "eeac082c-8ab9-4f83-9620-8200e4f16be2",
+  "created_at": "2025-07-15T12:05:20Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/49706efa-24b1-450d-9be7-f8a129423200.json
+++ b/.github/issue-updates/49706efa-24b1-450d-9be7-f8a129423200.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Integrate gcommon metrics",
+  "body": "Add Prometheus and new health endpoints",
+  "labels": ["enhancement"],
+  "guid": "49706efa-24b1-450d-9be7-f8a129423200",
+  "legacy_guid": "create-integrate-gcommon-metrics-2025-07-15"
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,11 +8,15 @@ import (
 	"strings"
 	"testing"
 
+	gmetrics "github.com/jdfalk/gcommon/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestProviderRequestsMetric(t *testing.T) {
+	if err := Initialize(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
 	// Test that the provider requests metric is properly registered
 	if ProviderRequests == nil {
 		t.Fatal("ProviderRequests metric is nil")
@@ -22,9 +26,18 @@ func TestProviderRequestsMetric(t *testing.T) {
 	ProviderRequests.Reset()
 
 	// Increment the metric
-	ProviderRequests.WithLabelValues("opensubtitles", "success").Inc()
-	ProviderRequests.WithLabelValues("opensubtitles", "error").Inc()
-	ProviderRequests.WithLabelValues("opensubtitles", "error").Inc()
+	ProviderRequests.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "opensubtitles"},
+		gmetrics.Tag{Key: "status", Value: "success"},
+	).Inc()
+	ProviderRequests.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "opensubtitles"},
+		gmetrics.Tag{Key: "status", Value: "error"},
+	).Inc()
+	ProviderRequests.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "opensubtitles"},
+		gmetrics.Tag{Key: "status", Value: "error"},
+	).Inc()
 
 	// Check the metric values
 	expected := `
@@ -39,6 +52,9 @@ func TestProviderRequestsMetric(t *testing.T) {
 }
 
 func TestTranslationRequestsMetric(t *testing.T) {
+	if err := Initialize(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
 	// Test that the translation requests metric is properly registered
 	if TranslationRequests == nil {
 		t.Fatal("TranslationRequests metric is nil")
@@ -48,8 +64,16 @@ func TestTranslationRequestsMetric(t *testing.T) {
 	TranslationRequests.Reset()
 
 	// Increment the metric
-	TranslationRequests.WithLabelValues("google", "en", "success").Inc()
-	TranslationRequests.WithLabelValues("openai", "fr", "error").Inc()
+	TranslationRequests.WithTags(
+		gmetrics.Tag{Key: "service", Value: "google"},
+		gmetrics.Tag{Key: "target_language", Value: "en"},
+		gmetrics.Tag{Key: "status", Value: "success"},
+	).Inc()
+	TranslationRequests.WithTags(
+		gmetrics.Tag{Key: "service", Value: "openai"},
+		gmetrics.Tag{Key: "target_language", Value: "fr"},
+		gmetrics.Tag{Key: "status", Value: "error"},
+	).Inc()
 
 	// Check the metric values
 	expected := `
@@ -64,6 +88,9 @@ func TestTranslationRequestsMetric(t *testing.T) {
 }
 
 func TestSubtitleDownloadsMetric(t *testing.T) {
+	if err := Initialize(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
 	// Test that the subtitle downloads metric is properly registered
 	if SubtitleDownloads == nil {
 		t.Fatal("SubtitleDownloads metric is nil")
@@ -73,9 +100,18 @@ func TestSubtitleDownloadsMetric(t *testing.T) {
 	SubtitleDownloads.Reset()
 
 	// Increment the metric
-	SubtitleDownloads.WithLabelValues("opensubtitles", "en").Inc()
-	SubtitleDownloads.WithLabelValues("opensubtitles", "en").Inc()
-	SubtitleDownloads.WithLabelValues("subscene", "fr").Inc()
+	SubtitleDownloads.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "opensubtitles"},
+		gmetrics.Tag{Key: "language", Value: "en"},
+	).Inc()
+	SubtitleDownloads.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "opensubtitles"},
+		gmetrics.Tag{Key: "language", Value: "en"},
+	).Inc()
+	SubtitleDownloads.WithTags(
+		gmetrics.Tag{Key: "provider", Value: "subscene"},
+		gmetrics.Tag{Key: "language", Value: "fr"},
+	).Inc()
 
 	// Check the metric values
 	expected := `
@@ -90,6 +126,9 @@ func TestSubtitleDownloadsMetric(t *testing.T) {
 }
 
 func TestAllMetricsRegistered(t *testing.T) {
+	if err := Initialize(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
 	// Check that all metrics are properly defined
 	metrics := []prometheus.Collector{
 		ProviderRequests,

--- a/pkg/webserver/health.go
+++ b/pkg/webserver/health.go
@@ -1,0 +1,110 @@
+// file: pkg/webserver/health.go
+// version: 1.0.0
+// guid: 9e8d7c6b-5a4f-3d2c-1b0a-9f8e7d6c5b4a
+
+package webserver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ghealth "github.com/jdfalk/gcommon/pkg/health"
+	"github.com/jdfalk/subtitle-manager/pkg/errors"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+)
+
+var HealthProvider ghealth.Provider
+
+// initializeHealth sets up the global health provider with built-in checks.
+func initializeHealth(endpoint string) error {
+	if HealthProvider != nil {
+		return nil
+	}
+
+	cfg := ghealth.DefaultConfig()
+	cfg.Endpoint = endpoint
+	cfg.EnableLivenessEndpoint = true
+	cfg.EnableReadinessEndpoint = true
+	cfg.MetricsEnabled = true
+
+	provider, err := ghealth.NewProvider(cfg)
+	if err != nil {
+		return err
+	}
+
+	provider.Register("errors", ghealth.CheckFunc(errorHealthCheck), ghealth.WithType(ghealth.TypeComponent))
+	provider.Register("cache", ghealth.CheckFunc(cacheHealthCheck), ghealth.WithType(ghealth.TypeComponent))
+
+	HealthProvider = provider
+	return nil
+}
+
+func errorHealthCheck(ctx context.Context) (ghealth.Result, error) {
+	stats := errors.GlobalTracker.GetStats()
+	var total, critical int
+	recent := time.Now().Add(-5 * time.Minute)
+	for _, stat := range stats {
+		total += stat.Count
+		if stat.LastOccurred.After(recent) && !stat.Retryable {
+			critical += stat.Count
+		}
+	}
+
+	status := ghealth.StatusUp
+	if critical > 10 {
+		status = ghealth.StatusDown
+	} else if critical > 5 {
+		status = ghealth.StatusDegraded
+	}
+
+	res := ghealth.NewResult(status).WithDetails(map[string]any{
+		"total_errors":           total,
+		"critical_errors_recent": critical,
+		"unique_error_types":     len(stats),
+	})
+	return res, nil
+}
+
+func cacheHealthCheck(ctx context.Context) (ghealth.Result, error) {
+	logger := logging.GetLogger("webserver.cache")
+	if cacheManager == nil {
+		return ghealth.NewResult(ghealth.StatusDown).WithError(fmt.Errorf("cache not initialized")), nil
+	}
+
+	testKey := "health-check"
+	testValue := []byte("ok")
+
+	if err := cacheManager.SetAPIResponse(ctx, testKey, testValue); err != nil {
+		logger.Errorf("cache health check failed (set): %v", err)
+		return ghealth.NewResult(ghealth.StatusDown).
+			WithError(err).
+			WithDetails(map[string]any{"message": "Failed to write to cache"}), nil
+	}
+
+	value, err := cacheManager.GetAPIResponse(ctx, testKey)
+	if err != nil {
+		logger.Errorf("cache health check failed (get): %v", err)
+		return ghealth.NewResult(ghealth.StatusDown).
+			WithError(err).
+			WithDetails(map[string]any{"message": "Failed to read from cache"}), nil
+	}
+	if string(value) != string(testValue) {
+		logger.Error("cache health check failed: value mismatch")
+		return ghealth.NewResult(ghealth.StatusDown).
+			WithDetails(map[string]any{"message": "Cache value mismatch"}), nil
+	}
+
+	_ = cacheManager.Delete(ctx, "api:"+testKey)
+
+	stats, err := cacheManager.Stats(ctx)
+	if err != nil {
+		logger.Warnf("failed to get stats for health check: %v", err)
+	}
+
+	res := ghealth.NewResult(ghealth.StatusUp).WithDetails(map[string]any{"message": "Cache is operational"})
+	if stats != nil {
+		res.WithDetails(map[string]any{"stats": stats})
+	}
+	return res, nil
+}

--- a/pkg/webserver/translate.go
+++ b/pkg/webserver/translate.go
@@ -1,4 +1,7 @@
 // file: pkg/webserver/translate.go
+// version: 1.0.0
+// guid: f0523cff-b15b-4527-aa90-0b65326f73f9
+
 package webserver
 
 import (
@@ -9,6 +12,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	gmetrics "github.com/jdfalk/gcommon/pkg/metrics"
 	"github.com/jdfalk/subtitle-manager/pkg/metrics"
 	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
 )
@@ -26,20 +30,32 @@ func translateHandler() http.Handler {
 			return
 		}
 		if err := r.ParseMultipartForm(32 << 20); err != nil {
-			metrics.TranslationRequests.WithLabelValues("", "", "bad_request").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: ""},
+				gmetrics.Tag{Key: "target_language", Value: ""},
+				gmetrics.Tag{Key: "status", Value: "bad_request"},
+			).Inc()
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		file, hdr, err := r.FormFile("file")
 		if err != nil {
-			metrics.TranslationRequests.WithLabelValues("", "", "bad_request").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: ""},
+				gmetrics.Tag{Key: "target_language", Value: ""},
+				gmetrics.Tag{Key: "status", Value: "bad_request"},
+			).Inc()
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		defer file.Close()
 		lang := r.FormValue("lang")
 		if lang == "" {
-			metrics.TranslationRequests.WithLabelValues("", "", "bad_request").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: ""},
+				gmetrics.Tag{Key: "target_language", Value: ""},
+				gmetrics.Tag{Key: "status", Value: "bad_request"},
+			).Inc()
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -59,7 +75,11 @@ func translateHandler() http.Handler {
 
 		in, err := os.CreateTemp("", "in-*"+filepath.Ext(hdr.Filename))
 		if err != nil {
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -67,37 +87,61 @@ func translateHandler() http.Handler {
 		defer os.Remove(in.Name())
 		if _, err := io.Copy(in, file); err != nil {
 			_ = in.Close()
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		out, err := os.CreateTemp("", "out-*.srt")
 		if err != nil {
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		defer func() { _ = out.Close() }()
 		defer os.Remove(out.Name())
 		if err := out.Close(); err != nil {
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		if err := subtitles.TranslateFileToSRT(in.Name(), out.Name(), lang, service, gKey, gptKey, grpcAddr); err != nil {
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		data, err := os.ReadFile(out.Name())
 		if err != nil {
-			metrics.TranslationRequests.WithLabelValues(service, lang, "error").Inc()
+			metrics.TranslationRequests.WithTags(
+				gmetrics.Tag{Key: "service", Value: service},
+				gmetrics.Tag{Key: "target_language", Value: lang},
+				gmetrics.Tag{Key: "status", Value: "error"},
+			).Inc()
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		metrics.TranslationRequests.WithLabelValues(service, lang, "success").Inc()
+		metrics.TranslationRequests.WithTags(
+			gmetrics.Tag{Key: "service", Value: service},
+			gmetrics.Tag{Key: "target_language", Value: lang},
+			gmetrics.Tag{Key: "status", Value: "success"},
+		).Inc()
 		w.Header().Set("Content-Type", "application/x-subrip")
 		_, _ = w.Write(data)
 	})


### PR DESCRIPTION
## Summary
- use gcommon metrics provider with Prometheus counters, gauges and histograms
- add gcommon health provider with cache and error checks
- expose `/metrics` and `/health` endpoints and start providers on server startup
- log documentation and issue updates via helper scripts

## Testing
- `go vet ./...` *(fails: undefined pb types in gcommon)*
- `go test ./...` *(fails: undefined pb types in gcommon)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6875d11738448321a176e99a4f15a9d4