### PR TITLE
feat(health): add grpc health service

### DIFF
--- a/.github/doc-updates/1ac5214b-582b-4a77-8a50-4bc03fc2fc41.json
+++ b/.github/doc-updates/1ac5214b-582b-4a77-8a50-4bc03fc2fc41.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "- Expose gRPC health service using gcommon protobufs",
+  "guid": "1ac5214b-582b-4a77-8a50-4bc03fc2fc41",
+  "created_at": "2025-07-23T03:44:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/eb681924-50cd-410b-9fc7-d9518ac263af.json
+++ b/.github/doc-updates/eb681924-50cd-410b-9fc7-d9518ac263af.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Added gRPC health service using gcommon protobufs",
+  "guid": "eb681924-50cd-410b-9fc7-d9518ac263af",
+  "created_at": "2025-07-23T03:44:43Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f6cf58d2-1e82-48d5-87b8-07408a8f2d81.json
+++ b/.github/doc-updates/f6cf58d2-1e82-48d5-87b8-07408a8f2d81.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add gRPC health service using gcommon protobufs",
+  "guid": "f6cf58d2-1e82-48d5-87b8-07408a8f2d81",
+  "created_at": "2025-07-23T03:44:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/45e66235-28cf-45b0-b7e2-b55bf1dc845b.json
+++ b/.github/issue-updates/45e66235-28cf-45b0-b7e2-b55bf1dc845b.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add gRPC health service",
+  "body": "Expose gRPC health service using gcommon protobufs",
+  "labels": ["codex", "enhancement"],
+  "guid": "45e66235-28cf-45b0-b7e2-b55bf1dc845b",
+  "legacy_guid": "create-add-grpc-health-service-2025-07-23"
+}

