### PR TITLE
Adopt gcommon QueueMessage proto

### DIFF
--- a/.github/doc-updates/4970a0fd-13b5-4e1d-b3e7-1c9653257fee.json
+++ b/.github/doc-updates/4970a0fd-13b5-4e1d-b3e7-1c9653257fee.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Adopted gcommon queue proto for internal queue",
+  "guid": "4970a0fd-13b5-4e1d-b3e7-1c9653257fee",
+  "created_at": "2025-07-23T03:24:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/73939f4e-8204-4ac7-b729-8b212b335d34.json
+++ b/.github/doc-updates/73939f4e-8204-4ac7-b729-8b212b335d34.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Centralized queue messages now use the gcommon QueueMessage proto.",
+  "guid": "73939f4e-8204-4ac7-b729-8b212b335d34",
+  "created_at": "2025-07-23T03:24:53Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bcee64c7-e6b1-43fe-8892-38d9ac40c53c.json
+++ b/.github/doc-updates/bcee64c7-e6b1-43fe-8892-38d9ac40c53c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "✅ Adopted gcommon QueueMessage for internal queue",
+  "guid": "bcee64c7-e6b1-43fe-8892-38d9ac40c53c",
+  "created_at": "2025-07-23T03:24:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/e6037b54-ec36-4b4d-a06e-e40f4371ebff.json
+++ b/.github/issue-updates/e6037b54-ec36-4b4d-a06e-e40f4371ebff.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Adopt gcommon QueueMessage",
+  "body": "Refactor internal queue to use gcommon queue proto",
+  "labels": ["refactor", "codex"],
+  "guid": "e6037b54-ec36-4b4d-a06e-e40f4371ebff",
+  "legacy_guid": "create-adopt-gcommon-queuemessage-2025-07-23"
+}

--- a/pkg/queue/message.go
+++ b/pkg/queue/message.go
@@ -1,12 +1,11 @@
 // file: pkg/queue/message.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f76c9a4-8f24-4d5f-9aaa-97db45af4c61
 package queue
 
-import "google.golang.org/protobuf/types/known/anypb"
+import queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
 
-// QueueMessage mirrors the gcommon queue message for basic use.
-type QueueMessage struct {
-	Id   string
-	Body *anypb.Any
-}
+// QueueMessage is an alias of the gcommon queue message type.
+// This allows the internal queue package to use the centralized
+// protobuf definition without rewriting existing code.
+type QueueMessage = queuepb.QueueMessage


### PR DESCRIPTION
## Summary

Migrates the internal queue message type to use the centralized `gcommon` protobuf.  Documentation updates track the change and an issue file is created for continued migration work.

## Issues Addressed

### refactor(queue): adopt gcommon queue proto

**Description:** Alias the queue message type to `gcommon.QueueMessage` to continue the protobuf migration.

**Files Modified:**
- [`pkg/queue/message.go`](./pkg/queue/message.go) – alias to centralized proto
- [`.github/doc-updates/4970a0fd-13b5-4e1d-b3e7-1c9653257fee.json`](./.github/doc-updates/4970a0fd-13b5-4e1d-b3e7-1c9653257fee.json) – changelog entry
- [`.github/doc-updates/73939f4e-8204-4ac7-b729-8b212b335d34.json`](./.github/doc-updates/73939f4e-8204-4ac7-b729-8b212b335d34.json) – README note
- [`.github/doc-updates/bcee64c7-e6b1-43fe-8892-38d9ac40c53c.json`](./.github/doc-updates/bcee64c7-e6b1-43fe-8892-38d9ac40c53c.json) – TODO update
- [`.github/issue-updates/e6037b54-ec36-4b4d-a06e-e40f4371ebff.json`](./.github/issue-updates/e6037b54-ec36-4b4d-a06e-e40f4371ebff.json) – issue file

## Testing

- `go test ./...` *(fails: undefined types in gcommon proto)*

------
https://chatgpt.com/codex/tasks/task_e_6880531de5748321844c59d32f2c31b4