### PR TITLE
fix(ci): bump Go toolchain to 1.25 to match go.mod

### DIFF
--- a/.github/scripts/detect_languages.py
+++ b/.github/scripts/detect_languages.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # file: .github/scripts/detect_languages.py
-# version: 1.0.0
+# version: 1.0.1
 # guid: 4f6c9d88-2d4b-4a1e-9c61-3e0b2b9a7f11
 """Detect project languages and emit key=value lines for GitHub Actions outputs.
 
@@ -43,9 +43,9 @@ else:
 go_matrix = (
     {
         "include": [
-            {"os": "ubuntu-latest", "go-version": "1.24", "primary": True},
-            {"os": "macos-latest", "go-version": "1.24", "primary": False},
-            {"os": "windows-latest", "go-version": "1.24", "primary": False},
+            {"os": "ubuntu-latest", "go-version": "1.25", "primary": True},
+            {"os": "macos-latest", "go-version": "1.25", "primary": False},
+            {"os": "windows-latest", "go-version": "1.25", "primary": False},
         ]
     }
     if has_go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 1.18.1
+# version: 1.18.2
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
 
 name: Continuous Integration
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
   NODE_VERSION: "22"
   PYTHON_VERSION: "3.13"
   RUST_VERSION: "1.76"
@@ -334,7 +334,7 @@ jobs:
     if: needs.detect-changes.outputs.gofiles == 'true' && needs.check-overrides.outputs.skip-tests != 'true'
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version: ["1.25"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-protobuf.yml
+++ b/.github/workflows/release-protobuf.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-protobuf.yml
-# version: 1.1.0
+# version: 1.1.1
 # guid: 9c2f1b18-7c4e-4c3a-9b54-2b5d9c7e2af1
 
 name: Release Protobuf Assets
@@ -22,7 +22,7 @@ on:
         value: ${{ jobs.generate.outputs.artifacts_available }}
 
 env:
-  GO_VERSION: "1.24.x"
+  GO_VERSION: "1.25.x"
   PYTHON_VERSION: "3.13"
   BUF_VERSION: "1.57.2"
   PROTOC_VERSION: "32.1"

--- a/changelog.d/ci-go-1.25.md
+++ b/changelog.d/ci-go-1.25.md
@@ -1,0 +1,9 @@
+### Fixed
+
+#### Bump CI Go toolchain to 1.25 to match `go.mod`
+
+`go.mod` requires `go 1.25.0`, but CI still pinned Go 1.24, so every Go and
+Docker build failed with `go.mod requires go >= 1.25.0 (running go 1.24.13)`.
+Bumped the Go version to 1.25 in `ci.yml` (`GO_VERSION` and the test matrix),
+`release-protobuf.yml`, and the release build matrix emitted by
+`.github/scripts/detect_languages.py`.


### PR DESCRIPTION
## Summary

`go.mod` requires `go 1.25.0`, but CI still pinned Go **1.24**, so every Go and Docker build failed:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This is the single biggest, lowest-risk win — it unblocks the Go builds (all OS) and, transitively, the Docker builds (which depend on the Go build).

## Changes

Bumped Go `1.24` → `1.25` at every live location:

- `.github/workflows/ci.yml` — `GO_VERSION` env + the test job matrix
- `.github/workflows/release-protobuf.yml` — `GO_VERSION`
- `.github/scripts/detect_languages.py` — the release build matrix (emitted as `go-matrix` JSON and consumed by `release-go.yml` via `fromJSON`; this was the real source of the "Build Go (1.24 on …)" release failures, not the workflow YAML)

Verified locally: `go build ./...` and `go vet ./...` pass clean on Go 1.26.5, and the detect script now emits a `1.25` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)