--- a/cmd/grpcserver/main.go
+++ b/cmd/grpcserver/main.go
@@ -6,9 +6,11 @@ import (
 
 	"google.golang.org/grpc"
 
+	ghealth "github.com/jdfalk/gcommon/pkg/health"
 	"github.com/jdfalk/subtitle-manager/pkg/grpcserver"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	pb "github.com/jdfalk/subtitle-manager/pkg/translatorpb"
+	"github.com/jdfalk/subtitle-manager/pkg/webserver"
 )
 
 func main() {
@@ -28,6 +30,13 @@ func main() {
 	)
 
 	pb.RegisterTranslatorServer(s, server)
+
+	if err := webserver.InitializeHealth(""); err == nil {
+		if provider := webserver.GetHealthProvider(); provider != nil {
+			ghealth.NewGRPCServer(provider).Register(s)
+		}
+	}
+
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		logging.GetLogger("grpc-server").Fatalf("Failed to listen: %v", err)

--- a/cmd/grpcserver_cmd.go
+++ b/cmd/grpcserver_cmd.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"net"
 
+	ghealth "github.com/jdfalk/gcommon/pkg/health"
 	"github.com/jdfalk/subtitle-manager/pkg/grpcserver"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	pb "github.com/jdfalk/subtitle-manager/pkg/translatorpb"
+	"github.com/jdfalk/subtitle-manager/pkg/webserver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
@@ -29,6 +31,12 @@ var grpcServerCmd = &cobra.Command{
 		)
 
 		pb.RegisterTranslatorServer(s, server)
+
+		if err := webserver.InitializeHealth(""); err == nil {
+			if provider := webserver.GetHealthProvider(); provider != nil {
+				ghealth.NewGRPCServer(provider).Register(s)
+			}
+		}
 		lis, err := net.Listen("tcp", grpcAddr)
 		if err != nil {
 			return err

--- a/pkg/webserver/health.go
+++ b/pkg/webserver/health.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/health.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9e8d7c6b-5a4f-3d2c-1b0a-9f8e7d6c5b4a
 
 package webserver
@@ -16,8 +16,8 @@ import (
 
 var HealthProvider ghealth.Provider
 
-// initializeHealth sets up the global health provider with built-in checks.
-func initializeHealth(endpoint string) error {
+// InitializeHealth sets up the global health provider with built-in checks.
+func InitializeHealth(endpoint string) error {
 	if HealthProvider != nil {
 		return nil
 	}
@@ -107,4 +107,9 @@ func cacheHealthCheck(ctx context.Context) (ghealth.Result, error) {
 		res.WithDetails(map[string]any{"stats": stats})
 	}
 	return res, nil
+}
+
+// GetHealthProvider returns the global health provider instance.
+func GetHealthProvider() ghealth.Provider {
+	return HealthProvider
 }

--- a/pkg/webserver/health_test.go
+++ b/pkg/webserver/health_test.go
@@ -1,0 +1,50 @@
+// file: pkg/webserver/health_test.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7a8b-9c0d-ef1234567890
+
+package webserver
+
+import (
+	"context"
+	"testing"
+
+	ghealth "github.com/jdfalk/gcommon/pkg/health"
+	"github.com/jdfalk/subtitle-manager/pkg/cache"
+)
+
+// TestInitializeHealth verifies the health provider initializes correctly.
+func TestInitializeHealth(t *testing.T) {
+	manager, err := cache.NewManager(cache.DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
+	defer manager.Close()
+	cacheManager = manager
+
+	if err := InitializeHealth("/health-test"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	if HealthProvider == nil {
+		t.Fatal("provider not set")
+	}
+	res, err := HealthProvider.CheckAll(context.Background())
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if res.Status() != ghealth.StatusUp {
+		t.Errorf("expected status up, got %v", res.Status())
+	}
+}
+
+// TestGRPCHealthServerCheck ensures the gRPC health server responds.
+func TestGRPCHealthServerCheck(t *testing.T) {
+	manager, _ := cache.NewManager(cache.DefaultConfig())
+	defer manager.Close()
+	cacheManager = manager
+	_ = InitializeHealth("")
+
+	srv := ghealth.NewGRPCServer(GetHealthProvider())
+	if srv == nil {
+		t.Fatal("grpc server nil")
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -316,7 +316,7 @@ func StartServer(addr string) error {
 		logger.Warnf("failed to initialize metrics: %v", err)
 	}
 
-	if err := initializeHealth(prefix + "/health"); err != nil {
+	if err := InitializeHealth(prefix + "/health"); err != nil {
 		logger.Warnf("failed to initialize health checks: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Adds gRPC health service integration using the centralized gcommon protobufs. A new `InitializeHealth` helper exposes the provider for both HTTP and gRPC servers.

## Issues Addressed

### feat(health): add grpc health service

**Description:** Implemented health provider export and registered the gcommon gRPC health server in translation server binaries. Added tests verifying provider initialization.

**Files Modified:**
- [`cmd/grpcserver/main.go`](./cmd/grpcserver/main.go) - register gRPC health service | [[diff]](../../pull/PR_NUMBER/files#diff-b4cc51) [[repo]](../../blob/main/cmd/grpcserver/main.go)
- [`cmd/grpcserver_cmd.go`](./cmd/grpcserver_cmd.go) - register health service in CLI server | [[diff]](../../pull/PR_NUMBER/files#diff-d8632c) [[repo]](../../blob/main/cmd/grpcserver_cmd.go)
- [`pkg/webserver/health.go`](./pkg/webserver/health.go) - export provider functions | [[diff]](../../pull/PR_NUMBER/files#diff-bc48c8) [[repo]](../../blob/main/pkg/webserver/health.go)
- [`pkg/webserver/server.go`](./pkg/webserver/server.go) - invoke exported initializer | [[diff]](../../pull/PR_NUMBER/files#diff-6bfef0) [[repo]](../../blob/main/pkg/webserver/server.go)
- [`pkg/webserver/health_test.go`](./pkg/webserver/health_test.go) - new tests for health initialization | [[diff]](../../pull/PR_NUMBER/files#diff-f2c116) [[repo]](../../blob/main/pkg/webserver/health_test.go)
- Documentation update JSON files created for README, CHANGELOG and TODO | [[diff]](../../pull/PR_NUMBER/files#diff-f01668)

## Testing

- `go test ./pkg/webserver -run TestInitializeHealth -count=1` *(failed: missing configpb)*

------
https://chatgpt.com/codex/tasks/task_e_6880532593d48321aaa7b37538f82dab