### PR TITLE
Migrate Config Loader to gcommon config

### DIFF
--- a/.github/doc-updates/2abfaec3-4fce-4773-878b-a590e8d2075d.json
+++ b/.github/doc-updates/2abfaec3-4fce-4773-878b-a590e8d2075d.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added instructions for migrate_config_to_gcommon.py",
+  "guid": "2abfaec3-4fce-4773-878b-a590e8d2075d",
+  "created_at": "2025-07-15T04:05:18Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/80e55e6b-dfbe-4cd1-8ad6-bd55187964e7.json
+++ b/.github/doc-updates/80e55e6b-dfbe-4cd1-8ad6-bd55187964e7.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Config loader migrated to gcommon/config",
+  "guid": "80e55e6b-dfbe-4cd1-8ad6-bd55187964e7",
+  "created_at": "2025-07-15T04:05:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8e62a5aa-1b43-420f-b8c3-bc6de7940e09.json
+++ b/.github/doc-updates/8e62a5aa-1b43-420f-b8c3-bc6de7940e09.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Migrated config loader to gcommon/config with new migration script",
+  "guid": "8e62a5aa-1b43-420f-b8c3-bc6de7940e09",
+  "created_at": "2025-07-15T04:05:13Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/c18a3b96-fd0c-435f-ad6d-cc036ff245dc.json
+++ b/.github/issue-updates/c18a3b96-fd0c-435f-ad6d-cc036ff245dc.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Track gcommon config loader usage",
+  "body": "Document migrating config loader to gcommon/config with script",
+  "labels": ["enhancement", "documentation"],
+  "guid": "c18a3b96-fd0c-435f-ad6d-cc036ff245dc",
+  "legacy_guid": "create-track-gcommon-config-loader-usage-2025-07-15"
+}

--- a/.github/issue-updates/cab77712-6720-4fdb-b429-643e76b366e4.json
+++ b/.github/issue-updates/cab77712-6720-4fdb-b429-643e76b366e4.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Expose config loader in gcommon repo",
+  "body": "Publish gcommon/config module separately\n\n<!-- GCOMMON ISSUE JSON\n{\"action\": \"create\", \"title\": \"Publish gcommon config loader\", \"body\": \"Expose gcommon/config as its own module so other projects can import it.\", \"labels\": [\"enhancement\"]}\n-->",
+  "labels": ["gcommon", "enhancement"],
+  "guid": "cab77712-6720-4fdb-b429-643e76b366e4",
+  "legacy_guid": "create-expose-config-loader-in-gcommon-repo-2025-07-15"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -32,6 +31,7 @@ import (
 
 	"github.com/jdfalk/subtitle-manager/pkg/captcha"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
+	gconfig "github.com/jdfalk/subtitle-manager/pkg/gcommon/config"
 	"github.com/jdfalk/subtitle-manager/pkg/i18n"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	"github.com/jdfalk/subtitle-manager/pkg/transcriber"
@@ -214,24 +214,8 @@ func init() {
 }
 
 func initConfig() {
-	viper.SetEnvPrefix("SM")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
-	viper.AutomaticEnv()
-
-	// Check for config file from flag, environment variable, or default
-	configFile := cfgFile
-	if configFile == "" {
-		configFile = viper.GetString("config_file") // This will get SM_CONFIG_FILE
-	}
-
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".subtitle-manager")
+	if err := gconfig.Load(rootCmd, cfgFile); err != nil {
+		rootCmd.PrintErrf("failed to load config: %v\n", err)
 	}
 
 	// Set defaults (needs to happen regardless of config file source)

--- a/pkg/gcommon/config/config.go
+++ b/pkg/gcommon/config/config.go
@@ -1,0 +1,54 @@
+// file: pkg/gcommon/config/config.go
+// version: 1.0.0
+// guid: 9f89692c-72ac-4bc6-b7be-7ff20bbf12e3
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Load initializes Viper using the given Cobra command and optional config file path.
+// Environment variables are automatically loaded using the SM_ prefix.
+// Default values mirror the previous internal loader for compatibility.
+func Load(cmd *cobra.Command, cfgFile string) error {
+	viper.SetEnvPrefix("SM")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	viper.AutomaticEnv()
+
+	configFile := cfgFile
+	if configFile == "" {
+		configFile = viper.GetString("config_file")
+	}
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".subtitle-manager")
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		viper.SetDefault("db_path", filepath.Join(home, ".subtitle-manager", "db"))
+	} else {
+		viper.SetDefault("db_path", "/config/db")
+	}
+	viper.SetDefault("db_backend", "pebble")
+	viper.SetDefault("sqlite3_filename", "subtitle-manager.db")
+	viper.SetDefault("log_file", "/config/logs/subtitle-manager.log")
+
+	if err := viper.ReadInConfig(); err == nil {
+		cmd.Printf("Using config file: %s\n", viper.ConfigFileUsed())
+	}
+	return nil
+}

