### PR TITLE
Add database protobuf definitions

### DIFF
--- a/.github/doc-updates/0bd05855-d8e7-48e7-b520-bddb726a7302.json
+++ b/.github/doc-updates/0bd05855-d8e7-48e7-b520-bddb726a7302.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add protobuf messages for database records",
+  "guid": "0bd05855-d8e7-48e7-b520-bddb726a7302",
+  "created_at": "2025-07-23T03:21:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8b391b80-2cef-454c-900f-28d0d2e33217.json
+++ b/.github/doc-updates/8b391b80-2cef-454c-900f-28d0d2e33217.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "Database records are now defined in `proto/database.proto` and generated to `pkg/databasepb` using `make proto-gen`.",
+  "guid": "8b391b80-2cef-454c-900f-28d0d2e33217",
+  "created_at": "2025-07-23T03:21:32Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b155167d-9ec0-48c5-8bb4-1c31b0de4730.json
+++ b/.github/doc-updates/b155167d-9ec0-48c5-8bb4-1c31b0de4730.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added protobuf definitions for database records",
+  "guid": "b155167d-9ec0-48c5-8bb4-1c31b0de4730",
+  "created_at": "2025-07-23T03:21:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/5f854524-5d77-42b9-8526-474345c96574.json
+++ b/.github/issue-updates/5f854524-5d77-42b9-8526-474345c96574.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Database protobuf messages",
+  "body": "Add proto definitions for SubtitleRecord and DownloadRecord for centralized protobuf migration.",
+  "labels": ["migration", "proto"],
+  "guid": "5f854524-5d77-42b9-8526-474345c96574",
+  "legacy_guid": "create-database-protobuf-messages-2025-07-23"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 	# file: Makefile
 # Makefile for Subtitle Manager - Comprehensive build automation
 
-# Project Configuration
-APP_NAME := subtitle-manager
+	# Project Configuration
+	APP_NAME := subtitle-manager
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_TIME := $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
 GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
@@ -471,6 +471,7 @@ docker-benchmark:
 proto-gen: ## Generate protobuf code
 	@echo "$(COLOR_BLUE)Generating protobuf code...$(COLOR_RESET)"
 	cd $(PROTO_DIR) && $(PROTOC) --go_out='paths=source_relative:../pkg/jobpb' queue_job.proto
+	cd $(PROTO_DIR) && $(PROTOC) --go_out='paths=source_relative:../pkg/databasepb' database.proto
 	@echo "$(COLOR_GREEN)✓ Protobuf code generated$(COLOR_RESET)"
 
 #

