### PR TITLE
fix(setup): handle missing protocol for Bazarr URL

### DIFF
--- a/webui/src/Setup.jsx
+++ b/webui/src/Setup.jsx
@@ -1,3 +1,7 @@
+// file: webui/src/Setup.jsx
+// version: 1.1.0
+// guid: fbd4687e-dff3-4715-8aad-504665006080
+
 import {
   CheckCircleOutlined,
   CloudDownloadOutlined,
@@ -38,6 +42,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { useState } from 'react';
 import { apiService } from './services/api.js';
+import { normalizeUrl } from './utils/url.js';
 
 // Material Design 3 theme
 const theme = createTheme({
@@ -132,8 +137,18 @@ export default function Setup() {
   const [loading, setLoading] = useState('');
 
   const importBazarr = async () => {
-    if (!bazarrURL || !bazarrAPIKey) {
+    const url = bazarrURL.trim();
+    if (!url || !bazarrAPIKey) {
       setBazarrError('Please enter both URL and API key');
+      return;
+    }
+
+    let normalized;
+    try {
+      normalized = normalizeUrl(url);
+      new URL(normalized);
+    } catch {
+      setBazarrError('Please enter a valid URL');
       return;
     }
 
@@ -142,7 +157,7 @@ export default function Setup() {
 
     try {
       const response = await apiService.setup.importBazarr(
-        bazarrURL,
+        normalized,
         bazarrAPIKey
       );
 

--- a/webui/src/utils/__tests__/url.test.js
+++ b/webui/src/utils/__tests__/url.test.js
@@ -1,0 +1,23 @@
+// file: webui/src/utils/__tests__/url.test.js
+// version: 1.0.0
+// guid: b10dabf3-a0db-474f-88f5-86cc4c8915f1
+
+import { describe, expect, test } from 'vitest';
+import { normalizeUrl } from '../url.js';
+
+describe('normalizeUrl', () => {
+  test('adds http to URLs without scheme', () => {
+    const result = normalizeUrl('localhost:6767');
+    expect(result).toBe('http://localhost:6767');
+  });
+
+  test('keeps existing http scheme', () => {
+    const result = normalizeUrl('http://example.com');
+    expect(result).toBe('http://example.com');
+  });
+
+  test('keeps existing https scheme', () => {
+    const result = normalizeUrl('https://example.com');
+    expect(result).toBe('https://example.com');
+  });
+});

--- a/webui/src/utils/url.js
+++ b/webui/src/utils/url.js
@@ -1,0 +1,14 @@
+// file: webui/src/utils/url.js
+// version: 1.0.0
+// guid: 148d07ae-f97c-4342-bb06-dfb662b10111
+
+export function normalizeUrl(rawUrl) {
+  const url = rawUrl.trim();
+  if (!url) {
+    return '';
+  }
+  if (!/^https?:\/\//i.test(url)) {
+    return `http://${url}`;
+  }
+  return url;
+}


### PR DESCRIPTION
## Summary
- allow Bazarr URL input without http/https by normalizing to include scheme

## Issues Addressed

### fix(setup): handle missing protocol for Bazarr URL

**Description:** Normalize user-provided Bazarr URLs to include a default http scheme and validate the result during setup.

**Files Modified:**

- [`webui/src/Setup.jsx`](./webui/src/Setup.jsx) - Normalize and validate input URL | [[diff]](../../pull/PR_NUMBER/files#diff-setup) [[repo]](../../blob/main/webui/src/Setup.jsx)
- [`webui/src/utils/url.js`](./webui/src/utils/url.js) - Add helper to ensure scheme | [[diff]](../../pull/PR_NUMBER/files#diff-urljs) [[repo]](../../blob/main/webui/src/utils/url.js)
- [`webui/src/utils/__tests__/url.test.js`](./webui/src/utils/__tests__/url.test.js) - Add coverage for URL normalization | [[diff]](../../pull/PR_NUMBER/files#diff-urltest) [[repo]](../../blob/main/webui/src/utils/__tests__/url.test.js)

## Testing
- `npm test` (7 failed, 14 passed)
- `npm test src/utils/__tests__/url.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688f658e5ef08321953f2262eed95a21