--- a/scripts/migrate_config_to_gcommon.py
+++ b/scripts/migrate_config_to_gcommon.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# file: scripts/migrate_config_to_gcommon.py
+# version: 1.0.0
+# guid: 9f4e8f26-a32a-4673-9d7c-cdca4cd81fd2
+
+"""Migrate legacy subtitle-manager config to gcommon format.
+
+This script reads an existing YAML configuration file and converts
+all keys with hyphens to use underscores. The resulting configuration
+is written to a new file specified by --out (default: gcommon-config.yaml).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def convert_keys(obj):
+    """Recursively convert map keys by replacing hyphens with underscores."""
+    if isinstance(obj, dict):
+        return {k.replace("-", "_"): convert_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [convert_keys(v) for v in obj]
+    return obj
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Migrate config to gcommon format")
+    parser.add_argument("input", help="path to existing YAML config")
+    parser.add_argument("--out", default="gcommon-config.yaml", help="output file")
+    args = parser.parse_args()
+
+    data = yaml.safe_load(Path(args.input).read_text())
+    converted = convert_keys(data)
+    Path(args.out).write_text(yaml.dump(converted, sort_keys=False))
+    print(f"Converted config written to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Ported the configuration loader to a new `gcommon/config` module and added a small migration script for legacy YAML files. Issue updates were generated for both this repository and the external gcommon repo.

## Issues Addressed

### feat(config): migrate loader to gcommon config

**Description:** Introduced a wrapper around Viper for consistent environment handling and updated the root command to use it. Provided a Python script to convert existing configs.

**Files Modified:**

- [`cmd/root.go`](./cmd/root.go) - call the new loader during initialization | [[diff]](../../pull/PR_NUMBER/files#diff-1) [[repo]](../../blob/main/cmd/root.go)
- [`pkg/gcommon/config/config.go`](./pkg/gcommon/config/config.go) - new loader implementation | [[diff]](../../pull/PR_NUMBER/files#diff-2) [[repo]](../../blob/main/pkg/gcommon/config/config.go)
- [`scripts/migrate_config_to_gcommon.py`](./scripts/migrate_config_to_gcommon.py) - conversion tool | [[diff]](../../pull/PR_NUMBER/files#diff-3) [[repo]](../../blob/main/scripts/migrate_config_to_gcommon.py)

### chore(issues): track config loader migration

**Description:** Created issue updates to document migration tasks for this repo and to request publishing the config loader in the gcommon repo.

**Files Modified:**

- [`c18a3b96-fd0c-435f-ad6d-cc036ff245dc.json`](./.github/issue-updates/c18a3b96-fd0c-435f-ad6d-cc036ff245dc.json) - new issue for Subtitle Manager | [[diff]](../../pull/PR_NUMBER/files#diff-4) [[repo]](../../blob/main/.github/issue-updates/c18a3b96-fd0c-435f-ad6d-cc036ff245dc.json)
- [`cab77712-6720-4fdb-b429-643e76b366e4.json`](./.github/issue-updates/cab77712-6720-4fdb-b429-643e76b366e4.json) - cross-repo issue for gcommon | [[diff]](../../pull/PR_NUMBER/files#diff-5) [[repo]](../../blob/main/.github/issue-updates/cab77712-6720-4fdb-b429-643e76b366e4.json)

## Testing

- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6875d0c4cc9c8321a3b1e6dee58b73da