### PR TITLE
Add monitor autosync command docs

### DIFF
--- a/.github/doc-updates/0837d5f7-b915-46a6-9fe3-5bf846b7348b.json
+++ b/.github/doc-updates/0837d5f7-b915-46a6-9fe3-5bf846b7348b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### Scheduled Sync\\n\\nUse `subtitle-manager monitor autosync` to periodically sync libraries from Sonarr and Radarr.",
+  "guid": "0837d5f7-b915-46a6-9fe3-5bf846b7348b",
+  "created_at": "2025-07-15T04:03:10Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b97dc142-8a55-433f-bf5f-4b2c9715e430.json
+++ b/.github/doc-updates/b97dc142-8a55-433f-bf5f-4b2c9715e430.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added monitor autosync command for scheduled Sonarr/Radarr synchronization",
+  "guid": "b97dc142-8a55-433f-bf5f-4b2c9715e430",
+  "created_at": "2025-07-15T04:03:07Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d78bf185-ffc7-4b60-86b2-0b161f8c7f4c.json
+++ b/.github/doc-updates/d78bf185-ffc7-4b60-86b2-0b161f8c7f4c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Document monitor autosync usage",
+  "guid": "d78bf185-ffc7-4b60-86b2-0b161f8c7f4c",
+  "created_at": "2025-07-15T04:03:15Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/179081c6-3269-4eea-a30f-46afb1843464.json
+++ b/.github/issue-updates/179081c6-3269-4eea-a30f-46afb1843464.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement monitor autosync",
+  "body": "Added command for periodic Sonarr/Radarr synchronization",
+  "labels": ["enhancement", "monitor"],
+  "guid": "179081c6-3269-4eea-a30f-46afb1843464",
+  "legacy_guid": "create-implement-monitor-autosync-2025-07-15"
+}


### PR DESCRIPTION
## Summary

Adds documentation updates describing the new `monitor autosync` command for periodic Sonarr/Radarr library synchronization.

## Issues Addressed

### docs(monitor): add autosync command documentation
- [cmd/monitor.go](cmd/monitor.go) - existing command definition for reference
- [.github/doc-updates/0837d5f7-b915-46a6-9fe3-5bf846b7348b.json](.github/doc-updates/0837d5f7-b915-46a6-9fe3-5bf846b7348b.json) - README update
- [.github/doc-updates/b97dc142-8a55-433f-bf5f-4b2c9715e430.json](.github/doc-updates/b97dc142-8a55-433f-bf5f-4b2c9715e430.json) - changelog entry
- [.github/doc-updates/d78bf185-ffc7-4b60-86b2-0b161f8c7f4c.json](.github/doc-updates/d78bf185-ffc7-4b60-86b2-0b161f8c7f4c.json) - TODO update
- [.github/issue-updates/179081c6-3269-4eea-a30f-46afb1843464.json](.github/issue-updates/179081c6-3269-4eea-a30f-46afb1843464.json) - issue tracking

## Testing

- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875d16d0364832197bc097ca5500062