### PR TITLE
Add gcommon logrus provider

### DIFF
--- a/.github/doc-updates/1a371050-39ba-4ba9-808a-e9b5185f97e7.json
+++ b/.github/doc-updates/1a371050-39ba-4ba9-808a-e9b5185f97e7.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-complete",
+  "content": "Add tests for structured logging",
+  "guid": "1a371050-39ba-4ba9-808a-e9b5185f97e7",
+  "created_at": "2025-07-23T03:42:14Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7929ec4e-9be7-4d9d-8e62-405c2b0f6a07.json
+++ b/.github/doc-updates/7929ec4e-9be7-4d9d-8e62-405c2b0f6a07.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### gcommon Logging Provider\\n\\nImplemented a logrus provider compatible with the centralized gcommon logging proto.",
+  "guid": "7929ec4e-9be7-4d9d-8e62-405c2b0f6a07",
+  "created_at": "2025-07-23T03:41:59Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e367c3e5-f1de-4981-82a8-553e8ef4f87e.json
+++ b/.github/doc-updates/e367c3e5-f1de-4981-82a8-553e8ef4f87e.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added gcommon logrus provider for structured logging",
+  "guid": "e367c3e5-f1de-4981-82a8-553e8ef4f87e",
+  "created_at": "2025-07-23T03:34:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b05bffdc-3c87-4a51-a0a1-22cbf5a598e5.json
+++ b/.github/issue-updates/b05bffdc-3c87-4a51-a0a1-22cbf5a598e5.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement gcommon logrus provider",
+  "body": "Add a logrus provider conforming to gcommon logging interfaces",
+  "labels": ["enhancement"],
+  "guid": "b05bffdc-3c87-4a51-a0a1-22cbf5a598e5",
+  "legacy_guid": "create-implement-gcommon-logrus-provider-2025-07-23"
+}

