### PR TITLE
Implement cron-based autosync

### DIFF
--- a/.github/doc-updates/7b795eec-3eb7-40d4-9076-93cf6c574a9c.json
+++ b/.github/doc-updates/7b795eec-3eb7-40d4-9076-93cf6c574a9c.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added --schedule flag to monitor autosync for cron scheduling",
+  "guid": "7b795eec-3eb7-40d4-9076-93cf6c574a9c",
+  "created_at": "2025-07-15T04:07:56Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/82244e2d-d47f-4fbd-bdb8-dbd406c8c7c7.json
+++ b/.github/doc-updates/82244e2d-d47f-4fbd-bdb8-dbd406c8c7c7.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- monitor autosync supports cron schedules",
+  "guid": "82244e2d-d47f-4fbd-bdb8-dbd406c8c7c7",
+  "created_at": "2025-07-15T04:08:01Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9e76139d-a768-430e-a2bb-c4bbc8daefa2.json
+++ b/.github/doc-updates/9e76139d-a768-430e-a2bb-c4bbc8daefa2.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Document cron support for monitor autosync",
+  "guid": "9e76139d-a768-430e-a2bb-c4bbc8daefa2",
+  "created_at": "2025-07-15T04:08:05Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -1,5 +1,5 @@
 // file: cmd/monitor.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12345678-1234-1234-1234-123456789014
 
 package cmd
@@ -84,6 +84,7 @@ var monitorBlacklistRemoveCmd = &cobra.Command{
 var (
 	monitorInterval     string
 	monitorSyncInterval string
+	monitorSyncSchedule string
 	monitorLanguages    []string
 	monitorMaxRetries   int
 	monitorQualityCheck bool
@@ -120,6 +121,7 @@ func init() {
 	monitorAutoSyncCmd.Flags().StringSliceVar(&monitorLanguages, "languages", []string{"en"}, "Languages to monitor (comma-separated)")
 	monitorAutoSyncCmd.Flags().IntVar(&monitorMaxRetries, "max-retries", 3, "Maximum retry attempts per item")
 	monitorAutoSyncCmd.Flags().StringVar(&monitorSource, "source", "both", "Source to sync from: sonarr, radarr, or both")
+	monitorAutoSyncCmd.Flags().StringVar(&monitorSyncSchedule, "schedule", "", "Cron schedule expression")
 
 	rootCmd.AddCommand(monitorCmd)
 }
@@ -263,6 +265,11 @@ func runMonitorAutoSync(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
+	if monitorSyncSchedule != "" {
+		fmt.Printf("Starting scheduled sync using cron '%s'\n", monitorSyncSchedule)
+		return monitoring.RunCronSync(ctx, monitorSyncSchedule, sched, opts)
+	}
+
 	fmt.Printf("Starting scheduled sync every %v\n", interval)
 	return sched.StartScheduledSync(ctx, interval, opts)
 }

--- a/pkg/monitoring/scheduler.go
+++ b/pkg/monitoring/scheduler.go
@@ -1,5 +1,5 @@
 // file: pkg/monitoring/scheduler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12345678-1234-1234-1234-123456789016
 
 package monitoring
@@ -81,5 +81,12 @@ func (s *ScheduledMonitor) StartScheduledSync(ctx context.Context, interval time
 
 	return scheduler.RunWithOptions(ctx, syncOpts, func(ctx context.Context) error {
 		return s.RunSyncTask(ctx, opts)
+	})
+}
+
+// RunCronSync executes a sync task immediately and then on the provided cron schedule.
+func RunCronSync(ctx context.Context, spec string, sched *ScheduledMonitor, opts SyncOptions) error {
+	return scheduler.RunCron(ctx, spec, func(ctx context.Context) error {
+		return sched.RunSyncTask(ctx, opts)
 	})
 }


### PR DESCRIPTION
## Summary
- enable cron scheduling for periodic Sonarr/Radarr sync
- add doc updates for the new `--schedule` flag

## Testing
- `go build ./...`
- `go test ./...`
- `pre-commit run --files cmd/monitor.go pkg/monitoring/scheduler.go pkg/monitoring/sync.go README.md CHANGELOG.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_6875d1c1776083218eff9c4403bd7db0