### PR TITLE
chore: migrate jdfalk/ refs to falkcorp/ org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   # Check for commit override flags
   check-overrides:
     name: Check Commit Overrides
-    uses: jdfalk/ghcommon/.github/workflows/commit-override-handler.yml@378e23a96c00d719075732dd2af4de45f7523cbb # v1.10.4
+    uses: falkcorp/github-common/.github/workflows/commit-override-handler.yml@378e23a96c00d719075732dd2af4de45f7523cbb # v1.10.4
 
   # Detect what files changed to optimize workflow execution
   detect-changes:

--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@1a52124c9513b0fd05734602734704d81e2cc7ad
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@1a52124c9513b0fd05734602734704d81e2cc7ad
     with:
       mode: ${{ inputs.mode || 'dry-run' }}
     secrets: inherit

--- a/.github/workflows/sync-receiver.yml
+++ b/.github/workflows/sync-receiver.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/sync-receiver.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/sync-receiver.yml
 
 name: Sync Receiver (DISABLED)
 

--- a/TODO.md
+++ b/TODO.md
@@ -887,7 +887,7 @@ into the binary and served by the `web` command.
 ## GCommon Refactor Plan
 
 This refactor will replace several internal packages with the shared modules
-provided by [gcommon](https://github.com/jdfalk/gcommon). The migration follows
+provided by [gcommon](https://github.com/falkcorp/gcommon). The migration follows
 the hybrid Docker build approach defined in `Dockerfile.hybrid` which installs
 Node.js in the Go builder stage so `go generate` can embed the pre-built React
 UI.
@@ -896,7 +896,7 @@ UI.
 
 #### Phase 1: Dependency Setup
 
-- Add `github.com/jdfalk/gcommon` to `go.mod` and run `go mod tidy`.
+- Add `github.com/falkcorp/gcommon` to `go.mod` and run `go mod tidy`.
 - Vendor the module to ensure consistent builds.
 - Confirm CI passes with the new dependency.
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -18,14 +18,14 @@ plugins:
       - Mgoogle/protobuf/empty.proto=google.golang.org/protobuf/types/known/emptypb
       - Mgoogle/protobuf/any.proto=google.golang.org/protobuf/types/known/anypb
       # gcommon mappings for consistent type usage
-      - Mgcommon/v1/common/user.proto=github.com/jdfalk/gcommon/sdks/go/v1/common
-      - Mgcommon/v1/common/session.proto=github.com/jdfalk/gcommon/sdks/go/v1/common
-      - Mgcommon/v1/common/error.proto=github.com/jdfalk/gcommon/sdks/go/v1/common
-      - Mgcommon/v1/common/metadata.proto=github.com/jdfalk/gcommon/sdks/go/v1/common
-      - Mgcommon/v1/config/config.proto=github.com/jdfalk/gcommon/sdks/go/v1/config
-      - Mgcommon/v1/health/health_check.proto=github.com/jdfalk/gcommon/sdks/go/v1/health
-      - Mgcommon/v1/media/media_file.proto=github.com/jdfalk/gcommon/sdks/go/v1/media
-      - Mgcommon/v1/media/language.proto=github.com/jdfalk/gcommon/sdks/go/v1/media
+      - Mgcommon/v1/common/user.proto=github.com/falkcorp/gcommon/sdks/go/v1/common
+      - Mgcommon/v1/common/session.proto=github.com/falkcorp/gcommon/sdks/go/v1/common
+      - Mgcommon/v1/common/error.proto=github.com/falkcorp/gcommon/sdks/go/v1/common
+      - Mgcommon/v1/common/metadata.proto=github.com/falkcorp/gcommon/sdks/go/v1/common
+      - Mgcommon/v1/config/config.proto=github.com/falkcorp/gcommon/sdks/go/v1/config
+      - Mgcommon/v1/health/health_check.proto=github.com/falkcorp/gcommon/sdks/go/v1/health
+      - Mgcommon/v1/media/media_file.proto=github.com/falkcorp/gcommon/sdks/go/v1/media
+      - Mgcommon/v1/media/language.proto=github.com/falkcorp/gcommon/sdks/go/v1/media
   - remote: buf.build/grpc/go:v1.5.1
     out: pkg
     opt:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/go-connections v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jdfalk/gcommon v1.8.0
+	github.com/falkcorp/gcommon v1.8.0
 	github.com/lib/pq v1.11.1
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/oz/osdb v0.0.0-20221214175751-f169057712ec


### PR DESCRIPTION
## Migrate org references: jdfalk → falkcorp

Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags
from `jdfalk/` to `falkcorp/` as part of the organization migration.

### Changed files:
- `buf.gen.yaml`
- `.github/workflows/sync-receiver.yml`
- `.github/workflows/ci.yml`
- `TODO.md`
- `go.mod`

🤖 Generated by `scripts/org-migration/update-workflow-refs.py`