### PR TITLE
Automated doc and issue updates after failed rebase

### DIFF
--- a/.github/doc-updates/26b1d3c2-e151-4d9e-885b-989b23cacd6b.json
+++ b/.github/doc-updates/26b1d3c2-e151-4d9e-885b-989b23cacd6b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Rebase script status\\n\\nTODO: Add content for this section",
+  "guid": "26b1d3c2-e151-4d9e-885b-989b23cacd6b",
+  "created_at": "2025-07-16T00:22:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/3d163431-589e-44bf-8729-20c64050321e.json
+++ b/.github/doc-updates/3d163431-589e-44bf-8729-20c64050321e.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Investigate remote configuration for rebase script",
+  "guid": "3d163431-589e-44bf-8729-20c64050321e",
+  "created_at": "2025-07-16T00:22:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bbcf3b7c-edc9-4def-ab4a-05325f9482ed.json
+++ b/.github/doc-updates/bbcf3b7c-edc9-4def-ab4a-05325f9482ed.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Codex rebase script failed due to missing origin remote",
+  "guid": "bbcf3b7c-edc9-4def-ab4a-05325f9482ed",
+  "created_at": "2025-07-16T00:22:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/4d471c5b-98f1-49ab-b7f5-f3ec03589630.json
+++ b/.github/issue-updates/4d471c5b-98f1-49ab-b7f5-f3ec03589630.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Failed rebase using rebase script",
+  "body": "Rebase attempt using codex-rebase.sh failed because the origin remote is not configured or accessible in this environment.",
+  "labels": ["rebase", "automation"],
+  "guid": "4d471c5b-98f1-49ab-b7f5-f3ec03589630",
+  "legacy_guid": "create-failed-rebase-using-rebase-script-2025-07-16"
+}


### PR DESCRIPTION
## Summary
- document a failing attempt to run the rebase script via the doc update system
- add TODO note to investigate remote configuration for the rebase script
- create issue update describing why the rebase failed

## Testing
- `go vet ./...` *(failed: could not download modules)*
- `go test ./...` *(failed: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6875d11738448321a176e99a4f15a9d4