### PR TITLE
fix: exclude /media root from library paths

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -1,4 +1,6 @@
 // file: pkg/security/security.go
+// version: 1.1.0
+// guid: efe90a08-389d-4157-a46e-8a57bfc1181a
 package security
 
 import (
@@ -66,8 +68,19 @@ func GetAllowedBaseDirs() []string {
 	if subDir := viper.GetString("subtitle_directory"); subDir != "" {
 		dirs = append(dirs, subDir)
 	}
+
+	if info, err := os.Stat("/media"); err == nil && info.IsDir() {
+		if entries, err := os.ReadDir("/media"); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					dirs = append(dirs, filepath.Join("/media", entry.Name()))
+				}
+			}
+		}
+	}
+
 	commonDirs := []string{
-		"/media", "/mnt/media", "/home/media", "/var/media",
+		"/mnt/media", "/home/media", "/var/media",
 		"/Movies", "/TV", "/Videos",
 	}
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary
- avoid automatically including `/media` in library directories
- cover `/media` exclusion with tests

## Issues Addressed

### fix(security): exclude /media root from library paths

**Description:** Updated directory discovery to enumerate subdirectories under `/media` instead of auto-adding the root and added regression tests.

**Files Modified:**
- `pkg/security/security.go` - list `/media` subdirectories and drop root directory from defaults
- `pkg/security/path_test.go` - add test to ensure `/media` root isn't included while subdirectories remain accessible

## Testing
- `go test ./...` *(fails: no required module provides package github.com/jdfalk/subtitle-manager/pkg/configpb)*


------
https://chatgpt.com/codex/tasks/task_e_688f6772940083219bfefc3b7b90d046