--- a/pkg/database/pb_conversions.go
+++ b/pkg/database/pb_conversions.go
@@ -1,0 +1,136 @@
+// file: pkg/database/pb_conversions.go
+// version: 1.0.0
+// guid: c9cf2d1a-c284-46f4-90d1-70925cbe8b27
+
+package database
+
+import (
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/databasepb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ToProto converts a SubtitleRecord to its protobuf representation.
+func (r *SubtitleRecord) ToProto() *databasepb.SubtitleRecord {
+	if r == nil {
+		return nil
+	}
+	var score *float64
+	if r.ConfidenceScore != nil {
+		v := *r.ConfidenceScore
+		score = &v
+	}
+	var parent *string
+	if r.ParentID != nil {
+		v := *r.ParentID
+		parent = &v
+	}
+	return &databasepb.SubtitleRecord{
+		Id:               r.ID,
+		File:             r.File,
+		VideoFile:        r.VideoFile,
+		Release:          r.Release,
+		Language:         r.Language,
+		Service:          r.Service,
+		Embedded:         r.Embedded,
+		SourceUrl:        r.SourceURL,
+		ProviderMetadata: r.ProviderMetadata,
+		ConfidenceScore:  score,
+		ParentId:         parent,
+		ModificationType: r.ModificationType,
+		CreatedAt:        timestamppb.New(r.CreatedAt.UTC()),
+	}
+}
+
+// SubtitleRecordFromProto converts a protobuf record to internal struct.
+func SubtitleRecordFromProto(pb *databasepb.SubtitleRecord) *SubtitleRecord {
+	if pb == nil {
+		return nil
+	}
+	rec := &SubtitleRecord{
+		ID:               pb.Id,
+		File:             pb.File,
+		VideoFile:        pb.VideoFile,
+		Release:          pb.Release,
+		Language:         pb.Language,
+		Service:          pb.Service,
+		Embedded:         pb.Embedded,
+		SourceURL:        pb.SourceUrl,
+		ProviderMetadata: pb.ProviderMetadata,
+		ModificationType: pb.ModificationType,
+	}
+	if pb.ConfidenceScore != nil {
+		v := *pb.ConfidenceScore
+		rec.ConfidenceScore = &v
+	}
+	if pb.ParentId != nil {
+		v := *pb.ParentId
+		rec.ParentID = &v
+	}
+	if pb.CreatedAt != nil {
+		rec.CreatedAt = pb.CreatedAt.AsTime()
+	} else {
+		rec.CreatedAt = time.Time{}
+	}
+	return rec
+}
+
+// ToProto converts a DownloadRecord to its protobuf representation.
+func (r *DownloadRecord) ToProto() *databasepb.DownloadRecord {
+	if r == nil {
+		return nil
+	}
+	var score *float64
+	if r.MatchScore != nil {
+		v := *r.MatchScore
+		score = &v
+	}
+	var rt *int32
+	if r.ResponseTimeMs != nil {
+		v := int32(*r.ResponseTimeMs)
+		rt = &v
+	}
+	return &databasepb.DownloadRecord{
+		Id:               r.ID,
+		File:             r.File,
+		VideoFile:        r.VideoFile,
+		Provider:         r.Provider,
+		Language:         r.Language,
+		SearchQuery:      r.SearchQuery,
+		MatchScore:       score,
+		DownloadAttempts: int32(r.DownloadAttempts),
+		ErrorMessage:     r.ErrorMessage,
+		ResponseTimeMs:   rt,
+		CreatedAt:        timestamppb.New(r.CreatedAt.UTC()),
+	}
+}
+
+// DownloadRecordFromProto converts protobuf to internal struct.
+func DownloadRecordFromProto(pb *databasepb.DownloadRecord) *DownloadRecord {
+	if pb == nil {
+		return nil
+	}
+	rec := &DownloadRecord{
+		ID:               pb.Id,
+		File:             pb.File,
+		VideoFile:        pb.VideoFile,
+		Provider:         pb.Provider,
+		Language:         pb.Language,
+		SearchQuery:      pb.SearchQuery,
+		DownloadAttempts: int(pb.DownloadAttempts),
+		ErrorMessage:     pb.ErrorMessage,
+	}
+	if pb.MatchScore != nil {
+		v := *pb.MatchScore
+		rec.MatchScore = &v
+	}
+	if pb.ResponseTimeMs != nil {
+		v := int(*pb.ResponseTimeMs)
+		rec.ResponseTimeMs = &v
+	}
+	if pb.CreatedAt != nil {
+		rec.CreatedAt = pb.CreatedAt.AsTime()
+	}
+	return rec
+}

--- a/pkg/database/pb_conversions_test.go
+++ b/pkg/database/pb_conversions_test.go
@@ -1,0 +1,67 @@
+// file: pkg/database/pb_conversions_test.go
+// version: 1.0.0
+// guid: 126b63da-4b50-4d5d-8299-1e4aec6ed6dd
+
+package database
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSubtitleRecordConversions(t *testing.T) {
+	now := time.Now().UTC()
+	score := 0.8
+	parent := "abc"
+	rec := &SubtitleRecord{
+		ID:               "1",
+		File:             "a.srt",
+		VideoFile:        "a.mkv",
+		Release:          "rel",
+		Language:         "en",
+		Service:          "svc",
+		Embedded:         true,
+		SourceURL:        "url",
+		ProviderMetadata: "meta",
+		ConfidenceScore:  &score,
+		ParentID:         &parent,
+		ModificationType: "sync",
+		CreatedAt:        now,
+	}
+	pb := rec.ToProto()
+	if pb.Id != rec.ID || pb.File != rec.File || pb.VideoFile != rec.VideoFile {
+		t.Fatalf("basic fields mismatch")
+	}
+	back := SubtitleRecordFromProto(pb)
+	if !reflect.DeepEqual(rec, back) {
+		t.Errorf("round trip mismatch: %#v != %#v", rec, back)
+	}
+}
+
+func TestDownloadRecordConversions(t *testing.T) {
+	now := time.Now().UTC()
+	score := 0.5
+	rt := 120
+	rec := &DownloadRecord{
+		ID:               "2",
+		File:             "b.srt",
+		VideoFile:        "b.mkv",
+		Provider:         "p",
+		Language:         "fr",
+		SearchQuery:      "query",
+		MatchScore:       &score,
+		DownloadAttempts: 3,
+		ErrorMessage:     "",
+		ResponseTimeMs:   &rt,
+		CreatedAt:        now,
+	}
+	pb := rec.ToProto()
+	if pb.Id != rec.ID || pb.Provider != rec.Provider {
+		t.Fatalf("basic fields mismatch")
+	}
+	back := DownloadRecordFromProto(pb)
+	if !reflect.DeepEqual(rec, back) {
+		t.Errorf("round trip mismatch")
+	}
+}

--- a/pkg/databasepb/databasepb.go
+++ b/pkg/databasepb/databasepb.go
@@ -1,0 +1,39 @@
+// file: pkg/databasepb/databasepb.go
+// version: 1.0.0
+// guid: b2ed7ce4-1a47-4da1-bbde-63d964be4896
+
+package databasepb
+
+import "google.golang.org/protobuf/types/known/timestamppb"
+
+// SubtitleRecord mirrors proto message for storing subtitle history.
+type SubtitleRecord struct {
+	Id               string
+	File             string
+	VideoFile        string
+	Release          string
+	Language         string
+	Service          string
+	Embedded         bool
+	SourceUrl        string
+	ProviderMetadata string
+	ConfidenceScore  *float64
+	ParentId         *string
+	ModificationType string
+	CreatedAt        *timestamppb.Timestamp
+}
+
+// DownloadRecord mirrors proto message for subtitle downloads.
+type DownloadRecord struct {
+	Id               string
+	File             string
+	VideoFile        string
+	Provider         string
+	Language         string
+	SearchQuery      string
+	MatchScore       *float64
+	DownloadAttempts int32
+	ErrorMessage     string
+	ResponseTimeMs   *int32
+	CreatedAt        *timestamppb.Timestamp
+}

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -1,0 +1,43 @@
+// file: proto/database.proto
+// version: 1.0.0
+// guid: d2b5a1f0-e01a-4f79-9a50-df50aa774617
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/jdfalk/subtitle-manager/pkg/databasepb;databasepb";
+option features.(pb.go).api_level = API_HYBRID;
+
+message SubtitleRecord {
+  string id = 1;
+  string file = 2;
+  string video_file = 3;
+  string release = 4;
+  string language = 5;
+  string service = 6;
+  bool embedded = 7;
+  string source_url = 8;
+  string provider_metadata = 9;
+  optional double confidence_score = 10;
+  optional string parent_id = 11;
+  string modification_type = 12;
+  google.protobuf.Timestamp created_at = 13;
+}
+
+message DownloadRecord {
+  string id = 1;
+  string file = 2;
+  string video_file = 3;
+  string provider = 4;
+  string language = 5;
+  string search_query = 6;
+  optional double match_score = 7;
+  int32 download_attempts = 8;
+  string error_message = 9;
+  optional int32 response_time_ms = 10;
+  google.protobuf.Timestamp created_at = 11;
+}


### PR DESCRIPTION
## Summary
- define `database.proto` with messages for subtitle and download records
- add placeholder generated structs and conversion helpers
- document the new proto spec
- track migration with an issue update
- add localized tests for proto conversions

## Testing
- `go test ./pkg/database`
- `go test ./...` *(fails: gcommon protobuf build issues)*

------
https://chatgpt.com/codex/tasks/task_e_68805302b8a08321973f5f7a9d13bfc3