### PR TITLE
Add gcommon config migration script

### DIFF
--- a/.github/doc-updates/2a558f78-967f-431d-9c3f-ce6d1d15d706.json
+++ b/.github/doc-updates/2a558f78-967f-431d-9c3f-ce6d1d15d706.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Write a migration script to convert existing configs to the new format.",
+  "guid": "2a558f78-967f-431d-9c3f-ce6d1d15d706",
+  "created_at": "2025-07-15T04:04:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/766f5909-086f-4aa8-809b-38989cb4b358.json
+++ b/.github/doc-updates/766f5909-086f-4aa8-809b-38989cb4b358.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added config migration script for gcommon",
+  "guid": "766f5909-086f-4aa8-809b-38989cb4b358",
+  "created_at": "2025-07-15T04:04:35Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/82237767-fb44-43d3-b87b-f7585c78a92f.json
+++ b/.github/doc-updates/82237767-fb44-43d3-b87b-f7585c78a92f.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added migrate-config-to-gcommon.py utility for converting legacy configs",
+  "guid": "82237767-fb44-43d3-b87b-f7585c78a92f",
+  "created_at": "2025-07-15T04:04:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/scripts/migrate-config-to-gcommon.py
+++ b/scripts/migrate-config-to-gcommon.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# file: scripts/migrate-config-to-gcommon.py
+# version: 1.0.0
+# guid: 9e3d1b40-1fa6-4f50-bdbe-62d0df0bf71d
+
+"""Config migration utility.
+
+This script converts legacy YAML or JSON configuration files to the gcommon
+configuration format. It flattens nested keys and outputs a JSON file with a
+list of config entries using gcommon's ConfigValue representation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+VALUE_TYPE_STRING = "VALUE_TYPE_STRING"
+VALUE_TYPE_INT = "VALUE_TYPE_INT"
+VALUE_TYPE_DOUBLE = "VALUE_TYPE_DOUBLE"
+VALUE_TYPE_BOOL = "VALUE_TYPE_BOOL"
+VALUE_TYPE_JSON = "VALUE_TYPE_JSON"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert config to gcommon format"
+    )
+    parser.add_argument("input", type=Path, help="Path to legacy config file")
+    parser.add_argument("output", type=Path, help="Path to write gcommon JSON")
+    parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Optional namespace/environment for the entries",
+    )
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    text = path.read_text()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return yaml.safe_load(text) or {}
+
+
+def flatten(prefix: str, data: Any, result: Dict[str, Any]) -> None:
+    if isinstance(data, dict):
+        for key, value in data.items():
+            new_prefix = f"{prefix}.{key}" if prefix else str(key)
+            flatten(new_prefix, value, result)
+    else:
+        result[prefix] = data
+
+
+def infer_value(value: Any) -> Dict[str, Any]:
+    if isinstance(value, bool):
+        return {"bool_value": value, "type": VALUE_TYPE_BOOL}
+    if isinstance(value, int):
+        return {"int_value": value, "type": VALUE_TYPE_INT}
+    if isinstance(value, float):
+        return {"double_value": value, "type": VALUE_TYPE_DOUBLE}
+    if isinstance(value, (list, dict)):
+        return {"json_value": json.dumps(value), "type": VALUE_TYPE_JSON}
+    return {"string_value": str(value), "type": VALUE_TYPE_STRING}
+
+
+def migrate_config(config: Dict[str, Any], namespace: str) -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    flatten("", config, flat)
+    entries = []
+    for key, value in flat.items():
+        entry = {"key": key, **infer_value(value), "namespace": namespace}
+        entries.append(entry)
+    return {"entries": entries, "namespace": namespace}
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config(args.input)
+    migrated = migrate_config(config, args.namespace)
+    args.output.write_text(json.dumps(migrated, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `migrate-config-to-gcommon.py` utility for converting legacy configs into gcommon JSON
- mark migration TODO as complete and document the new tool via doc updates
- update parser formatting to follow repository style guidelines

## Testing
- `pre-commit run --files scripts/migrate-config-to-gcommon.py` *(fails: files reformatted)*
- `go test ./...`
- `bash scripts/codex-rebase.sh main` *(fails: could not fetch origin)*

------
https://chatgpt.com/codex/tasks/task_e_6875d17ce3148321bffd5974421179b1