--- a/pkg/gcommonlog/logrus_provider.go
+++ b/pkg/gcommonlog/logrus_provider.go
@@ -1,0 +1,117 @@
+// file: pkg/gcommonlog/logrus_provider.go
+// version: 1.0.0
+// guid: a1e4bca3-27a2-4e4a-9d4c-1c2f3b4d5e6f
+
+package gcommonlog
+
+import (
+	"context"
+	"io"
+
+	gclog "github.com/jdfalk/gcommon/pkg/log"
+	"github.com/sirupsen/logrus"
+)
+
+type logrusProvider struct {
+	entry *logrus.Entry
+}
+
+// NewLogrusProvider registers a logrus based logging provider compatible with gcommon.
+func NewLogrusProvider(cfg gclog.Config) (gclog.Provider, error) {
+	l := logrus.New()
+	lvl, err := logrus.ParseLevel(cfg.Level)
+	if err != nil {
+		lvl = logrus.InfoLevel
+	}
+	l.SetLevel(lvl)
+	return &logrusProvider{entry: logrus.NewEntry(l)}, nil
+}
+
+func (p *logrusProvider) Name() string               { return "logrus" }
+func (p *logrusProvider) Close() error               { return nil }
+func (p *logrusProvider) Sync() error                { return nil }
+func (p *logrusProvider) SetOutput(w io.Writer)      { p.entry.Logger.SetOutput(w) }
+func (p *logrusProvider) AddHook(h gclog.Hook) error { return nil }
+
+func (p *logrusProvider) log(level logrus.Level, msg string, fields []gclog.Field) {
+	if !p.entry.Logger.IsLevelEnabled(level) {
+		return
+	}
+	p.entry.WithFields(convert(fields)).Log(level, msg)
+}
+
+func (p *logrusProvider) Debug(msg string, f ...gclog.Field) { p.log(logrus.DebugLevel, msg, f) }
+func (p *logrusProvider) DebugContext(ctx context.Context, msg string, f ...gclog.Field) {
+	p.WithContext(ctx).Debug(msg, f...)
+}
+func (p *logrusProvider) Info(msg string, f ...gclog.Field) { p.log(logrus.InfoLevel, msg, f) }
+func (p *logrusProvider) InfoContext(ctx context.Context, msg string, f ...gclog.Field) {
+	p.WithContext(ctx).Info(msg, f...)
+}
+func (p *logrusProvider) Warn(msg string, f ...gclog.Field) { p.log(logrus.WarnLevel, msg, f) }
+func (p *logrusProvider) WarnContext(ctx context.Context, msg string, f ...gclog.Field) {
+	p.WithContext(ctx).Warn(msg, f...)
+}
+func (p *logrusProvider) Error(msg string, f ...gclog.Field) { p.log(logrus.ErrorLevel, msg, f) }
+func (p *logrusProvider) ErrorContext(ctx context.Context, msg string, f ...gclog.Field) {
+	p.WithContext(ctx).Error(msg, f...)
+}
+func (p *logrusProvider) Fatal(msg string, f ...gclog.Field) { p.log(logrus.FatalLevel, msg, f) }
+func (p *logrusProvider) FatalContext(ctx context.Context, msg string, f ...gclog.Field) {
+	p.WithContext(ctx).Fatal(msg, f...)
+}
+
+func (p *logrusProvider) With(fields ...gclog.Field) gclog.Logger {
+	return &logrusProvider{entry: p.entry.WithFields(convert(fields))}
+}
+func (p *logrusProvider) WithContext(ctx context.Context) gclog.Logger {
+	return &logrusProvider{entry: p.entry.WithContext(ctx)}
+}
+func (p *logrusProvider) SetLevel(l gclog.Level) { p.entry.Logger.SetLevel(toLogrusLevel(l)) }
+func (p *logrusProvider) GetLevel() gclog.Level  { return fromLogrusLevel(p.entry.Logger.GetLevel()) }
+
+func convert(fields []gclog.Field) logrus.Fields {
+	out := make(logrus.Fields, len(fields))
+	for _, f := range fields {
+		out[f.Key] = f.Value
+	}
+	return out
+}
+
+func toLogrusLevel(l gclog.Level) logrus.Level {
+	switch l {
+	case gclog.DebugLevel:
+		return logrus.DebugLevel
+	case gclog.InfoLevel:
+		return logrus.InfoLevel
+	case gclog.WarnLevel:
+		return logrus.WarnLevel
+	case gclog.ErrorLevel:
+		return logrus.ErrorLevel
+	case gclog.FatalLevel:
+		return logrus.FatalLevel
+	default:
+		return logrus.InfoLevel
+	}
+}
+
+func fromLogrusLevel(l logrus.Level) gclog.Level {
+	switch l {
+	case logrus.DebugLevel:
+		return gclog.DebugLevel
+	case logrus.InfoLevel:
+		return gclog.InfoLevel
+	case logrus.WarnLevel:
+		return gclog.WarnLevel
+	case logrus.ErrorLevel:
+		return gclog.ErrorLevel
+	case logrus.FatalLevel, logrus.PanicLevel:
+		return gclog.FatalLevel
+	default:
+		return gclog.InfoLevel
+	}
+}
+
+func init() {
+	gclog.RegisterProvider("logrus", NewLogrusProvider)
+}

--- a/pkg/gcommonlog/logrus_provider_test.go
+++ b/pkg/gcommonlog/logrus_provider_test.go
@@ -1,0 +1,46 @@
+// file: pkg/gcommonlog/logrus_provider_test.go
+// version: 1.0.0
+// guid: 3456b7c8-9d0e-4f12-8b34-5a6c7d8e9f01
+package gcommonlog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gclog "github.com/jdfalk/gcommon/pkg/log"
+)
+
+// TestLogrusProvider verifies that the provider writes log messages and fields.
+func TestLogrusProvider(t *testing.T) {
+	buf := &bytes.Buffer{}
+	p, err := gclog.NewProvider(gclog.Config{Provider: "logrus", Level: "debug"})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	p.SetOutput(buf)
+	p.Info("hello", gclog.Field{Key: "k", Value: "v"})
+
+	out := buf.String()
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "k=v") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+// TestWithField ensures With adds structured fields.
+func TestWithField(t *testing.T) {
+	buf := &bytes.Buffer{}
+	p, err := gclog.NewProvider(gclog.Config{Provider: "logrus", Level: "info"})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	p.SetOutput(buf)
+
+	logger := p.With(gclog.Field{Key: "module", Value: "test"})
+	logger.Info("msg")
+
+	out := buf.String()
+	if !strings.Contains(out, "module=test") {
+		t.Errorf("expected field not found: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new logging provider that bridges logrus with gcommon's logging interface. Documentation is updated via the doc update system and a tracking issue is created.

## Testing

- `go test ./pkg/gcommonlog -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6880532bb03c8321af1c5d29687a244d