### PR TITLE
chore(standards): sync instruction/config files from ghcommon

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report to help us improve
-title: "bug: [Brief description]"
-labels: ["bug", "needs-triage"]
+title: 'bug: [Brief description]'
+labels: ['bug', 'needs-triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for this project
-title: "feat: [Brief description]"
-labels: ["enhancement", "needs-triage"]
+title: 'feat: [Brief description]'
+labels: ['enhancement', 'needs-triage']
 body:
   - type: markdown
     attributes:

--- a/.github/instructions/commit-messages.instructions.md
+++ b/.github/instructions/commit-messages.instructions.md
@@ -1,0 +1,274 @@
+<!-- file: .github/instructions/commit-messages.instructions.md -->
+<!-- version: 2.0.1 -->
+<!-- guid: msg12345-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**"
+description: |
+  Conventional commit message format rules for all Copilot/AI agents and VS Code Copilot customization. These rules apply to all git commits and follow the project's commit message standards. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Conventional Commit Message Instructions
+
+These instructions are the canonical source for all conventional commit message
+formatting rules in this repository. They are used by GitHub Copilot for commit
+message generation and follow our established standards.
+
+- Follow the [general coding instructions](general-coding.instructions.md) for
+  basic file formatting rules.
+- All commit formatting and workflow rules are found in
+  `.github/instructions/*.instructions.md` files.
+- Document all changes comprehensively in commit messages.
+- For agent/AI-specific instructions, see [AGENTS.md](../AGENTS.md) and related
+  files.
+
+For more details and the full system, see
+[copilot-instructions.md](../copilot-instructions.md).
+
+## Template Structure
+
+**CRITICAL REQUIREMENT**: Every commit MUST have a conventional commit header in the format `type(scope): description`. This is mandatory and non-negotiable.
+
+**IMPORTANT**: Only include issue numbers if you are working on a specific GitHub issue. Do not use placeholder numbers like #123.
+
+### Standard Format
+
+For single logical changes:
+
+```text
+type(scope): description
+
+Brief description of what was changed and why.
+
+Files changed:
+- path/to/file1.ext - Description of changes
+- path/to/file2.ext - Description of changes
+```
+
+### Multi-Change Format
+
+When making multiple distinct changes that each deserve their own conventional commit header:
+
+```text
+feat(scope): primary description of the main change
+
+Brief description of the overall changes and their purpose.
+
+Changes Made:
+
+feat(frontend): description of frontend changes
+- path/to/frontend1.ext - Description of changes
+- path/to/frontend2.ext - Description of changes
+
+fix(backend): description of backend changes
+- path/to/backend1.ext - Description of changes
+- path/to/backend2.ext - Description of changes
+
+docs(readme): description of documentation changes
+- path/to/docs1.ext - Description of changes
+```
+
+### With Issue References
+
+Only when working on specific GitHub issues:
+
+```text
+type(scope): description (#actual-issue-number)
+
+Brief description of what was changed and why.
+
+Files changed:
+- path/to/file1.ext - Description of changes
+- path/to/file2.ext - Description of changes
+
+Closes #actual-issue-number
+```
+
+## Guidelines
+
+### Commit Header (MANDATORY)
+
+- **CRITICAL**: Every commit MUST use conventional commit format: `type(scope): description`
+- Include issue number only if working on a specific issue: `type(scope): description (#issue-number)`
+- Keep the header under 72 characters
+- Use present tense ("add feature" not "added feature")
+- Be specific and descriptive
+
+### Body Structure
+
+- **Single Change**: Use "Files changed:" section for one logical change
+- **Multiple Distinct Changes**: Use "Changes Made:" with subsections, each having their own conventional commit header
+- **Multiple Issues**: Use "Issues Addressed:" with subsections grouped by issue
+- Group files logically by the type of change they represent
+- Include brief context about the overall changes
+
+### Conventional Commit Types
+
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, no logic changes)
+- `refactor`: Code refactoring (no functional changes)
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks, build changes, etc.
+- `perf`: Performance improvements
+- `ci`: CI/CD changes
+- `build`: Build system changes
+- `revert`: Reverting previous commits
+
+### File Documentation
+
+- **Always list every modified file**
+- Explain what changed in each file, not just what the file does
+- Use relative paths from repository root
+- Be specific about the nature of changes
+- Group files by functional area when dealing with multi-area changes
+
+### Issue References
+
+- Include issue numbers in the header: `(#123)`
+- Use closing keywords in footer: `Closes #123, #456`
+- For related issues: `Related to #999`
+- Omit issue references if not working on a specific issue
+
+## Examples
+
+### Multi-Change Commit Example
+
+```text
+feat(system): implement user dashboard with backend API
+
+Added complete user dashboard functionality including frontend components,
+backend API endpoints, and updated documentation.
+
+Changes Made:
+
+feat(frontend): add user dashboard components
+- [src/components/Dashboard.jsx](src/components/Dashboard.jsx) - Main dashboard component with data visualization
+- [src/components/UserStats.jsx](src/components/UserStats.jsx) - User statistics display component
+- [src/styles/dashboard.css](src/styles/dashboard.css) - Responsive dashboard styling
+
+feat(backend): add dashboard API endpoints
+- [src/routes/dashboard.js](src/routes/dashboard.js) - New dashboard data API endpoints
+- [src/controllers/userController.js](src/controllers/userController.js) - User data aggregation logic
+
+test(integration): add dashboard test coverage
+- [tests/dashboard.test.js](tests/dashboard.test.js) - Frontend component tests
+- [tests/api/dashboard.test.js](tests/api/dashboard.test.js) - Backend API endpoint tests
+
+docs(api): update API documentation
+- [docs/api.md](docs/api.md) - Added dashboard endpoint documentation
+```
+
+### Multi-Issue Commit Example
+
+```text
+feat(auth): implement user authentication system (#123)
+
+Added comprehensive authentication system with JWT tokens, profile management,
+and updated documentation to support the new auth workflow.
+
+Issues Addressed:
+
+feat(auth): implement JWT token validation (#123)
+- [src/middleware/auth.js](src/middleware/auth.js) - JWT validation logic and middleware
+- [src/routes/api.js](src/routes/api.js) - Applied auth middleware to protected routes
+- [tests/auth.test.js](tests/auth.test.js) - Comprehensive test coverage for auth flow
+
+feat(ui): add user profile page (#456)
+- [src/components/UserProfile.jsx](src/components/UserProfile.jsx) - Main profile component with edit functionality
+- [src/styles/profile.css](src/styles/profile.css) - Responsive styling for profile page
+
+docs(readme): update installation instructions (#789)
+- [README.md](README.md) - Updated installation and auth setup documentation
+
+Closes #123, #456, #789
+```
+
+### Single-Issue Commit Example
+
+```text
+fix(search): resolve pagination bug in results (#542)
+
+Fixed issue where search results pagination was not properly handling
+empty result sets, causing infinite loading states.
+
+Files changed:
+- [src/components/SearchResults.jsx](src/components/SearchResults.jsx) - Added null check for empty results
+- [src/hooks/useSearchPagination.js](src/hooks/useSearchPagination.js) - Fixed pagination logic for edge cases
+- [tests/search.test.js](tests/search.test.js) - Added test coverage for empty result pagination
+
+Closes #542
+```
+
+### Simple Commit Example
+
+```text
+style(ui): format search component files
+
+Applied prettier formatting to search-related components.
+
+Files changed:
+- [src/components/SearchBar.jsx](src/components/SearchBar.jsx) - Code formatting only
+- [src/components/SearchResults.jsx](src/components/SearchResults.jsx) - Code formatting only
+```
+
+### Breaking Change Example
+
+```text
+feat(api)!: restructure user authentication endpoints (#345)
+
+BREAKING CHANGE: Authentication endpoints have been restructured.
+The /auth/login endpoint now returns different response format.
+
+Issues Addressed:
+
+feat(api): restructure authentication endpoints (#345)
+- [src/routes/auth.js](src/routes/auth.js) - New endpoint structure and response format
+- [src/middleware/auth.js](src/middleware/auth.js) - Updated to handle new token format
+- [docs/api.md](docs/api.md) - Updated API documentation
+
+Closes #345
+```
+
+## Best Practices
+
+### Do
+
+1. **ALWAYS use conventional commit headers** - This is mandatory, no exceptions
+2. **Be specific** - Explain what changed and why
+3. **Group by area/issue** - Keep related changes together with proper headers
+4. **List all files** - Don't leave any modified files undocumented
+5. **Use present tense** - "add" not "added"
+6. **Reference issues only when working on specific issues** - Don't use placeholder numbers
+7. **Be consistent** - Follow the format every time
+
+### Don't
+
+1. **NEVER skip the conventional commit header** - This will cause commit failure
+2. **Mix unrelated changes** - One commit per logical change set
+3. **Use vague descriptions** - "fix stuff" or "update files"
+4. **Forget file listings** - Every file should be documented
+5. **Use placeholder issue numbers** - Only reference real issues you're working on
+6. **Use past tense** - Avoid "fixed" or "added"
+7. **Ignore functional grouping** - Group files by area when they serve different purposes
+
+## Integration with VS Code
+
+Your VS Code settings are configured to use these commit message guidelines.
+When generating commit messages with GitHub Copilot, it will follow this format
+automatically.
+
+## Atomic Commits
+
+- **One logical change per commit** - Don't mix features, fixes, and docs
+- **Complete changes** - Don't split related files across commits
+- **Buildable commits** - Each commit should leave the code in a working state
+- **Issue-focused** - Group files by the issue they address, not by file type

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -1,0 +1,29 @@
+<!-- file: .github/copilot-instructions.md -->
+<!-- version: 2.4.0 -->
+<!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
+<!-- last-edited: 2026-06-13 -->
+
+# github-common — Additional Context
+
+Org-wide coding standards (file headers, language rules, commit format) are at
+**<https://github.com/falkcorp/.github>** and apply automatically to this repo.
+
+For full project context: **CLAUDE.md** at the repo root.
+
+## Project overview
+
+Reusable GitHub Actions workflows, scripts, and multi-repo automation. Language: Python.
+
+## Key directories
+
+| Path | Purpose |
+|---|---|
+| `.github/workflows/reusable-*.yml` | Reusable workflows called by other repos |
+| `scripts/` | Python automation tools for cross-repo operations |
+| `.github/instructions/` | Modular AI agent rules with language targeting |
+
+## Critical constraints
+
+- `scripts/intelligent_sync_to_repos.py` — propagates changes to target repos; use `--dry-run` first
+- `scripts/workflow-debugger.py` — analyzes workflow failures; outputs to `workflow-debug-output/fix-tasks/`
+- All commits must use conventional commit format: `type(scope): description`

--- a/.github/instructions/general-coding.instructions.md
+++ b/.github/instructions/general-coding.instructions.md
@@ -1,0 +1,313 @@
+<!-- file: .github/instructions/general-coding.instructions.md -->
+<!-- version: 2.2.0 -->
+<!-- guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**"
+description: |
+  General coding, documentation, and workflow rules for all Copilot/AI agents and VS Code Copilot customization. These rules apply to all files and languages unless overridden by a more specific instructions file. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# General Coding Instructions
+
+These instructions are the canonical source for all Copilot/AI agent coding,
+documentation, and workflow rules in this repository. They are referenced by
+language- and task-specific instructions, and are always included by default in
+Copilot customization.
+
+- Follow conventional commit message standards and pull request guidelines.
+- All language/framework-specific style and workflow rules are now found in
+  `.github/instructions/*.instructions.md` files. These are the only canonical
+  source for code style, documentation, and workflow rules for each language or
+  framework.
+- Document all code, classes, functions, and tests extensively, using the
+  appropriate style for the language.
+- Use the Arrange-Act-Assert pattern for tests.
+- Do not duplicate rules; reference this file from more specific instructions.
+- For VS Code Copilot customization, this file is included via symlink in
+  `.vscode/copilot/`.
+- **ALWAYS check before doing:** Before creating files, running operations, or executing scripts, always check current state first. Make all scripts and operations idempotent by checking if the desired state already exists before making changes.
+- **USE VS CODE TASKS FIRST:** ALWAYS use VS Code tasks when available instead of manual terminal commands. Tasks provide consistent logging, error handling, and automation. Only fall back to manual commands when no appropriate task exists.
+- **🚨 CRITICAL: Always increment file header versions when modifying any file.** When you change any file with a version header, you MUST update the version number according to semantic versioning rules (patch for fixes/typos, minor for features/additions, major for breaking changes). This is mandatory for all files including documentation, templates, workflows, and configuration files.
+
+For more details and the full system, see
+[copilot-instructions.md](../copilot-instructions.md).
+
+## Copilot Agent Utility
+
+The repositories use the `copilot-agent-util` command-line tool for enhanced logging, error handling, and automation in VS Code tasks. This Rust-based utility provides consistent output formatting and task management across all repositories.
+
+**If the `copilot-agent-util` tool is not available in your environment:**
+
+- Install it from the source repository: <https://github.com/jdfalk/copilot-agent-util-rust>
+- Follow the installation instructions in that repository's README
+- The tool is required for proper VS Code task execution and logging
+
+## 🚨 CRITICAL: Use MCP GitHub Tools for Git Operations
+
+**MANDATORY RULE: Always use MCP GitHub tools for git operations instead of manual commands or VS Code tasks.**
+
+When performing git operations (commit, push, pull, file operations), use the MCP GitHub tools:
+
+- `mcp_gitkraken_git_add_or_commit` - Add and commit files
+- `mcp_gitkraken_git_push` - Push commits to remote
+- `mcp_github_create_or_update_file` - Create or update files in GitHub
+- `mcp_github_push_files` - Push multiple files in a single commit
+
+**Benefits:**
+- Direct GitHub integration without shell commands
+- Consistent error handling and authentication
+- Proper logging and audit trail
+- Works across all environments
+
+## 🚨 CRITICAL: Use VS Code Tasks First
+
+**MANDATORY RULE: Always attempt to use VS Code tasks before manual commands (except for git operations - use MCP tools for those).**
+
+When performing ANY operation (git, build, test, etc.), follow this priority:
+
+1. **FIRST**: Check if a VS Code task exists for the operation
+2. **SECOND**: Use the task via `run_task` tool with appropriate workspace folder
+3. **THIRD**: Check task logs in `logs/` folder for results
+4. **LAST RESORT**: Use manual terminal commands only if no task exists
+
+### Common Operations and Their Tasks
+
+| Operation | Task Name | Manual Fallback |
+|-----------|-----------|-----------------|
+| Git add all files | `Git Add All` | `git add .` |
+| Git add specific files | `Git Add Selective` | `git add <pattern>` |
+| Git commit | `Git Commit` | `git commit -m "message"` |
+| Git push | `Git Push` | `git push` |
+| Git status | `Git Status` | `git status` |
+| Build Go project | `Go Build` | `go build` |
+| Run Go tests | `Go Test` | `go test ./...` |
+| Protocol buffer generation | `Buf Generate with Output` | `buf generate` |
+| Python tests | `Python Test` | `python -m pytest` |
+| Rust build | `Rust Build` | `cargo build` |
+| Rust tests | `Rust Test` | `cargo test` |
+
+### Task Usage Examples
+
+```bash
+# ✅ CORRECT: Use tasks first
+run_task("Git Add All", "/path/to/workspace")
+run_task("Git Commit", "/path/to/workspace")  # Will prompt for message
+run_task("Git Push", "/path/to/workspace")
+
+# ❌ INCORRECT: Manual commands without checking for tasks
+git add . && git commit -m "message" && git push
+```
+
+### Benefits of Using Tasks
+
+- **Consistent Logging**: All output logged to `logs/` folder with timestamps
+- **Error Handling**: Standardized error reporting and debugging information
+- **Workspace Awareness**: Tasks run in correct directory with proper context
+- **Automation**: Tasks can chain together and include pre/post operations
+- **Debugging**: Log files provide complete audit trail for troubleshooting
+
+## Script Language Preference
+
+**MANDATORY RULE: Prefer Python for scripts unless they are incredibly simple.**
+
+When creating automation scripts, configuration tools, or data processing utilities:
+
+1. **FIRST CHOICE**: Python for any script with:
+   - API interactions (GitHub, REST APIs, etc.)
+   - JSON/YAML processing
+   - File manipulation beyond simple copying
+   - Error handling and logging
+   - Data parsing or transformation
+   - More than 20-30 lines of logic
+
+2. **SECOND CHOICE**: Shell scripts (bash/sh) only for:
+   - Simple file operations (copy, move, basic checks)
+   - Basic git commands
+   - Simple environment setup
+   - Scripts under 20 lines with minimal logic
+
+3. **CONVERSION REQUIRED**: When existing shell scripts become complex:
+   - Convert to Python when adding features
+   - Rewrite in Python if error handling is insufficient
+   - Migrate when API calls or JSON processing is needed
+
+### Examples
+
+**✅ CORRECT - Use Python for:**
+
+- GitHub API interactions
+- Configuration file processing
+- Multi-step automation workflows
+- Scripts with error handling requirements
+- Data validation and transformation
+
+**❌ INCORRECT - Don't use shell for:**
+
+- Complex JSON parsing
+- API authentication and error handling
+- Multi-repository operations
+- Scripts requiring robust error recovery
+
+**✅ ACCEPTABLE - Shell scripts for:**
+
+- Simple `cp`, `mv`, `mkdir` operations
+- Basic git commands with minimal logic
+- Environment variable setup
+- Simple file existence checks
+
+## Required File Header (File Identification)
+
+All source, script, and documentation files MUST begin with a standard header
+containing:
+
+- The exact relative file path from the repository root (e.g.,
+  `# file: path/to/file.py`)
+- The file's semantic version (e.g., `# version: 1.1.0`)
+- The file's GUID (e.g., `# guid: 123e4567-e89b-12d3-a456-426614174000`)
+
+**Header format varies by language/file type:**
+
+- **Markdown:**
+
+  ```markdown
+  <!-- file: path/to/file.md -->
+  <!-- version: 1.1.0 -->
+  <!-- guid: 123e4567-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+  ```
+
+- **Python:**
+
+  ```python
+  #!/usr/bin/env python3
+  # file: path/to/file.py
+  # version: 1.1.0
+  # guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+- **Go:**
+
+  ```go
+  // file: path/to/file.go
+  // version: 1.1.0
+  // guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+- **JavaScript/TypeScript:**
+
+  ```js
+  // file: path/to/file.js
+  // version: 1.1.0
+  // guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+- **Shell (bash/sh):**
+
+  ```bash
+  #!/bin/bash
+  # file: path/to/script.sh
+  # version: 1.1.0
+  # guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+  (Header must come after the shebang line)
+- **CSS:**
+
+  ```css
+  /* file: path/to/file.css */
+  /* version: 1.1.0 */
+  /* guid: 123e4567-e89b-12d3-a456-426614174000 */
+  ```
+
+- **R:**
+
+  ```r
+  # file: path/to/file.R
+  # version: 1.1.0
+  # guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+  For executable R scripts:
+
+  ```r
+  #!/usr/bin/env Rscript
+  # file: path/to/script.R
+  # version: 1.1.0
+  # guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+  (Header must come after the shebang line)
+- **JSON:**
+
+  ```jsonc
+  // file: path/to/file.json
+  // version: 1.1.0
+  // guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+- **TOML:**
+
+  ```toml
+  [section]
+  # file: path/to/file.toml
+  # version: 1.1.0
+  # guid: 123e4567-e89b-12d3-a456-426614174000
+  ```
+
+  (Header must be inside a section as TOML doesn't support top-level comments)
+
+**All files must include this header in the correct format for their type.**
+
+## Version Update Requirements
+
+**When modifying any file with a version header, ALWAYS update the version
+number:**
+
+- **Patch version** (x.y.Z): Bug fixes, typos, minor formatting changes
+- **Minor version** (x.Y.z): New features, significant content additions,
+  template changes
+- **Major version** (X.y.z): Breaking changes, structural overhauls, format
+  changes
+
+**Examples:**
+
+- Fix typo: `1.2.3` → `1.2.4`
+- Add new section: `1.2.3` → `1.3.0`
+- Change template structure: `1.2.3` → `2.0.0`
+
+**This applies to all files with version headers including documentation,
+templates, and configuration files.**
+
+## VS Code Tasks Implementation Details
+
+All repositories are configured with standardized VS Code tasks following the priority system outlined above.
+
+### Task Categories
+
+- **Git Operations**: `Git Add All`, `Git Add Selective`, `Git Commit`, `Git Push`, `Git Status`
+- **Build Operations**: Repository-specific tasks (e.g., `Go Build`, `Buf Generate`, `Python Test`)
+- **Project Operations**: Language/framework-specific tasks
+
+### Task Output and Logging
+
+- **All task output is logged to the `logs/` folder** (gitignored)
+- **Always check log files after running tasks** to verify success or diagnose issues
+- Log files are named descriptively: `git_commit.log`, `go_build.log`, etc.
+- Tasks include success/failure messages at the end of each log
+
+### Task Execution Workflow
+
+1. **Execute**: Use `run_task` tool with task name and workspace folder
+2. **Verify**: Check the corresponding log file in `logs/` folder
+3. **Debug**: Review log contents if task fails
+4. **Retry**: Fix issues and re-run task if needed
+
+This approach provides consistent logging, error handling, and automation across all repositories.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,242 @@
+<!-- file: .github/instructions/github-actions.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: 9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: ".github/workflows/*.{yml,yaml}"
+description: |
+  Coding, documentation, and workflow rules for GitHub Actions workflow files, following Google and project-specific style guides. Reference the general instructions for all Copilot/AI agents and VS Code Copilot customization. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# GitHub Actions Workflow Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google GitHub Actions/YAML Style Guide](https://github.com/google/styleguide/blob/gh-pages/docguide/style.md)
+  for additional best practices.
+- All workflow files must begin with the required file header (see general
+  instructions for details and YAML example).
+
+## Workflow File Structure
+
+- Use `.github/workflows/` directory for all workflow files
+- Use descriptive names for workflow files (e.g., `ci.yml`,
+  `deploy-production.yml`)
+- Use lowercase, hyphen-separated names for workflow files
+- Include file extension `.yml` (preferred) or `.yaml`
+
+## YAML Formatting
+
+- Use 2 spaces for indentation
+- Keep line length to a reasonable limit (recommended: 100 characters)
+- Use blank lines to separate logical sections within workflows
+- Use comments to explain complex steps or configurations
+- Use consistent formatting for arrays and objects
+
+## Workflow Configuration
+
+### Naming
+
+```yaml
+name: Descriptive Workflow Name
+```
+
+- Always include a clear, descriptive name for each workflow
+- Use title case for workflow names
+- Include the purpose of the workflow in its name
+
+### Triggers
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+```
+
+- List triggers in order of importance
+- Use specific branch filters when appropriate
+- Consider using `paths` filters to limit execution
+- Document custom trigger configurations with comments
+
+### Job Structure
+
+```yaml
+jobs:
+  job-id:
+    name: Human Readable Job Name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Descriptive step name
+        uses: actions/checkout@v4
+```
+
+- Use lowercase, hyphen-separated names for job IDs
+- Always include a human-readable `name` property for jobs
+- Group related steps logically
+- Use consistent naming conventions across workflows
+
+## Steps Best Practices
+
+### Step Naming
+
+- Always include a descriptive name for each step
+- Use sentence case for step names
+- Include an action verb describing what the step does
+
+### Actions References
+
+- Always pin actions to specific versions using SHA hashes for critical
+  workflows
+- Use major version references (`@v4`) for general usage
+- Avoid using `@master` or `@main` references
+
+```yaml
+# Good - pinned to specific version
+- uses: actions/checkout@v4.1.1
+
+# Better - pinned to SHA for critical workflows
+- uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+
+# Avoid
+- uses: actions/checkout@main
+```
+
+### Commands and Scripts
+
+- Use multi-line syntax for complex commands
+- Use `|` for multi-line scripts rather than chaining with `&&`
+- Consider extracting complex scripts to separate files in the repository
+
+```yaml
+# Good
+- name: Run complex script
+  run: |
+    echo "Starting process"
+    npm test
+
+# Avoid
+- name: Run complex script
+  run: echo "Starting process" && npm ci && npm run build && npm test
+```
+
+## Variables and Secrets
+
+- Use `env:` section at the appropriate scope (workflow, job, or step)
+- Define shared variables at the highest appropriate scope
+- Prefer environment files for projects with many environment variables
+- Never hardcode sensitive information
+
+```yaml
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build:
+    env:
+      CACHE_KEY: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+    steps:
+      - name: Use specific variable
+        env:
+          SPECIFIC_VAR: 'value'
+        run: echo $SPECIFIC_VAR
+```
+
+## Reusability and DRY Principles
+
+- Use composite actions for reusable step sequences
+- Use reusable workflows for common workflow patterns
+- Create workflow templates for organizational standards
+- Standardize common job patterns across workflows
+
+## Conditional Execution
+
+- Use clear, explicit conditions
+- Use expressions for dynamic behavior
+- Comment complex conditions to explain the logic
+
+```yaml
+- name: Step that runs only on main branch
+  if: github.ref == 'refs/heads/main'
+  run: ./deploy.sh
+
+- name: Step with complex condition
+  # Run only on pull requests to main when specific files changed
+  if: |
+    github.event_name == 'pull_request' &&
+    github.base_ref == 'main' &&
+    contains(github.event.pull_request.labels.*.name, 'deploy')
+  run: ./conditional-task.sh
+```
+
+## Error Handling
+
+- Use `continue-on-error` for non-critical steps
+- Set appropriate timeout limits for long-running steps
+- Implement retry logic for flaky operations
+
+```yaml
+- name: Flaky external API call
+  uses: some/api-action@v1
+  with:
+    retries: 3
+    timeout-minutes: 5
+  continue-on-error: true
+```
+
+## Performance Optimization
+
+- Use caching for dependencies and build artifacts
+- Set appropriate concurrency limits
+- Use matrix builds efficiently
+- Use job outputs to pass data between jobs
+
+```yaml
+- name: Cache dependencies
+  uses: actions/cache@v3
+  with:
+    path: ~/.npm
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+## Security Best Practices
+
+- Use GITHUB_TOKEN with minimum required permissions
+- Use OpenID Connect for cloud provider authentication when possible
+- Avoid printing secrets in logs
+- Use organization/repository secrets for sensitive values
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+## Documentation
+
+- Include comments explaining non-obvious workflow behavior
+- Document expected inputs and outputs for reusable workflows
+- Keep a changelog for significant workflow changes
+- Document any required secrets or environment setup
+
+## Required File Header
+
+All workflow files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for YAML:
+
+```yaml
+# file: .github/workflows/ci.yml
+# version: 1.0.0
+# guid: 123e4567-e89b-12d3-a456-426614174000
+```

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,2860 @@
+<!-- file: .github/instructions/go.instructions.md -->
+<!-- version: 1.11.0 -->
+<!-- guid: 4a5b6c7d-8e9f-1a2b-3c4d-5e6f7a8b9c0d -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.go"
+description: |
+  Go language-specific coding, documentation, and testing rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and merge all unique content from the Google Go Style Guide.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Go Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google Go Style Guide](https://google.github.io/styleguide/go/index.html) for
+  additional best practices.
+- All Go files must begin with the required file header (see general
+  instructions for details and Go example).
+
+## Core Principles
+
+- Clarity over cleverness: Code should be clear and readable
+- Simplicity: Prefer simple solutions over complex ones
+- Consistency: Follow established patterns within the codebase
+- Readability: Code is written for humans to read
+
+## Version Requirements
+
+- **MANDATORY**: All Go projects must use Go 1.23.0 or higher
+- **NO EXCEPTIONS**: Do not use older Go versions in any repository
+- Update `go.mod` files to specify `go 1.23` minimum version
+- Update `go.work` files to specify `go 1.23` minimum version
+- All Go file headers must use version 1.23.0 or higher
+- Use `go version` to verify your installation meets requirements
+
+## Architecture: Go Version Strategy
+
+This repository uses **branch-aware version targeting** to support multiple Go versions across parallel release tracks, enabling gradual adoption of Go 1.24 and 1.25 features while maintaining stability for production systems.
+
+### Supported Go Versions
+
+The following Go versions are supported with branch-specific policies:
+
+- **Go 1.23**: Stable production version (supported on all branches)
+- **Go 1.24**: Current stable with modern features (main branch + stable-1-go-1.24)
+- **Go 1.25**: Latest with cutting-edge features (main branch only)
+
+### Branch-Specific Version Policies
+
+#### Main Branch
+
+- **Go Versions**: 1.23, 1.24, 1.25
+- **Policy**: Latest versions with all features
+- **Use Case**: Active development, new features, testing
+- **Feature Access**: All Go 1.25 features available
+
+#### Stable Branches (stable-1-go-X.XX)
+
+- **Go Versions**: Locked to specific version
+- **Policy**: Version-locked for stability
+- **Examples**:
+  - `stable-1-go-1.24`: Go 1.24 only
+  - `stable-1-go-1.23`: Go 1.23 only
+- **Use Case**: Production deployments, long-term support
+- **Feature Access**: Features available in locked version only
+
+#### EOL and Work-Stopped Branches
+
+- **EOL Branches**: Critical security fixes only
+- **Work-Stopped Branches**: No further development
+- **Policy**: Maintained for legacy systems, no new features
+
+### Feature Adoption Timeline
+
+#### Go 1.24 Features (Available Now)
+
+- **testing.B.Loop()**: New benchmark loop syntax (see testing section)
+- **Improved error wrapping**: Enhanced error context
+- **Performance improvements**: Faster compilation, runtime optimizations
+
+**Adoption**:
+
+- ✅ Main branch: Use freely
+- ✅ stable-1-go-1.24: Use freely
+- ❌ stable-1-go-1.23: Not available
+
+#### Go 1.25 Features (Available on Main)
+
+- **os.Root()**: Filesystem root isolation (see security section)
+- **Generic optimization**: Core Types removal, performance improvements
+- **Integer range iteration**: `for i := range n {}` syntax (see iteration section)
+- **Enhanced type inference**: Improved generic type deduction
+
+**Adoption**:
+
+- ✅ Main branch: Use freely for new code
+- ⏳ stable-1-go-1.24: Wait for branch policy update
+- ❌ stable-1-go-1.23: Not available
+
+### Version Detection in Workflows
+
+The CI/CD system automatically detects appropriate Go versions based on branch configuration:
+
+```yaml
+# Automatically resolved from workflow-versions.yml
+go-versions:
+  main: ["1.23", "1.24", "1.25"]
+  stable-1-go-1.24: ["1.24"]
+  stable-1-go-1.23: ["1.23"]
+```
+
+**Workflow Behavior**:
+
+- **Main branch**: Tests against all supported versions
+- **Stable branches**: Tests against locked version only
+- **Release builds**: Uses highest version for the branch
+
+### Migration Guide
+
+#### Adopting Go 1.24 Features
+
+1. **Verify Branch Policy**:
+
+   ```bash
+   # Check current branch
+   git branch --show-current
+
+   # Verify Go version in go.mod
+   grep "^go " go.mod
+   ```
+
+2. **Update go.mod (if needed)**:
+
+   ```go
+   go 1.24
+   ```
+
+3. **Use New Features**:
+
+   - Replace manual benchmark loops with `testing.B.Loop()`
+   - Leverage improved error wrapping
+   - Benefit from performance improvements automatically
+
+#### Adopting Go 1.25 Features
+
+1. **Confirm Main Branch**:
+
+   ```bash
+   git branch --show-current
+   # Must be: main
+   ```
+
+2. **Update go.mod**:
+
+   ```go
+   go 1.25
+   ```
+
+3. **Use New Features**:
+
+   - Use `os.Root()` for filesystem isolation in sandboxed operations
+   - Replace traditional `for i := 0; i < n; i++` with `for i := range n {}`
+   - Benefit from generic optimizations automatically
+   - Leverage enhanced type inference
+
+### Best Practices
+
+#### Version Selection
+
+- **New Projects**: Start with Go 1.24 for stability
+- **Experimental Features**: Use Go 1.25 on main branch only
+- **Production Code**: Use stable branches with locked versions
+
+#### Feature Flags
+
+Use build tags for version-specific features:
+
+```go
+//go:build go1.24
+
+package mypackage
+
+// Go 1.24-specific implementation using testing.B.Loop()
+```
+
+```go
+//go:build go1.25
+
+package mypackage
+
+// Go 1.25-specific implementation using os.Root()
+```
+
+#### Compatibility
+
+- **Write for minimum version**: Target Go 1.23 for maximum compatibility
+- **Test across versions**: CI tests all supported versions on main branch
+- **Document requirements**: Clearly state minimum Go version in README
+
+### Version-Specific Sections
+
+This document includes detailed sections for version-specific features:
+
+- **testing.B.Loop() (Go 1.24+)**: See benchmarking section below
+- **os.Root() (Go 1.25)**: See filesystem isolation section below
+- **Integer Range Iteration (Go 1.25)**: See iteration patterns section below
+- **Generic Optimization (Go 1.25)**: See generics section below
+
+### Decision: When to Upgrade
+
+#### Upgrade to Go 1.24 When
+
+- ✅ Need improved benchmark testing with `testing.B.Loop()`
+- ✅ Want better error wrapping capabilities
+- ✅ Require performance improvements
+- ✅ Ready to test on stable-1-go-1.24 branch
+
+#### Upgrade to Go 1.25 When
+
+- ✅ Need filesystem isolation with `os.Root()`
+- ✅ Want cleaner integer range iteration
+- ✅ Benefit from generic optimizations
+- ✅ Working on main branch for active development
+- ❌ **NOT for stable branches** (wait for policy update)
+
+### Platform Support
+
+All Go versions support the same platforms:
+
+- **Linux**: amd64, arm64
+- **macOS**: amd64 (Intel), arm64 (Apple Silicon)
+- **NO WINDOWS**: Windows platform not supported
+
+Cross-compilation configured for all targets in `.cargo/config.toml` and release workflows.
+
+## Naming Conventions
+
+- Use short, concise, evocative package names (lowercase, no underscores)
+- Use camelCase for unexported names, PascalCase for exported names
+- Use short names for short-lived variables, descriptive names for longer-lived
+  variables
+- Use PascalCase for exported constants, camelCase for unexported constants
+- Single-method interfaces should end in "-er" (e.g., Reader, Writer)
+
+## Code Organization
+
+- Use `goimports` to format imports automatically
+- Group imports: standard library, third-party, local
+- No blank lines within groups, one blank line between groups
+- Keep functions short and focused
+- Use blank lines to separate logical sections
+- Order: receiver, name, parameters, return values
+
+## Formatting
+
+- Use tabs for indentation, spaces for alignment
+- Opening brace on same line as declaration, closing brace on its own line
+- No strict line length limit, but aim for readability
+
+## Comments
+
+- Every package should have a package comment
+- Public functions must have comments starting with the function name
+- Comment exported variables, explain purpose and constraints
+
+## Error Handling
+
+- Use lowercase for error messages, no punctuation at end
+- Be specific about what failed
+- Create custom error types for specific error conditions
+- Use `errors.Is` and `errors.As` for error checking
+
+## Best Practices
+
+- Use short variable declarations (`:=`) when possible
+- Use `var` for zero values or when type is important
+- Use `make()` for slices and maps with known capacity
+- Accept interfaces, return concrete types
+- Keep interfaces small and focused
+- Use channels for communication between goroutines
+- Use sync primitives for protecting shared state
+- Test file names end with `_test.go`, test function names start with `Test`
+- Use table-driven tests for multiple scenarios
+
+## Required File Header
+
+All Go files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for Go:
+
+```go
+// file: path/to/file.go
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+```
+
+## Google Go Style Guide (Complete)
+
+Follow the complete Google Go Style Guide below for all Go code:
+
+### Google Go Style Guide (Complete)
+
+This style guide provides comprehensive conventions for writing clean, readable, and maintainable Go code.
+
+#### Formatting
+
+**gofmt:** All Go code must be formatted with `gofmt`. This is non-negotiable.
+
+**Line Length:** No hard limit, but prefer shorter lines. Break long lines sensibly.
+
+**Indentation:** Use tabs for indentation (handled automatically by gofmt).
+
+**Spacing:** Let gofmt handle spacing. Generally:
+
+- No space inside parentheses: `f(a, b)`
+- Space around binary operators: `a + b`
+- No space around unary operators: `!condition`
+
+#### Naming Conventions
+
+**Packages:**
+
+- Short, concise, evocative names
+- Lowercase, no underscores or mixedCaps
+- Often single words
+
+```go
+// Good
+package user
+package httputil
+package json
+
+// Bad
+package userService
+package http_util
+```
+
+**Interfaces:**
+
+- Use -er suffix for single-method interfaces
+- Use MixedCaps
+
+```go
+// Good
+type Reader interface {
+    Read([]byte) (int, error)
+}
+
+type FileWriter interface {
+    WriteFile(string, []byte) error
+}
+
+// Bad
+type IReader interface {  // Don't prefix with I
+    Read([]byte) (int, error)
+}
+```
+
+**Functions and Methods:**
+
+- Use MixedCaps
+- Exported functions start with capital letter
+- Unexported functions start with lowercase letter
+
+```go
+// Good - exported
+func CalculateTotal(price, tax float64) float64 {
+    return price + tax
+}
+
+// Good - unexported
+func validateInput(input string) bool {
+    return len(input) > 0
+}
+```
+
+**Variables:**
+
+- Use MixedCaps
+- Short names for short scopes
+- Longer descriptive names for longer scopes
+
+```go
+// Good - short scope
+for i, v := range items {
+    process(i, v)
+}
+
+// Good - longer scope
+func processUserData(userData map[string]interface{}) error {
+    userID, exists := userData["id"]
+    if !exists {
+        return errors.New("user ID not found")
+    }
+    // ... more processing
+}
+
+// Bad
+func processUserData(d map[string]interface{}) error {  // 'd' too short for scope
+    userIdentificationNumber, exists := d["id"]  // Too long for simple value
+    // ...
+}
+```
+
+**Constants:**
+
+- Use MixedCaps
+- Group related constants in blocks
+
+```go
+// Good
+const (
+    StatusOK       = 200
+    StatusNotFound = 404
+    StatusError    = 500
+)
+
+const DefaultTimeout = 30 * time.Second
+
+// Bad
+const STATUS_OK = 200  // Don't use underscores
+```
+
+#### Package Organization
+
+**Package Names:**
+
+- Choose package names that are both short and clear
+- Avoid generic names like "util", "common", "misc"
+- Package name should describe what it provides, not what it contains
+
+```go
+// Good
+package user     // for user management
+package auth     // for authentication
+package httputil // for HTTP utilities
+
+// Bad
+package utils    // Too generic
+package stuff    // Too vague
+```
+
+**Import Organization:**
+
+- Group imports: standard library, third-party, local
+- Use goimports to handle this automatically
+
+```go
+import (
+    // Standard library
+    "fmt"
+    "os"
+    "time"
+
+    // Third-party
+    "github.com/gorilla/mux"
+    "google.golang.org/grpc"
+
+    // Local
+    "myproject/internal/auth"
+    "myproject/pkg/utils"
+)
+```
+
+#### Error Handling
+
+**Error Strings:**
+
+- Don't capitalize error messages
+- Don't end with punctuation
+- Be descriptive but concise
+
+```go
+// Good
+return fmt.Errorf("failed to connect to database: %w", err)
+return errors.New("invalid user ID")
+
+// Bad
+return errors.New("Failed to connect to database.")  // Capitalized, punctuation
+return errors.New("error")  // Too vague
+```
+
+**Error Wrapping:**
+
+- Use fmt.Errorf with %w verb to wrap errors
+- Add context to errors as they bubble up
+
+```go
+func processUser(id string) error {
+    user, err := getUserFromDB(id)
+    if err != nil {
+        return fmt.Errorf("failed to get user %s: %w", id, err)
+    }
+
+    if err := validateUser(user); err != nil {
+        return fmt.Errorf("user validation failed: %w", err)
+    }
+
+    return nil
+}
+```
+
+**Error Checking:**
+
+- Check errors immediately after operations
+- Don't ignore errors (use _ only when truly appropriate)
+
+```go
+// Good
+file, err := os.Open(filename)
+if err != nil {
+    return fmt.Errorf("failed to open file: %w", err)
+}
+defer file.Close()
+
+// Bad
+file, _ := os.Open(filename)  // Ignoring error
+// ... later in code ...
+if file == nil {  // Too late to handle properly
+    return errors.New("file is nil")
+}
+```
+
+#### Function Design
+
+**Function Length:** Keep functions short and focused. If a function is very long, consider breaking it up.
+
+**Function Signature:**
+
+- Related parameters should be grouped
+- Use meaningful parameter names
+
+```go
+// Good
+func CreateUser(firstName, lastName, email string, age int) *User {
+    return &User{
+        FirstName: firstName,
+        LastName:  lastName,
+        Email:     email,
+        Age:       age,
+    }
+}
+
+// Bad
+func CreateUser(a, b, c string, d int) *User {  // Unclear parameter names
+    return &User{
+        FirstName: a,
+        LastName:  b,
+        Email:     c,
+        Age:       d,
+    }
+}
+```
+
+**Return Values:**
+
+- Return errors as the last value
+- Use named return parameters sparingly
+
+```go
+// Good
+func divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+
+// Acceptable for short, clear functions
+func split(path string) (dir, file string) {
+    // ... implementation
+    return
+}
+```
+
+#### Struct Design
+
+**Field Organization:**
+
+- Group related fields together
+- Consider field alignment for memory efficiency
+
+```go
+type User struct {
+    // Identity fields
+    ID       int64
+    Username string
+    Email    string
+
+    // Personal information
+    FirstName string
+    LastName  string
+    Age       int
+
+    // Metadata
+    CreatedAt time.Time
+    UpdatedAt time.Time
+    Active    bool
+}
+```
+
+**Constructor Functions:**
+
+- Use New prefix for constructor functions
+- Return pointers for structs that will be modified
+
+```go
+func NewUser(username, email string) *User {
+    return &User{
+        Username:  username,
+        Email:     email,
+        CreatedAt: time.Now(),
+        Active:    true,
+    }
+}
+```
+
+#### Concurrency
+
+**Goroutines:**
+
+- Use goroutines for independent tasks
+- Always consider how goroutines will exit
+
+```go
+// Good
+func processItems(items []Item) {
+    var wg sync.WaitGroup
+
+    for _, item := range items {
+        wg.Add(1)
+        go func(item Item) {
+            defer wg.Done()
+            process(item)
+        }(item)
+    }
+
+    wg.Wait()
+}
+```
+
+**Channels:**
+
+- Use channels for communication between goroutines
+- Close channels when done sending
+
+```go
+func producer(ch chan<- int) {
+    defer close(ch)
+    for i := 0; i < 10; i++ {
+        ch <- i
+    }
+}
+
+func consumer(ch <-chan int) {
+    for value := range ch {
+        fmt.Println(value)
+    }
+}
+```
+
+#### Comments and Documentation
+
+**Package Comments:**
+
+- Every package should have a package comment
+- Use complete sentences
+
+```go
+// Package user provides functionality for user management,
+// including authentication, authorization, and user data operations.
+package user
+```
+
+**Function Comments:**
+
+- Document all exported functions
+- Start with the function name
+- Explain what the function does, not how
+
+```go
+// CalculateTotal computes the total price including tax.
+// It returns an error if the tax rate is negative.
+func CalculateTotal(price, taxRate float64) (float64, error) {
+    if taxRate < 0 {
+        return 0, errors.New("tax rate cannot be negative")
+    }
+    return price * (1 + taxRate), nil
+}
+```
+
+**Inline Comments:**
+
+- Use for complex logic or non-obvious code
+- Explain why, not what
+
+```go
+// Sort items by priority to ensure high-priority items are processed first
+sort.Slice(items, func(i, j int) bool {
+    return items[i].Priority > items[j].Priority
+})
+```
+
+#### Testing
+
+**Test Functions:**
+
+- Use TestXxx naming convention
+- Use t.Run for subtests
+
+```go
+func TestCalculateTotal(t *testing.T) {
+    tests := []struct {
+        name     string
+        price    float64
+        taxRate  float64
+        expected float64
+        hasError bool
+    }{
+        {
+            name:     "positive values",
+            price:    100.0,
+            taxRate:  0.1,
+            expected: 110.0,
+            hasError: false,
+        },
+        {
+            name:     "negative tax rate",
+            price:    100.0,
+            taxRate:  -0.1,
+            expected: 0.0,
+            hasError: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result, err := CalculateTotal(tt.price, tt.taxRate)
+
+            if tt.hasError {
+                if err == nil {
+                    t.Errorf("expected error, got none")
+                }
+                return
+            }
+
+            if err != nil {
+                t.Errorf("unexpected error: %v", err)
+                return
+            }
+
+            if result != tt.expected {
+                t.Errorf("expected %f, got %f", tt.expected, result)
+            }
+        })
+    }
+}
+```
+
+**Benchmark Functions:**
+
+```go
+func BenchmarkCalculateTotal(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        CalculateTotal(100.0, 0.1)
+    }
+}
+```
+
+## Benchmarking with testing.B.Loop() (Go 1.24+)
+
+**Available**: Go 1.24 and later
+
+Go 1.24 introduces `testing.B.Loop()`, a new method for writing benchmark loops that replaces the traditional `for i := 0; i < b.N; i++` pattern. This new approach provides better compiler optimizations and cleaner benchmark code.
+
+### Basic Usage
+
+#### Traditional Approach (Go 1.23 and earlier)
+
+```go
+func BenchmarkProcessData(b *testing.B) {
+    data := generateTestData()
+    b.ResetTimer() // Reset timer after setup
+
+    for i := 0; i < b.N; i++ {
+        processData(data)
+    }
+}
+```
+
+#### Modern Approach (Go 1.24+)
+
+```go
+func BenchmarkProcessData(b *testing.B) {
+    data := generateTestData()
+    b.ResetTimer() // Reset timer after setup
+
+    for b.Loop() {
+        processData(data)
+    }
+}
+```
+
+### Key Benefits
+
+1. **Cleaner Syntax**: Eliminates the need for explicit loop variable
+2. **Compiler Optimizations**: Better optimization opportunities for the compiler
+3. **Consistent Pattern**: Matches the style of `for range` loops
+4. **No Manual Counter**: Removes potential for off-by-one errors
+
+### When to Use testing.B.Loop()
+
+✅ **Use testing.B.Loop() when:**
+
+- Writing new benchmarks in Go 1.24+ codebases
+- Refactoring existing benchmarks for modernization
+- Working on main branch or stable-1-go-1.24 branches
+- Benchmark doesn't need the iteration index
+
+❌ **Use traditional loop when:**
+
+- Maintaining Go 1.23 compatibility
+- Need access to iteration index (rare in benchmarks)
+- Working on stable-1-go-1.23 or older branches
+
+### Complete Examples
+
+#### Simple Function Benchmark
+
+```go
+// Traditional (Go 1.23)
+func BenchmarkStringConcat(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        _ = "hello" + "world"
+    }
+}
+
+// Modern (Go 1.24+)
+func BenchmarkStringConcat(b *testing.B) {
+    for b.Loop() {
+        _ = "hello" + "world"
+    }
+}
+```
+
+#### Benchmark with Setup
+
+```go
+func BenchmarkDatabaseQuery(b *testing.B) {
+    // Setup (not measured)
+    db := setupTestDatabase()
+    defer db.Close()
+
+    query := "SELECT * FROM users WHERE active = ?"
+    b.ResetTimer() // Start timing here
+
+    for b.Loop() {
+        rows, err := db.Query(query, true)
+        if err != nil {
+            b.Fatal(err)
+        }
+        rows.Close()
+    }
+}
+```
+
+#### Benchmark with Sub-Benchmarks
+
+```go
+func BenchmarkJSONOperations(b *testing.B) {
+    data := map[string]interface{}{
+        "name": "John Doe",
+        "age":  30,
+        "active": true,
+    }
+
+    b.Run("Marshal", func(b *testing.B) {
+        for b.Loop() {
+            _, err := json.Marshal(data)
+            if err != nil {
+                b.Fatal(err)
+            }
+        }
+    })
+
+    b.Run("Unmarshal", func(b *testing.B) {
+        jsonData, _ := json.Marshal(data)
+        var result map[string]interface{}
+
+        for b.Loop() {
+            err := json.Unmarshal(jsonData, &result)
+            if err != nil {
+                b.Fatal(err)
+            }
+        }
+    })
+}
+```
+
+#### Parallel Benchmarks
+
+```go
+func BenchmarkConcurrentProcessor(b *testing.B) {
+    processor := NewProcessor()
+
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() { // Note: RunParallel uses pb.Next(), not b.Loop()
+            processor.Process(generateRandomData())
+        }
+    })
+}
+```
+
+**Important**: When using `b.RunParallel()`, continue using `pb.Next()` in the parallel function. The `testing.B.Loop()` method is for sequential benchmarks only.
+
+### Migration Strategy
+
+#### Gradual Migration (Recommended)
+
+1. **Update go.mod** to Go 1.24:
+
+   ```go
+   go 1.24
+   ```
+
+2. **Use build tags** for version-specific benchmarks:
+
+   ```go
+   //go:build go1.24
+
+   package mypackage
+
+   import "testing"
+
+   func BenchmarkModern(b *testing.B) {
+       for b.Loop() {
+           // benchmark code
+       }
+   }
+   ```
+
+3. **Keep compatibility versions** for older Go:
+
+   ```go
+   //go:build !go1.24
+
+   package mypackage
+
+   import "testing"
+
+   func BenchmarkModern(b *testing.B) {
+       for i := 0; i < b.N; i++ {
+           // same benchmark code
+       }
+   }
+   ```
+
+#### Complete Migration (Go 1.24+ Only)
+
+Replace all traditional benchmark loops:
+
+```bash
+# Find all traditional benchmark loops
+grep -r "for i := 0; i < b.N; i++" . --include="*_test.go"
+
+# Replace with testing.B.Loop()
+# (Do this carefully, reviewing each change)
+```
+
+### Best Practices
+
+#### DO: Use for Simple Iterations
+
+```go
+func BenchmarkSimpleOperation(b *testing.B) {
+    for b.Loop() {
+        result := expensiveOperation()
+        _ = result // Prevent compiler optimization
+    }
+}
+```
+
+#### DO: Reset Timer After Setup
+
+```go
+func BenchmarkWithSetup(b *testing.B) {
+    data := setupTestData() // Not measured
+    b.ResetTimer()          // Start measuring here
+
+    for b.Loop() {
+        process(data)
+    }
+}
+```
+
+#### DO: Use Sub-Benchmarks for Comparisons
+
+```go
+func BenchmarkStringBuilding(b *testing.B) {
+    b.Run("Concat", func(b *testing.B) {
+        for b.Loop() {
+            _ = "a" + "b" + "c"
+        }
+    })
+
+    b.Run("Builder", func(b *testing.B) {
+        for b.Loop() {
+            var builder strings.Builder
+            builder.WriteString("a")
+            builder.WriteString("b")
+            builder.WriteString("c")
+            _ = builder.String()
+        }
+    })
+}
+```
+
+#### DON'T: Access Non-Existent Loop Variable
+
+```go
+// Bad - no loop variable with testing.B.Loop()
+func BenchmarkBad(b *testing.B) {
+    for b.Loop() {
+        // Can't use i here - it doesn't exist
+        fmt.Println(i) // Compile error
+    }
+}
+
+// Good - use traditional loop if you need the index
+func BenchmarkWithIndex(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        if i%100 == 0 {
+            // Do something every 100 iterations
+        }
+    }
+}
+```
+
+#### DON'T: Mix with RunParallel
+
+```go
+// Wrong - use pb.Next() with RunParallel
+func BenchmarkParallel(b *testing.B) {
+    b.RunParallel(func(pb *testing.PB) {
+        for b.Loop() { // Wrong! Use pb.Next()
+            process()
+        }
+    })
+}
+
+// Correct
+func BenchmarkParallel(b *testing.B) {
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() { // Correct
+            process()
+        }
+    })
+}
+```
+
+### Performance Characteristics
+
+The `testing.B.Loop()` method provides the same performance as traditional loops while offering:
+
+- **Better Compiler Optimization**: Simpler loop structure allows for better optimizations
+- **Reduced Overhead**: Eliminates unnecessary loop variable management
+- **Consistent Behavior**: Same iteration count as `for i := 0; i < b.N; i++`
+
+### Branch-Specific Guidelines
+
+#### Main Branch
+
+- ✅ Use `testing.B.Loop()` for all new benchmarks
+- ✅ Refactor existing benchmarks when convenient
+- ✅ Both styles acceptable during transition
+
+#### stable-1-go-1.24
+
+- ✅ Use `testing.B.Loop()` for all new benchmarks
+- ✅ Migration encouraged but not required
+
+#### stable-1-go-1.23
+
+- ❌ Cannot use `testing.B.Loop()` (not available)
+- ✅ Continue using traditional loop syntax
+
+### Compatibility Check
+
+Ensure your code targets the correct Go version:
+
+```go
+// In go.mod
+go 1.24  // Required for testing.B.Loop()
+```
+
+```go
+// In benchmark file (optional build tag)
+//go:build go1.24
+
+package mypackage
+
+import "testing"
+
+func BenchmarkModern(b *testing.B) {
+    for b.Loop() {
+        // Modern benchmark code
+    }
+}
+```
+
+## Filesystem Isolation with os.Root() (Go 1.25+)
+
+> **Availability**: Go 1.25+ only. Not available on Go 1.23 or 1.24.
+
+### Overview
+
+The `os.Root()` API introduced in Go 1.25 provides secure filesystem isolation by creating a restricted view of the filesystem rooted at a specific directory. This is critical for sandboxing untrusted code, implementing secure file operations, and preventing path traversal attacks.
+
+### Why Use os.Root()?
+
+- **Security Sandboxing**: Prevent access to files outside a designated directory tree
+- **Path Traversal Protection**: Automatically blocks `..` and symlink escapes
+- **Multi-Tenant Isolation**: Safely isolate operations for different users/tenants
+- **Plugin Security**: Sandbox plugin file operations to specific directories
+- **Testing Isolation**: Create isolated filesystem views for tests
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+    // Create a filesystem root at /safe/directory
+    root, err := os.Root("/safe/directory")
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Failed to create root: %v\n", err)
+        return
+    }
+    defer root.Close()
+
+    // All file operations through root are isolated to /safe/directory
+    file, err := root.Open("data.txt") // Actually opens /safe/directory/data.txt
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Failed to open file: %v\n", err)
+        return
+    }
+    defer file.Close()
+
+    // Attempts to escape are blocked
+    _, err = root.Open("../../../etc/passwd") // Returns error, cannot escape
+    if err != nil {
+        fmt.Println("Path traversal blocked (expected)")
+    }
+}
+```
+
+### Complete Example: Sandboxed File Server
+
+```go
+package main
+
+import (
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+    "path/filepath"
+)
+
+// SecureFileServer serves files only from a sandboxed directory
+type SecureFileServer struct {
+    root *os.Root
+}
+
+func NewSecureFileServer(baseDir string) (*SecureFileServer, error) {
+    // Create isolated filesystem view
+    root, err := os.Root(baseDir)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create root: %w", err)
+    }
+
+    return &SecureFileServer{root: root}, nil
+}
+
+func (s *SecureFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // Clean the path but root isolation prevents escapes anyway
+    cleanPath := filepath.Clean(r.URL.Path)
+
+    // Open file through isolated root
+    file, err := s.root.Open(cleanPath)
+    if err != nil {
+        http.Error(w, "File not found", http.StatusNotFound)
+        return
+    }
+    defer file.Close()
+
+    // Get file info for content type detection
+    info, err := file.Stat()
+    if err != nil {
+        http.Error(w, "Internal error", http.StatusInternalServerError)
+        return
+    }
+
+    // Serve the file
+    http.ServeContent(w, r, info.Name(), info.ModTime(), file)
+}
+
+func (s *SecureFileServer) Close() error {
+    return s.root.Close()
+}
+
+func main() {
+    server, err := NewSecureFileServer("/var/www/public")
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Failed to create server: %v\n", err)
+        os.Exit(1)
+    }
+    defer server.Close()
+
+    http.Handle("/files/", server)
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+### Example: Secure Plugin Execution
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+)
+
+type PluginSandbox struct {
+    root      *os.Root
+    pluginID  string
+}
+
+func NewPluginSandbox(pluginID string) (*PluginSandbox, error) {
+    // Create isolated directory for this plugin
+    sandboxDir := filepath.Join("/var/plugins", pluginID)
+    if err := os.MkdirAll(sandboxDir, 0755); err != nil {
+        return nil, fmt.Errorf("failed to create sandbox: %w", err)
+    }
+
+    // Create filesystem root for isolation
+    root, err := os.Root(sandboxDir)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create root: %w", err)
+    }
+
+    return &PluginSandbox{
+        root:     root,
+        pluginID: pluginID,
+    }, nil
+}
+
+// ReadConfig safely reads plugin configuration
+func (s *PluginSandbox) ReadConfig(filename string) ([]byte, error) {
+    file, err := s.root.Open(filename)
+    if err != nil {
+        return nil, fmt.Errorf("config not found: %w", err)
+    }
+    defer file.Close()
+
+    return io.ReadAll(file)
+}
+
+// WriteOutput safely writes plugin output
+func (s *PluginSandbox) WriteOutput(filename string, data []byte) error {
+    file, err := s.root.Create(filename)
+    if err != nil {
+        return fmt.Errorf("failed to create output: %w", err)
+    }
+    defer file.Close()
+
+    _, err = file.Write(data)
+    return err
+}
+
+// ListFiles lists files in the sandbox
+func (s *PluginSandbox) ListFiles() ([]string, error) {
+    dir, err := s.root.Open(".")
+    if err != nil {
+        return nil, err
+    }
+    defer dir.Close()
+
+    entries, err := dir.Readdir(-1)
+    if err != nil {
+        return nil, err
+    }
+
+    var files []string
+    for _, entry := range entries {
+        files = append(files, entry.Name())
+    }
+    return files, nil
+}
+
+func (s *PluginSandbox) Close() error {
+    return s.root.Close()
+}
+```
+
+### Example: Secure Testing Isolation
+
+```go
+package mypackage_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func TestWithIsolatedFS(t *testing.T) {
+    // Create temporary directory for test
+    tempDir := t.TempDir()
+
+    // Create isolated filesystem view
+    root, err := os.Root(tempDir)
+    if err != nil {
+        t.Fatalf("Failed to create root: %v", err)
+    }
+    defer root.Close()
+
+    // Create test files in isolated environment
+    testData := []byte("test content")
+    if err := root.WriteFile("test.txt", testData, 0644); err != nil {
+        t.Fatalf("Failed to write test file: %v", err)
+    }
+
+    // Test file operations in isolation
+    data, err := root.ReadFile("test.txt")
+    if err != nil {
+        t.Fatalf("Failed to read file: %v", err)
+    }
+
+    if string(data) != string(testData) {
+        t.Errorf("Data mismatch: got %q, want %q", data, testData)
+    }
+
+    // Verify path traversal is blocked
+    _, err = root.ReadFile("../../../../../etc/passwd")
+    if err == nil {
+        t.Error("Path traversal should have been blocked")
+    }
+}
+```
+
+### Security Considerations
+
+#### ✅ DO: Use for Untrusted Code
+
+```go
+// Good - isolate untrusted plugin operations
+func executePlugin(pluginPath string) error {
+    root, err := os.Root(filepath.Dir(pluginPath))
+    if err != nil {
+        return err
+    }
+    defer root.Close()
+
+    // Plugin can only access files within its directory
+    return runPluginInSandbox(root, filepath.Base(pluginPath))
+}
+```
+
+#### ✅ DO: Validate Before Creating Root
+
+```go
+// Good - validate directory exists and is safe
+func createSafeRoot(path string) (*os.Root, error) {
+    // Ensure path exists
+    info, err := os.Stat(path)
+    if err != nil {
+        return nil, fmt.Errorf("invalid path: %w", err)
+    }
+
+    // Ensure it's a directory
+    if !info.IsDir() {
+        return nil, fmt.Errorf("path is not a directory: %s", path)
+    }
+
+    // Create isolated root
+    return os.Root(path)
+}
+```
+
+#### ✅ DO: Always Close Roots
+
+```go
+// Good - clean up root when done
+root, err := os.Root("/sandbox")
+if err != nil {
+    return err
+}
+defer root.Close() // Always clean up
+
+// Use root for operations
+```
+
+#### ❌ DON'T: Trust User-Provided Paths Without Validation
+
+```go
+// Bad - no validation of user input
+func openUserFile(userPath string) error {
+    root, _ := os.Root(userPath) // Could be anything!
+    defer root.Close()
+    // ...
+}
+
+// Good - validate user input first
+func openUserFile(userPath string) error {
+    // Validate path is within allowed directory
+    allowedBase := "/var/user-data"
+    cleanPath := filepath.Clean(userPath)
+    if !filepath.HasPrefix(cleanPath, allowedBase) {
+        return fmt.Errorf("path outside allowed directory")
+    }
+
+    root, err := os.Root(cleanPath)
+    if err != nil {
+        return err
+    }
+    defer root.Close()
+    // ...
+}
+```
+
+#### ❌ DON'T: Assume Root Prevents All Attacks
+
+```go
+// Bad - root isolation doesn't prevent logic errors
+func processFile(filename string) error {
+    root, _ := os.Root("/data")
+    defer root.Close()
+
+    // Still vulnerable to logic errors:
+    // - SQL injection if filename used in queries
+    // - Command injection if filename passed to exec
+    // - Resource exhaustion if file is huge
+
+    file, _ := root.Open(filename)
+    // ... process file without size limits (bad!)
+}
+
+// Good - combine root isolation with other security measures
+func processFile(filename string) error {
+    root, err := os.Root("/data")
+    if err != nil {
+        return err
+    }
+    defer root.Close()
+
+    // Validate filename
+    if err := validateFilename(filename); err != nil {
+        return err
+    }
+
+    file, err := root.Open(filename)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    // Check file size before processing
+    info, err := file.Stat()
+    if err != nil {
+        return err
+    }
+    if info.Size() > maxFileSize {
+        return fmt.Errorf("file too large: %d bytes", info.Size())
+    }
+
+    // Process with limits
+    return processWithLimits(file, info.Size())
+}
+```
+
+### Performance Characteristics
+
+The `os.Root()` API provides:
+
+- **Minimal Overhead**: Root creation is lightweight (similar to opening a directory)
+- **No Path Rewriting**: Operations are enforced at the kernel level where possible
+- **Efficient Checking**: Path validation happens once at root creation
+- **Scalable**: Multiple roots can coexist for different isolation contexts
+
+### Branch-Specific Guidelines
+
+#### Main Branch (Go 1.25+)
+
+- ✅ Use `os.Root()` for all sandboxing operations
+- ✅ Refactor existing sandboxing code to use `os.Root()`
+- ✅ Document security benefits in code comments
+
+#### stable-1-go-1.24 and stable-1-go-1.23
+
+- ❌ Cannot use `os.Root()` (not available)
+- ✅ Use alternative approaches:
+  - Manual path validation with `filepath.Clean()` and prefix checking
+  - chroot (Unix-specific, requires privileges)
+  - Container-level isolation
+  - Third-party libraries like `securejoin`
+
+### Compatibility Check
+
+```go
+// In go.mod
+go 1.25  // Required for os.Root()
+```
+
+```go
+// With build tags for version-specific code
+//go:build go1.25
+
+package secure
+
+import "os"
+
+func CreateSandbox(dir string) (*os.Root, error) {
+    return os.Root(dir)
+}
+```
+
+```go
+// Fallback for older versions
+//go:build !go1.25
+
+package secure
+
+import (
+    "fmt"
+    "os"
+)
+
+type Root struct {
+    basePath string
+}
+
+func (r *Root) Close() error {
+    return nil
+}
+
+func CreateSandbox(dir string) (*Root, error) {
+    // Fallback implementation using manual validation
+    return &Root{basePath: dir}, nil
+}
+```
+
+### Migration from Manual Path Validation
+
+**Before (Go 1.24 and earlier):**
+
+```go
+func openSandboxedFile(baseDir, filename string) (*os.File, error) {
+    // Manual validation required
+    cleanPath := filepath.Clean(filename)
+    if filepath.IsAbs(cleanPath) {
+        return nil, fmt.Errorf("absolute paths not allowed")
+    }
+
+    fullPath := filepath.Join(baseDir, cleanPath)
+    if !strings.HasPrefix(fullPath, baseDir) {
+        return nil, fmt.Errorf("path escapes base directory")
+    }
+
+    return os.Open(fullPath)
+}
+```
+
+**After (Go 1.25+):**
+
+```go
+func openSandboxedFile(baseDir, filename string) (*os.File, error) {
+    root, err := os.Root(baseDir)
+    if err != nil {
+        return nil, err
+    }
+    defer root.Close()
+
+    // Root automatically prevents escapes
+    return root.Open(filename)
+}
+```
+
+### Integration with Existing Security Practices
+
+#### Combine with Capabilities
+
+```go
+import (
+    "os"
+    "syscall"
+)
+
+// Drop privileges and create sandbox
+func createSecureSandbox(dir string) (*os.Root, error) {
+    // Drop unnecessary capabilities (Unix)
+    if err := dropCapabilities(); err != nil {
+        return nil, err
+    }
+
+    // Create filesystem isolation
+    return os.Root(dir)
+}
+
+func dropCapabilities() error {
+    // Implementation depends on platform
+    // Use syscall or x/sys/unix for capability management
+    return nil
+}
+```
+
+#### Combine with Resource Limits
+
+```go
+import (
+    "os"
+    "syscall"
+)
+
+// Create sandbox with resource limits
+type SandboxConfig struct {
+    BaseDir     string
+    MaxFileSize int64
+    MaxFiles    int
+}
+
+func CreateLimitedSandbox(cfg SandboxConfig) (*os.Root, error) {
+    // Set resource limits
+    var rlimit syscall.Rlimit
+    rlimit.Cur = uint64(cfg.MaxFiles)
+    rlimit.Max = uint64(cfg.MaxFiles)
+    if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
+        return nil, fmt.Errorf("failed to set file limit: %w", err)
+    }
+
+    // Create filesystem isolation
+    return os.Root(cfg.BaseDir)
+}
+```
+
+## Generic Optimization and Type Parameters (Go 1.25+)
+
+> **Availability**: Go 1.25+ includes significant generic optimizations. Type parameters available since Go 1.18, but performance improved in 1.25.
+
+### Overview
+
+Go 1.25 brings major improvements to generics performance through:
+
+- **Core Types Removal**: Simplified type parameter constraints (breaking change from Go 1.18-1.24)
+- **Better Type Inference**: Reduced need for explicit type arguments
+- **Performance Optimizations**: Dictionary-based implementation improvements
+- **Reduced Code Bloat**: Better monomorphization strategies
+
+### What Changed in Go 1.25
+
+#### Core Types Constraint Simplification
+
+**Before (Go 1.18-1.24):**
+
+```go
+// Old syntax with core types
+type Integer interface {
+    ~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type Signed interface {
+    ~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Complex approximation constraints
+type Stringer interface {
+    ~string
+}
+```
+
+**After (Go 1.25+):**
+
+```go
+// Simplified constraints - no tilde operator needed for basic cases
+type Integer interface {
+    int | int8 | int16 | int32 | int64
+}
+
+type Signed interface {
+    int | int8 | int16 | int32 | int64
+}
+
+// More natural constraint syntax
+type Stringer interface {
+    string
+}
+
+// Tilde still available for underlying type matching when needed
+type CustomInt interface {
+    ~int  // Still works: matches int and types with underlying type int
+}
+```
+
+### Generic Function Optimization
+
+#### Example: Generic Slice Utilities
+
+**Optimized Generic Functions (Go 1.25):**
+
+```go
+package sliceutil
+
+// Map applies a function to each element
+// Go 1.25: Better type inference, reduced allocations
+func Map[T, U any](slice []T, fn func(T) U) []U {
+    result := make([]U, len(slice))
+    for i, v := range slice {
+        result[i] = fn(v)
+    }
+    return result
+}
+
+// Filter returns elements matching predicate
+// Go 1.25: Optimized for common types (int, string, etc.)
+func Filter[T any](slice []T, predicate func(T) bool) []T {
+    result := make([]T, 0, len(slice))
+    for _, v := range slice {
+        if predicate(v) {
+            result = append(result, v)
+        }
+    }
+    return result
+}
+
+// Reduce combines elements using a function
+func Reduce[T, U any](slice []T, initial U, fn func(U, T) U) U {
+    result := initial
+    for _, v := range slice {
+        result = fn(result, v)
+    }
+    return result
+}
+
+// Contains checks if slice contains element
+// Go 1.25: Compiler can optimize for comparable types
+func Contains[T comparable](slice []T, value T) bool {
+    for _, v := range slice {
+        if v == value {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**Usage Examples:**
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    numbers := []int{1, 2, 3, 4, 5}
+
+    // Type inference works better in Go 1.25
+    doubled := Map(numbers, func(n int) int {
+        return n * 2
+    })
+    fmt.Println(doubled) // [2 4 6 8 10]
+
+    // Even works without explicit types
+    evens := Filter(numbers, func(n int) bool {
+        return n%2 == 0
+    })
+    fmt.Println(evens) // [2 4]
+
+    // Type inference across different types
+    sum := Reduce(numbers, 0, func(acc, n int) int {
+        return acc + n
+    })
+    fmt.Println(sum) // 15
+}
+```
+
+### Enhanced Type Inference
+
+**Go 1.25 improvements:**
+
+```go
+// Complex generic function
+func Transform[T, U, V any](input []T, f1 func(T) U, f2 func(U) V) []V {
+    temp := make([]U, len(input))
+    for i, v := range input {
+        temp[i] = f1(v)
+    }
+
+    result := make([]V, len(temp))
+    for i, v := range temp {
+        result[i] = f2(v)
+    }
+    return result
+}
+
+// Go 1.25: Type inference works without explicit type arguments
+numbers := []int{1, 2, 3}
+result := Transform(
+    numbers,
+    func(n int) string { return fmt.Sprint(n) },
+    func(s string) bool { return len(s) > 0 },
+)
+// result is []bool, fully inferred
+
+// Go 1.24 and earlier often required:
+// result := Transform[int, string, bool](numbers, ...)
+```
+
+### Generic Data Structures
+
+#### Example: Type-Safe Cache
+
+```go
+package cache
+
+import (
+    "sync"
+    "time"
+)
+
+// Cache is a generic thread-safe cache with expiration
+// Go 1.25: Optimized for common key/value types
+type Cache[K comparable, V any] struct {
+    mu      sync.RWMutex
+    items   map[K]*cacheItem[V]
+    ttl     time.Duration
+}
+
+type cacheItem[V any] struct {
+    value      V
+    expiration time.Time
+}
+
+func NewCache[K comparable, V any](ttl time.Duration) *Cache[K, V] {
+    c := &Cache[K, V]{
+        items: make(map[K]*cacheItem[V]),
+        ttl:   ttl,
+    }
+    go c.cleanup()
+    return c
+}
+
+func (c *Cache[K, V]) Set(key K, value V) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+
+    c.items[key] = &cacheItem[V]{
+        value:      value,
+        expiration: time.Now().Add(c.ttl),
+    }
+}
+
+func (c *Cache[K, V]) Get(key K) (V, bool) {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+
+    item, exists := c.items[key]
+    if !exists {
+        var zero V
+        return zero, false
+    }
+
+    if time.Now().After(item.expiration) {
+        var zero V
+        return zero, false
+    }
+
+    return item.value, true
+}
+
+func (c *Cache[K, V]) cleanup() {
+    ticker := time.NewTicker(c.ttl)
+    defer ticker.Stop()
+
+    for range ticker.C {
+        c.mu.Lock()
+        now := time.Now()
+        for key, item := range c.items {
+            if now.After(item.expiration) {
+                delete(c.items, key)
+            }
+        }
+        c.mu.Unlock()
+    }
+}
+```
+
+**Usage:**
+
+```go
+// Type inference makes this clean
+userCache := NewCache[string, User](5 * time.Minute)
+userCache.Set("user123", User{Name: "Alice", Age: 30})
+
+if user, found := userCache.Get("user123"); found {
+    fmt.Printf("Found user: %s\n", user.Name)
+}
+
+// Works with any comparable key and any value type
+intCache := NewCache[int, []string](1 * time.Hour)
+intCache.Set(42, []string{"foo", "bar"})
+```
+
+### Performance Best Practices
+
+#### ✅ DO: Use Concrete Types for Hot Paths
+
+```go
+// Good - use generics for API flexibility
+func ProcessData[T any](data []T, processor func(T) T) []T {
+    result := make([]T, len(data))
+    for i, v := range data {
+        result[i] = processor(v)
+    }
+    return result
+}
+
+// Better - use concrete type for performance-critical inner loop
+func ProcessIntegers(data []int, processor func(int) int) []int {
+    result := make([]int, len(data))
+    for i, v := range data {
+        result[i] = processor(v)
+    }
+    return result
+}
+
+// Best - provide both: generic for API, concrete for performance
+func Process[T any](data []T, processor func(T) T) []T {
+    return ProcessData(data, processor)
+}
+
+// Specialized version for common case
+func ProcessInt(data []int, processor func(int) int) []int {
+    return ProcessIntegers(data, processor)
+}
+```
+
+#### ✅ DO: Constrain Type Parameters Appropriately
+
+```go
+// Good - specific constraint enables optimization
+func Sum[T constraints.Integer](values []T) T {
+    var sum T
+    for _, v := range values {
+        sum += v
+    }
+    return sum
+}
+
+// Good - comparable enables map usage
+func Unique[T comparable](slice []T) []T {
+    seen := make(map[T]bool)
+    result := make([]T, 0)
+
+    for _, v := range slice {
+        if !seen[v] {
+            seen[v] = true
+            result = append(result, v)
+        }
+    }
+    return result
+}
+```
+
+#### ✅ DO: Preallocate Slices with Known Capacity
+
+```go
+// Good - preallocate for known size
+func Map[T, U any](slice []T, fn func(T) U) []U {
+    result := make([]U, len(slice)) // Exact size
+    for i, v := range slice {
+        result[i] = fn(v)
+    }
+    return result
+}
+
+// Good - preallocate with capacity hint
+func Filter[T any](slice []T, predicate func(T) bool) []T {
+    result := make([]T, 0, len(slice)) // Capacity hint
+    for _, v := range slice {
+        if predicate(v) {
+            result = append(result, v)
+        }
+    }
+    return result
+}
+```
+
+#### ❌ DON'T: Over-Genericize Simple Functions
+
+```go
+// Bad - unnecessary generics for simple case
+func Add[T constraints.Integer](a, b T) T {
+    return a + b
+}
+
+// Good - just use int or int64
+func Add(a, b int) int {
+    return a + b
+}
+
+// Or if you really need multiple types, use concrete overloads
+func AddInt(a, b int) int { return a + b }
+func AddInt64(a, b int64) int64 { return a + b }
+```
+
+#### ❌ DON'T: Use `any` When More Specific Constraint Exists
+
+```go
+// Bad - too permissive
+func Max[T any](a, b T) T {
+    // Can't compare T without constraint
+    // Requires reflection or panic
+}
+
+// Good - use appropriate constraint
+func Max[T constraints.Ordered](a, b T) T {
+    if a > b {
+        return a
+    }
+    return b
+}
+```
+
+### Common Generic Patterns
+
+#### Option Type
+
+```go
+package option
+
+// Option represents an optional value
+type Option[T any] struct {
+    value T
+    valid bool
+}
+
+func Some[T any](value T) Option[T] {
+    return Option[T]{value: value, valid: true}
+}
+
+func None[T any]() Option[T] {
+    return Option[T]{valid: false}
+}
+
+func (o Option[T]) IsSome() bool {
+    return o.valid
+}
+
+func (o Option[T]) IsNone() bool {
+    return !o.valid
+}
+
+func (o Option[T]) Unwrap() T {
+    if !o.valid {
+        panic("called Unwrap on None")
+    }
+    return o.value
+}
+
+func (o Option[T]) UnwrapOr(defaultValue T) T {
+    if !o.valid {
+        return defaultValue
+    }
+    return o.value
+}
+
+func (o Option[T]) Map[U any](fn func(T) U) Option[U] {
+    if !o.valid {
+        return None[U]()
+    }
+    return Some(fn(o.value))
+}
+```
+
+**Usage:**
+
+```go
+func FindUser(id string) Option[User] {
+    user, found := userCache.Get(id)
+    if !found {
+        return None[User]()
+    }
+    return Some(user)
+}
+
+// Chain operations
+result := FindUser("123").
+    Map(func(u User) string { return u.Email }).
+    UnwrapOr("no-email@example.com")
+```
+
+#### Result Type
+
+```go
+package result
+
+// Result represents success or failure
+type Result[T any] struct {
+    value T
+    err   error
+}
+
+func Ok[T any](value T) Result[T] {
+    return Result[T]{value: value}
+}
+
+func Err[T any](err error) Result[T] {
+    return Result[T]{err: err}
+}
+
+func (r Result[T]) IsOk() bool {
+    return r.err == nil
+}
+
+func (r Result[T]) IsErr() bool {
+    return r.err != nil
+}
+
+func (r Result[T]) Unwrap() (T, error) {
+    return r.value, r.err
+}
+
+func (r Result[T]) Map[U any](fn func(T) U) Result[U] {
+    if r.err != nil {
+        return Err[U](r.err)
+    }
+    return Ok(fn(r.value))
+}
+
+func (r Result[T]) AndThen[U any](fn func(T) Result[U]) Result[U] {
+    if r.err != nil {
+        return Err[U](r.err)
+    }
+    return fn(r.value)
+}
+```
+
+### Migration from Pre-1.25 Generics
+
+**If you have existing generic code from Go 1.18-1.24:**
+
+1. **Review Core Types Usage**: The `~` operator behavior is more refined in Go 1.25
+2. **Test Performance**: Many generic operations are faster in 1.25
+3. **Simplify Constraints**: Remove unnecessary `~` operators where applicable
+4. **Leverage Better Inference**: Remove explicit type arguments where inference now works
+
+**Example Migration:**
+
+```go
+// Go 1.24 code
+type Number interface {
+    ~int | ~int64 | ~float64
+}
+
+func Sum[T Number](values []T) T {
+    var sum T
+    for _, v := range values {
+        sum += v
+    }
+    return sum
+}
+
+// Usage required explicit types
+result := Sum[int]([]int{1, 2, 3})
+```
+
+```go
+// Go 1.25 optimized
+import "golang.org/x/exp/constraints"
+
+func Sum[T constraints.Integer | constraints.Float](values []T) T {
+    var sum T
+    for _, v := range values {
+        sum += v
+    }
+    return sum
+}
+
+// Better type inference
+result := Sum([]int{1, 2, 3}) // Type inferred
+```
+
+### Branch-Specific Guidelines
+
+#### Main Branch (Go 1.25+)
+
+- ✅ Use optimized generics freely
+- ✅ Leverage improved type inference
+- ✅ Benchmark generic vs concrete for hot paths
+- ✅ Use standard constraint packages from `golang.org/x/exp/constraints`
+
+#### stable-1-go-1.24 and stable-1-go-1.23
+
+- ✅ Generics available but less optimized
+- ⚠️ More explicit type arguments may be required
+- ⚠️ Consider concrete types for performance-critical code
+- ⚠️ Core types constraints work differently
+
+### Performance Characteristics
+
+**Go 1.25 improvements:**
+
+- **10-30% faster** generic function calls for common types
+- **Reduced memory allocations** in generic data structures
+- **Better inlining** of generic functions
+- **Smaller binary sizes** due to improved monomorphization
+
+**Benchmark before and after:**
+
+```go
+// Benchmark generic operations
+func BenchmarkGenericMap(b *testing.B) {
+    data := make([]int, 1000)
+    for i := range data {
+        data[i] = i
+    }
+
+    for b.Loop() {
+        _ = Map(data, func(n int) int { return n * 2 })
+    }
+}
+
+// Go 1.24: ~500 ns/op
+// Go 1.25: ~350 ns/op (30% improvement)
+```
+
+### Compatibility Check
+
+```go
+// In go.mod
+go 1.25  // Required for optimized generics
+```
+
+```go
+// Use build tags for version-specific optimizations
+//go:build go1.25
+
+package mypackage
+
+// Go 1.25-specific optimized generic implementation
+```
+
+## Integer Range Iteration (Go 1.25+)
+
+> **Availability**: Go 1.25+ only. Not available on Go 1.23 or 1.24.
+
+### Overview
+
+Go 1.25 introduces a cleaner syntax for iterating over integer ranges using `for i := range n {}` instead of the traditional `for i := 0; i < n; i++` pattern. This simplifies common loop patterns and reduces boilerplate code.
+
+### Basic Syntax
+
+**Traditional Approach (Go 1.23, 1.24):**
+
+```go
+// Old way - manual counter initialization and condition
+for i := 0; i < 10; i++ {
+    fmt.Println(i) // 0 through 9
+}
+```
+
+**Modern Approach (Go 1.25+):**
+
+```go
+// New way - range over integer
+for i := range 10 {
+    fmt.Println(i) // 0 through 9
+}
+```
+
+### Key Benefits
+
+- **Less Boilerplate**: No need to write initialization, condition, and increment
+- **More Readable**: Intent is clearer - "iterate from 0 to n-1"
+- **Consistent Syntax**: Follows existing `range` patterns for slices/maps
+- **Less Error-Prone**: Eliminates off-by-one errors in loop conditions
+
+### Complete Examples
+
+#### Example 1: Simple Iteration
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    // Print numbers 0-4
+    for i := range 5 {
+        fmt.Println(i)
+    }
+    // Output: 0, 1, 2, 3, 4
+}
+```
+
+#### Example 2: Creating Slices
+
+```go
+// Traditional
+func makeSlice(n int) []int {
+    result := make([]int, n)
+    for i := 0; i < n; i++ {
+        result[i] = i * 2
+    }
+    return result
+}
+
+// Go 1.25
+func makeSlice(n int) []int {
+    result := make([]int, n)
+    for i := range n {
+        result[i] = i * 2
+    }
+    return result
+}
+```
+
+#### Example 3: Initializing Arrays
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    var grid [5][5]int
+
+    // Fill grid with coordinates
+    for i := range 5 {
+        for j := range 5 {
+            grid[i][j] = i*10 + j
+        }
+    }
+
+    fmt.Println(grid)
+}
+```
+
+#### Example 4: Batch Processing
+
+```go
+package batch
+
+import "fmt"
+
+// ProcessInBatches processes items in batches
+func ProcessInBatches(items []string, batchSize int) {
+    numBatches := (len(items) + batchSize - 1) / batchSize
+
+    for i := range numBatches {
+        start := i * batchSize
+        end := start + batchSize
+        if end > len(items) {
+            end = len(items)
+        }
+
+        batch := items[start:end]
+        fmt.Printf("Processing batch %d: %v\n", i, batch)
+        processBatch(batch)
+    }
+}
+
+func processBatch(batch []string) {
+    // Process the batch
+    for _, item := range batch {
+        fmt.Printf("  - %s\n", item)
+    }
+}
+```
+
+#### Example 5: Generating Test Data
+
+```go
+package generator
+
+import "fmt"
+
+type User struct {
+    ID   int
+    Name string
+}
+
+// GenerateUsers creates n test users
+func GenerateUsers(n int) []User {
+    users := make([]User, n)
+    for i := range n {
+        users[i] = User{
+            ID:   i + 1,
+            Name: fmt.Sprintf("User%d", i+1),
+        }
+    }
+    return users
+}
+```
+
+#### Example 6: Retry Logic
+
+```go
+package retry
+
+import (
+    "fmt"
+    "time"
+)
+
+// RetryOperation attempts operation up to maxRetries times
+func RetryOperation(maxRetries int, operation func() error) error {
+    for attempt := range maxRetries {
+        err := operation()
+        if err == nil {
+            return nil
+        }
+
+        if attempt < maxRetries-1 {
+            backoff := time.Duration(attempt+1) * time.Second
+            fmt.Printf("Attempt %d failed: %v. Retrying in %v...\n",
+                attempt+1, err, backoff)
+            time.Sleep(backoff)
+        }
+    }
+
+    return fmt.Errorf("operation failed after %d attempts", maxRetries)
+}
+```
+
+### When to Use
+
+#### ✅ Use Integer Range When
+
+- **Simple counter loops**: Iterating a fixed number of times
+- **Zero-based sequences**: When you need 0, 1, 2, ..., n-1
+- **Array/slice initialization**: Filling arrays with computed values
+- **Batch processing**: Dividing work into n chunks
+- **Retry logic**: Fixed number of retry attempts
+- **Test data generation**: Creating n test objects
+
+#### ❌ Use Traditional Loop When
+
+- **Non-zero start**: Loops that don't start at 0
+- **Custom increment**: Loops with step != 1 (e.g., `i += 2`)
+- **Complex conditions**: Conditions beyond simple `i < n`
+- **Counting backwards**: Descending loops
+- **Need loop variable modification**: Changing `i` inside loop body
+
+### Comparison Examples
+
+#### Simple Counting
+
+```go
+// Traditional - more verbose
+for i := 0; i < 10; i++ {
+    fmt.Println(i)
+}
+
+// Go 1.25 - cleaner
+for i := range 10 {
+    fmt.Println(i)
+}
+```
+
+#### Custom Start (Still Use Traditional)
+
+```go
+// Traditional - necessary when not starting at 0
+for i := 5; i < 10; i++ {
+    fmt.Println(i)
+}
+
+// Can't use range for this - it always starts at 0
+```
+
+#### Custom Step (Still Use Traditional)
+
+```go
+// Traditional - necessary for step != 1
+for i := 0; i < 10; i += 2 {
+    fmt.Println(i) // 0, 2, 4, 6, 8
+}
+
+// Can't use range for this
+```
+
+#### Countdown (Still Use Traditional)
+
+```go
+// Traditional - necessary for descending
+for i := 10; i > 0; i-- {
+    fmt.Println(i)
+}
+
+// Can't use range for descending loops
+```
+
+### Best Practices
+
+#### ✅ DO: Use for Simple 0-to-n Loops
+
+```go
+// Good - clear and concise
+for i := range count {
+    process(i)
+}
+```
+
+#### ✅ DO: Use with Variables
+
+```go
+// Good - works with any integer expression
+n := calculateSize()
+for i := range n {
+    items[i] = createItem(i)
+}
+```
+
+#### ✅ DO: Use for Nested Loops
+
+```go
+// Good - clear coordinate iteration
+for i := range height {
+    for j := range width {
+        grid[i][j] = compute(i, j)
+    }
+}
+```
+
+#### ❌ DON'T: Use When Traditional is Clearer
+
+```go
+// Bad - adding offset makes it less clear
+for i := range 10 {
+    process(i + 5) // Unclear start point
+}
+
+// Good - explicit start value
+for i := 5; i < 15; i++ {
+    process(i)
+}
+```
+
+#### ❌ DON'T: Use with Magic Numbers
+
+```go
+// Bad - unclear what 100 means
+for i := range 100 {
+    process(i)
+}
+
+// Good - use named constant
+const maxItems = 100
+for i := range maxItems {
+    process(i)
+}
+```
+
+### Performance Characteristics
+
+The integer range syntax has identical performance to traditional loops:
+
+- **Zero Overhead**: Compiles to the same machine code
+- **Same Optimization**: Compiler optimizations apply equally
+- **No Allocations**: No heap allocations for the counter
+
+```go
+// Both have identical performance
+func benchTraditional(n int) int {
+    sum := 0
+    for i := 0; i < n; i++ {
+        sum += i
+    }
+    return sum
+}
+
+func benchRange(n int) int {
+    sum := 0
+    for i := range n {
+        sum += i
+    }
+    return sum
+}
+
+// Benchmark results are identical
+```
+
+### Migration Strategy
+
+#### Gradual Migration
+
+Use build tags to support both versions during transition:
+
+```go
+//go:build go1.25
+
+package mypackage
+
+func initialize(items []int) {
+    for i := range len(items) {
+        items[i] = i
+    }
+}
+```
+
+```go
+//go:build !go1.25
+
+package mypackage
+
+func initialize(items []int) {
+    for i := 0; i < len(items); i++ {
+        items[i] = i
+    }
+}
+```
+
+#### Complete Migration
+
+When targeting Go 1.25+ exclusively:
+
+1. **Find candidates**: Search for simple `for i := 0; i < n; i++` patterns
+2. **Verify simplicity**: Ensure no custom start/step/condition
+3. **Replace systematically**: Convert to `for i := range n`
+4. **Test thoroughly**: Verify behavior unchanged
+
+```bash
+# Find potential candidates (review each manually)
+grep -rn "for [a-z] := 0; [a-z] <" . --include="*.go"
+```
+
+### Common Patterns
+
+#### Pattern 1: Array Initialization
+
+```go
+// Initialize array with index values
+var data [100]int
+for i := range len(data) {
+    data[i] = i
+}
+```
+
+#### Pattern 2: Parallel Processing
+
+```go
+package parallel
+
+import "sync"
+
+func ProcessParallel(n int, worker func(int)) {
+    var wg sync.WaitGroup
+
+    for i := range n {
+        wg.Add(1)
+        go func(id int) {
+            defer wg.Done()
+            worker(id)
+        }(i)
+    }
+
+    wg.Wait()
+}
+```
+
+#### Pattern 3: Timed Operations
+
+```go
+package timer
+
+import "time"
+
+// RunNTimes executes function n times with delay
+func RunNTimes(n int, delay time.Duration, fn func(int)) {
+    for i := range n {
+        fn(i)
+        if i < n-1 {
+            time.Sleep(delay)
+        }
+    }
+}
+```
+
+#### Pattern 4: Matrix Operations
+
+```go
+package matrix
+
+type Matrix [][]float64
+
+// NewMatrix creates n×m matrix
+func NewMatrix(rows, cols int) Matrix {
+    m := make(Matrix, rows)
+    for i := range rows {
+        m[i] = make([]float64, cols)
+    }
+    return m
+}
+
+// Identity creates n×n identity matrix
+func Identity(n int) Matrix {
+    m := NewMatrix(n, n)
+    for i := range n {
+        m[i][i] = 1.0
+    }
+    return m
+}
+```
+
+### Branch-Specific Guidelines
+
+#### Main Branch (Go 1.25+)
+
+- ✅ Use integer range syntax for simple 0-to-n loops
+- ✅ Refactor existing code when convenient
+- ✅ Document the pattern in code reviews
+- ✅ Both styles acceptable during transition
+
+#### stable-1-go-1.24 and stable-1-go-1.23
+
+- ❌ Cannot use integer range syntax (not available)
+- ✅ Continue using traditional `for i := 0; i < n; i++`
+- ✅ Use named constants to improve readability
+
+### Edge Cases and Gotchas
+
+#### Zero Iterations
+
+```go
+// Both handle zero iterations identically
+for i := range 0 {
+    fmt.Println("Never executed")
+}
+
+for i := 0; i < 0; i++ {
+    fmt.Println("Never executed")
+}
+```
+
+#### Negative Values
+
+```go
+// Range with negative n
+n := -5
+for i := range n {
+    // Loop doesn't execute (same as range 0)
+    fmt.Println("Never executed")
+}
+```
+
+#### Large Values
+
+```go
+// Works with large integers
+const billion = 1_000_000_000
+for i := range billion {
+    // Iterates 1 billion times
+    // Be careful with large values!
+}
+```
+
+#### Variable Shadowing
+
+```go
+// Be careful with scope
+i := 42
+for i := range 10 {
+    // This i shadows outer i
+    fmt.Println(i) // Prints 0-9, not 42
+}
+fmt.Println(i) // Still 42
+```
+
+### Compatibility Check
+
+```go
+// In go.mod
+go 1.25  // Required for integer range syntax
+```
+
+```go
+// With build tags
+//go:build go1.25
+
+package mypackage
+
+func example() {
+    for i := range 10 {
+        // Go 1.25+ code
+    }
+}
+```
+
+### Complete Real-World Example
+
+```go
+package scheduler
+
+import (
+    "fmt"
+    "time"
+)
+
+type Task struct {
+    ID       int
+    Name     string
+    Duration time.Duration
+}
+
+// ScheduleTasks creates and schedules n tasks
+func ScheduleTasks(n int, baseDuration time.Duration) []Task {
+    tasks := make([]Task, n)
+
+    for i := range n {
+        tasks[i] = Task{
+            ID:       i + 1,
+            Name:     fmt.Sprintf("Task-%d", i+1),
+            Duration: baseDuration * time.Duration(i+1),
+        }
+    }
+
+    return tasks
+}
+
+// ExecuteTasks runs tasks in sequence
+func ExecuteTasks(tasks []Task) {
+    for i := range len(tasks) {
+        task := tasks[i]
+        fmt.Printf("Starting %s (duration: %v)\n", task.Name, task.Duration)
+        time.Sleep(task.Duration)
+        fmt.Printf("Completed %s\n", task.Name)
+    }
+}
+
+func main() {
+    tasks := ScheduleTasks(5, 100*time.Millisecond)
+    ExecuteTasks(tasks)
+}
+```
+
+This covers the essential Go style guidelines including formatting, naming conventions, package organization, error handling, function design, struct design, concurrency, comments, and testing best practices.

--- a/.github/instructions/html-css.instructions.md
+++ b/.github/instructions/html-css.instructions.md
@@ -1,0 +1,63 @@
+<!-- file: .github/instructions/html-css.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: 2d1e0f9a-8b7c-6d5e-4f3a-2b1c0d9e8f7a -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.{html,css}"
+description: |
+  Coding, documentation, and workflow rules for HTML and CSS files, following Google HTML/CSS style guide and general project rules. Reference this for all HTML and CSS code, documentation, and formatting in this repository. All unique content from the Google HTML/CSS Style Guide is merged here.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# HTML/CSS Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html)
+  for additional best practices.
+- All HTML and CSS files must begin with the required file header (see general
+  instructions for details and HTML/CSS example).
+
+## Core Principles
+
+- Consistency: Follow the same conventions throughout the project
+- Readability: Write code that is easy to read and understand
+- Maintainability: Code should be easy to modify and extend
+- Performance: Consider the impact on page load times and rendering
+- Accessibility: Ensure content is accessible to all users
+
+## HTML Guidelines
+
+- Use HTML5 doctype: `<!DOCTYPE html>`
+- Use valid HTML, validate with W3C tools
+- Use UTF-8 encoding: `<meta charset="utf-8" />`
+- Use semantic HTML and accessible markup
+- Use 2 spaces for indentation, lowercase for tags/attributes, double quotes for
+  attribute values
+- Provide alternative content for multimedia
+- Use appropriate input types and labels in forms
+
+## CSS Guidelines
+
+- Use valid CSS, validate with W3C tools
+- Use meaningful, lowercase, hyphen-separated class and ID names
+- Avoid presentational names
+- Use shorthand properties when possible
+- Avoid qualifying class names with type selectors unless necessary
+
+## Required File Header
+
+All HTML and CSS files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for CSS:
+
+```css
+/* file: path/to/file.css */
+/* version: 1.0.0 */
+/* guid: 123e4567-e89b-12d3-a456-426614174000 */
+```

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,0 +1,290 @@
+<!-- file: .github/instructions/javascript.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: 8e7d6c5b-4a3c-2d1e-0f9a-8b7c6d5e4f3a -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.{js,jsx}"
+description: |
+  JavaScript language-specific coding, documentation, and testing rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and merge all unique content from the Google
+JavaScript Style Guide.
+
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# JavaScript Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)
+  for additional best practices.
+- All JavaScript files must begin with the required file header (see general
+  instructions for details and JavaScript example).
+
+## File Structure
+
+- Use `camelCase` for file names
+- Each file should contain exactly one ES module
+- Prefer ES6 modules (`import`/`export`) over other module systems
+
+## Formatting
+
+- Use 2 spaces for indentation
+- Line length maximum of 80 characters
+- Use semicolons to terminate statements
+- Use single quotes for string literals
+- Add trailing commas for multi-line object/array literals
+- Use parentheses only where required for clarity or priority
+
+## Naming Conventions
+
+- `functionNamesLikeThis`, `variableNamesLikeThis`, `ClassNamesLikeThis`,
+  `EnumNamesLikeThis`, `methodNamesLikeThis`, `CONSTANT_VALUES_LIKE_THIS`,
+  `private_values_with_underscore`, `package-names-like-this`
+
+## Comments
+
+- Use JSDoc for documentation
+- Comment all non-obvious code sections
+
+## Language Features
+
+- Use `const` and `let` instead of `var`
+- Use arrow functions for anonymous functions, especially callbacks
+- Use template literals instead of string concatenation
+- Use object/array destructuring where it improves readability
+- Use default parameters instead of conditional statements
+- Use spread operator and rest parameters where appropriate
+
+## Best Practices
+
+- Avoid using the global scope
+- Avoid deeply nested code blocks
+- Use early returns to reduce nesting
+- Limit line length to improve readability
+- Separate logic and display concerns
+
+## Error Handling
+
+- Always handle Promise rejections
+- Use try/catch blocks appropriately
+- Provide useful error messages
+
+## Testing
+
+- Write unit tests for all code
+- Use descriptive test names
+- Follow AAA pattern (Arrange, Act, Assert)
+
+## Required File Header
+
+All JavaScript files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for
+JavaScript:
+
+```js
+// file: path/to/file.js
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+```
+
+## Google JavaScript Style Guide (Complete)
+
+Follow the complete Google JavaScript Style Guide below for all JavaScript code:
+
+### Google JavaScript Style Guide (Complete)
+
+This style guide provides comprehensive conventions for writing clean, readable, and maintainable JavaScript code.
+
+#### Source File Basics
+
+**File Name:** File names must be all lowercase and may include underscores (`_`) or dashes (`-`), but no additional punctuation. Filenames' extension must be `.js`.
+
+**File Encoding:** Source files are encoded in UTF-8.
+
+**Special Characters:**
+
+- Use ASCII horizontal space character (0x20) as the only whitespace character
+- Tab characters are not used for indentation
+- Use special escape sequences (`\'`, `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`) rather than numeric escapes
+- For non-ASCII characters, use actual Unicode character or equivalent hex/Unicode escape based on readability
+
+#### Source File Structure
+
+All files follow this order:
+
+1. License or copyright information (if present)
+2. `@fileoverview` JSDoc (if present)
+3. `goog.module` statement or ES `import` statements
+4. `goog.require` and `goog.requireType` statements
+5. The file's implementation
+
+**ES Module Guidelines:**
+
+- Use `import` statement for ES module files
+- File extension `.js` is required in import paths
+- Module import names use `lowerCamelCase` derived from imported file name
+- Prefer named exports over default exports
+- Exported variables must not be mutated outside module initialization
+
+#### Formatting
+
+**Braces:**
+
+- Braces required for all control structures
+- Follow K&R style (Egyptian brackets)
+- No line break before opening brace
+- Line break after opening brace and before closing brace
+
+**Indentation:**
+
+- Use +2 spaces for block indentation
+- Array and object literals may be formatted as block-like constructs
+- Function expressions indented +2 from preceding indentation
+
+**Statements:**
+
+- One statement per line
+- Semicolons are required
+
+**Column Limit:**
+
+- 80 characters maximum
+- Exceptions: `goog.module`, `goog.require`, ES module statements, long URLs, shell commands, file paths
+
+**Line Wrapping:**
+
+- Break at higher syntactic level when possible
+- Operators: break comes after the symbol
+- Continuation lines indented at least +4 spaces
+- Method/constructor names stay with opening parenthesis
+
+**Whitespace:**
+
+- Single blank line between consecutive methods
+- Space after reserved words before parenthesis (except `function` and `super`)
+- Space before opening curly brace
+- Space on both sides of binary/ternary operators
+- Space after comma or semicolon
+- No trailing whitespace
+
+#### Language Features
+
+**Variable Declarations:**
+
+- Use `const` by default, `let` when reassignment needed
+- Never use `var`
+- One variable per declaration
+- Declare close to first use
+- JSDoc type annotations when needed
+
+**Arrays:**
+
+- Use trailing commas with line breaks
+- Use array literals `[]` instead of `new Array()`
+- Use spread operator instead of `Array.prototype` methods
+- Destructuring allowed with default values
+
+**Objects:**
+
+- Use trailing commas with line breaks
+- Use object literals `{}` instead of `new Object()`
+- Don't mix quoted and unquoted keys
+- Method shorthand allowed: `{method() {...}}`
+- Shorthand properties allowed: `{foo, bar}`
+- Computed property names allowed for dict-style
+
+**Classes:**
+
+- Define all fields in constructor
+- Annotate fields with `@const`, `@private`, `@protected` as appropriate
+- Computed properties only for symbols
+- Prefer module-local functions over private static methods
+- Use `@override` annotation for overridden methods
+
+**Functions:**
+
+- Arrow functions preferred for nested functions and callbacks
+- Use `function` keyword for top-level functions and methods
+- Default parameters allowed with `=` operator
+- Rest parameters with `...` prefix
+- Generators: attach `*` to `function` keyword
+
+**Strings:**
+
+- Use single quotes for ordinary strings
+- Template literals for complex concatenation or multi-line strings
+- No line continuations with backslash
+
+**Control Structures:**
+
+- Use `for-of` loops when possible
+- Empty catch blocks must have explanatory comment
+- Switch statements: comment fall-through, include default case
+
+**Equality:**
+
+- Use `===` and `!==`
+- Exception: `== null` to catch both null and undefined
+
+#### Naming Conventions
+
+- **Package names:** `lowerCamelCase`
+- **Class names:** `UpperCamelCase`
+- **Method names:** `lowerCamelCase`, verbs or verb phrases
+- **Enum names:** `UpperCamelCase`, items in `CONSTANT_CASE`
+- **Constants:** `CONSTANT_CASE` for module-level constants
+- **Fields:** `lowerCamelCase`, optional trailing underscore for private
+- **Parameters:** `lowerCamelCase`
+- **Local variables:** `lowerCamelCase`
+
+#### JSDoc Requirements
+
+**General Form:**
+
+```javascript
+/**
+ * Multiple lines of JSDoc text are written here,
+ * wrapped normally.
+ * @param {number} arg A number to do something to.
+ */
+function doSomething(arg) { ... }
+```
+
+**Required Documentation:**
+
+- All classes, interfaces, and records
+- All public methods and functions
+- All enum and typedef declarations
+- Parameter and return types (except same-signature overrides)
+
+**Type Annotations:**
+
+- Use `!` for non-null, `?` for nullable reference types
+- Primitives are non-nullable by default
+- Always specify template parameters
+- Function type expressions: always specify return type
+
+#### Disallowed Features
+
+- `with` keyword
+- `eval` or `Function(...string)` constructor
+- Non-standard features or proprietary extensions
+- Wrapper objects for primitives (`new Boolean`, `new Number`, etc.)
+- Modifying builtin objects
+- Omitting parentheses when invoking constructors
+
+#### Best Practices
+
+- Use descriptive names, avoid abbreviations
+- Prefer consistency when style guide doesn't specify
+- Use compiler warnings and address them appropriately
+- Mark deprecated code with `@deprecated` annotation
+- Extract methods or variables instead of line-wrapping when possible
+- Use horizontal alignment sparingly
+- Prefer clear code over clever code

--- a/.github/instructions/json.instructions.md
+++ b/.github/instructions/json.instructions.md
@@ -1,0 +1,49 @@
+<!-- file: .github/instructions/json.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: 3c2d1e0f-9a8b-7c6d-5e4f-3a2b1c0d9e8f -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.json"
+description: |
+  Coding, documentation, and workflow rules for JSON files, following Google JSON style guide and general project rules. Reference this for all JSON code, documentation, and formatting in this repository. All unique content from the Google JSON Style Guide is merged here.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# JSON Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml)
+  for additional best practices.
+- All JSON files must begin with the required file header (see general
+  instructions for details and JSON example).
+
+## Core Principles
+
+- Consistency: Follow the same conventions throughout all JSON files
+- Readability: Format JSON to be easily readable by humans
+- Validity: Ensure all JSON is well-formed and valid
+- Clarity: Use meaningful property names and structure
+- Simplicity: Keep JSON structure as simple as possible
+
+## General Guidelines
+
+- Use proper JSON syntax as defined by RFC 7159
+- Use UTF-8 encoding
+- Property names must be camelCase, meaningful, and descriptive
+- Avoid JavaScript reserved words as property names
+- Use appropriate JSON data types (string, number, boolean, array, object, null)
+- Use double quotes for all strings
+- Use 2 spaces for indentation
+- Omit properties that don't apply or aren't available
+- Write clear, concise, and valid JSON
+
+## Required File Header
+
+Files with the `.json` extension (JSON without comments), which are exempt from this requirement and do not require a file header.

--- a/.github/instructions/jsonc.instructions.md
+++ b/.github/instructions/jsonc.instructions.md
@@ -1,0 +1,59 @@
+<!-- file: .github/instructions/json.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: a7b8c9d0-e1f2-3456-7890-1a2b3c4d5e6f -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.jsonc"
+description: |
+  Coding, documentation, and workflow rules for JSON files, following Google JSON style guide and general project rules. Reference this for all JSON code, documentation, and formatting in this repository. All unique content from the Google JSON Style Guide is merged here.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# JSON Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml)
+  for additional best practices.
+- All JSON files must begin with the required file header (see general
+  instructions for details and JSON example).
+
+## Core Principles
+
+- Consistency: Follow the same conventions throughout all JSON files
+- Readability: Format JSON to be easily readable by humans
+- Validity: Ensure all JSON is well-formed and valid
+- Clarity: Use meaningful property names and structure
+- Simplicity: Keep JSON structure as simple as possible
+
+## General Guidelines
+
+- Use proper JSON syntax as defined by RFC 7159
+- Use UTF-8 encoding
+- Property names must be camelCase, meaningful, and descriptive
+- Avoid JavaScript reserved words as property names
+- Use appropriate JSON data types (string, number, boolean, array, object, null)
+- Use double quotes for all strings
+- Use 2 spaces for indentation
+- Omit properties that don't apply or aren't available
+- Write clear, concise, and valid JSON
+
+## Required File Header
+
+All JSONC files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). The **only
+exception** is files with the `.json` extension (JSON without comments), which
+are exempt from this requirement and do not require a file header. For standard
+`.jsonc` files, include the following header:
+
+```jsonc
+// file: path/to/file.jsonc
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+```

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -1,0 +1,121 @@
+<!-- file: .github/instructions/markdown.instructions.md -->
+<!-- version: 1.3.0 -->
+<!-- guid: e2f8a5b1-9c4d-4e2f-8a5b-4d9c8a5b1e2f -->
+<!-- last-edited: 2026-07-16 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.md"
+description: |
+  Markdown formatting, documentation, and style rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and merge all unique content from the Google Markdown Style Guide.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Markdown Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google Markdown Style Guide](https://github.com/google/styleguide/blob/gh-pages/docguide/style.md)
+  for additional best practices.
+- All Markdown files must begin with the required file header (see general
+  instructions for details and Markdown example).
+- **Exception:** changelog fragments under `changelog.d/` (excluding its
+  `README.md`) are exempt from the file-header rule. Their contents are
+  concatenated verbatim into `CHANGELOG.md` by
+  [`scriv`](https://scriv.readthedocs.io/), so a header would leak into the
+  changelog. See `changelog.d/README.md`.
+
+## File Structure and Organization
+
+- Use lowercase letters and hyphens for file names
+- Start with a single H1 heading (document title)
+- Use hierarchical heading structure (H1 → H2 → H3)
+- Include table of contents for long documents
+- End with references/links section if applicable
+
+## Heading Guidelines
+
+- Use descriptive, specific headings
+- Maintain consistent capitalization
+- Avoid punctuation in headings except question marks
+- Keep headings concise but informative
+
+## Text Formatting
+
+- Use bold for UI elements, commands, strong emphasis
+- Use italics for definitions, foreign words, light emphasis
+- Use inline code for variables, functions, file names
+- Use code blocks with language specification
+
+## Links and References
+
+- Use descriptive link text, avoid "click here" or "read more"
+
+## Lists and Structure
+
+- Use hyphens (`-`) for unordered lists
+- Use numbers with periods for ordered lists
+- Use task lists for actionable items
+
+## Tables
+
+- Use proper alignment with pipes (`|`)
+- Include header row with separator
+- Align columns consistently
+
+## Code Documentation
+
+- Always specify language for syntax highlighting
+- Use descriptive comments in code examples
+- Keep examples concise but complete
+
+## Images and Media
+
+- Use descriptive alt text
+- Use relative paths for local images
+- Optimize images for web
+
+## Line Length and Whitespace
+
+- Aim for 80-100 characters per line
+- One blank line between major sections
+- No trailing whitespace at line ends
+
+## Special Elements
+
+- Use blockquotes for quotes, callouts, or emphasized content
+- Use horizontal rules for major document sections
+- Use footnotes for additional information or citations
+
+## Accessibility Guidelines
+
+- Provide meaningful alt text for images
+- Use proper heading hierarchy for screen readers
+- Use lists for grouped information
+
+## Validation and Quality
+
+- Write clear, concise sentences
+- Use active voice when possible
+- Maintain consistent tone and style
+- Proofread for grammar and spelling
+- Validate Markdown syntax with linters
+- Test links to ensure they work
+- Check code examples for accuracy
+
+## Required File Header
+
+All Markdown files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for
+Markdown:
+
+```markdown
+<!-- file: path/to/file.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 123e4567-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+```

--- a/.github/instructions/protobuf.instructions.md
+++ b/.github/instructions/protobuf.instructions.md
@@ -1,0 +1,784 @@
+<!-- file: .github/instructions/protobuf.instructions.md -->
+<!-- version: 3.0.1 -->
+<!-- guid: 7d6c5b4a-3c2d-1e0f-9a8b-7c6d5e4f3a2b -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.proto"
+description: |
+  Protocol Buffers (protobuf) style and documentation rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and implement comprehensive protobuf best practices including the 1-1-1 design pattern, Edition 2023 features, and Google's style guide.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Protobuf Coding Instructions
+
+## Core Principles
+
+- Follow the [general coding instructions](general-coding.instructions.md)
+- Follow the
+  [Google Protobuf Style Guide](https://protobuf.dev/programming-guides/style/)
+- Implement the
+  [1-1-1 Best Practice](https://protobuf.dev/best-practices/1-1-1/) - one
+  top-level entity per file
+- Use [Edition 2023](https://protobuf.dev/programming-guides/editions/) for all
+  new files
+- Follow [Proto Best Practices](https://protobuf.dev/best-practices/dos-donts/)
+
+## Required File Header
+
+All protobuf files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md):
+
+```protobuf
+// file: path/to/file.proto
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+
+edition = "2023";
+
+package your.package.name;
+
+option go_package = "github.com/owner/repo/path/to/package;packagepb";
+```
+
+## Edition 2023 Requirements
+
+- **MANDATORY**: All proto files MUST use `edition = "2023";` as the first
+  non-comment line
+- Enhanced features with better defaults and future-proofing
+- Improved validation and hybrid API support
+- Better backwards compatibility with proto2/proto3
+
+## 1-1-1 Design Pattern (MANDATORY)
+
+Each protobuf file contains exactly ONE of:
+
+- One message definition
+- One enum definition
+- One service definition
+
+### Benefits
+
+- **Modularity**: Easy to find and modify specific types
+- **Dependency Management**: Clear import relationships
+- **Code Generation**: Cleaner generated code
+- **Team Collaboration**: Reduces merge conflicts
+- **Build Optimization**: Smaller transitive dependencies
+
+### File Organization Structure
+
+```
+pkg/module/proto/
+├── types/             # Basic types for import (shared)
+│   ├── status.proto   # Common enums
+│   ├── error.proto    # Error types
+│   └── metadata.proto # Metadata structures
+├── messages/          # 1-1-1 message definitions
+│   ├── user_info.proto
+│   └── config_data.proto
+├── enums/             # 1-1-1 enum definitions
+│   ├── user_status.proto
+│   └── priority_level.proto
+├── services/          # 1-1-1 service definitions
+│   ├── auth_service.proto
+│   └── user_service.proto
+├── requests/          # Request message definitions
+│   ├── create_user_request.proto
+│   └── get_user_request.proto
+└── responses/         # Response message definitions
+    ├── create_user_response.proto
+    └── get_user_response.proto
+```
+
+## Naming Conventions
+
+### CRITICAL: Module Prefix Strategy for Avoiding Conflicts
+
+**Problem**: Multiple packages can have similar message names, causing import conflicts and confusion.
+
+**Solution**: Use consistent module prefixes for all message types to ensure uniqueness across the entire project.
+
+### Module Prefix Rules (MANDATORY)
+
+1. **All messages MUST include module prefix**: `{Module}{MessageName}`
+2. **Consistent prefixing**: Either ALL messages in a module have prefixes OR NONE do
+3. **Module prefix examples**:
+   - Auth module: `AuthUserInfo`, `AuthSessionData`, `AuthLoginRequest`
+   - Subtitle module: `SubtitleRecord`, `SubtitleMetadata`, `SubtitleSearchRequest`
+   - Metrics module: `MetricsHealthStatus`, `MetricsBatchOptions`, `MetricsTimeRange`
+   - Common module: `CommonError`, `CommonPagination`, `CommonFilterOptions`
+
+### Module Prefix Mapping
+
+| Module | Prefix | Examples |
+|--------|--------|----------|
+| `auth` | `Auth` | `AuthUserInfo`, `AuthSessionData`, `AuthLoginRequest` |
+| `subtitle` | `Subtitle` | `SubtitleRecord`, `SubtitleMetadata`, `SubtitleProcessingJob` |
+| `metrics` | `Metrics` | `MetricsHealthStatus`, `MetricsBatchOptions`, `MetricsCollectionData` |
+| `common` | `Common` | `CommonError`, `CommonPagination`, `CommonFilterOptions` |
+| `health` | `Health` | `HealthCheckResult`, `HealthServiceStatus`, `HealthMonitorConfig` |
+| `queue` | `Queue` | `QueueSubscriptionInfo`, `QueueMessage`, `QueueConfiguration` |
+| `database` | `Database` | `DatabaseHealthStatus`, `DatabaseConnection`, `DatabaseMigration` |
+| `web` | `Web` | `WebHealthResponse`, `WebConfiguration`, `WebRouteInfo` |
+
+### Files
+
+- Use `lower_snake_case.proto` for filenames
+- **Services**: `{service_name}_service.proto`
+- **Messages**: `{message_name}.proto` (snake_case, WITHOUT module prefix in filename)
+- **Enums**: `{enum_name}.proto` (snake_case)
+- **Types**: `{type_category}.proto` for shared types
+
+**Examples**:
+
+```
+pkg/auth/proto/
+├── user_info.proto          # Contains: message AuthUserInfo
+├── session_data.proto       # Contains: message AuthSessionData
+├── login_request.proto      # Contains: message AuthLoginRequest
+└── auth_service.proto       # Contains: service AuthService
+```
+
+### Packages
+
+- Use dot-delimited `lower_snake_case`: `gcommon.v1.auth`
+- Format: `{project}.{version}.{module}`
+- Example: `gcommon.v1.subtitle`, `myproject.v2.storage`
+
+### Messages (UPDATED FOR CONFLICT PREVENTION)
+
+- Use `TitleCase` for message names
+- **MANDATORY**: Include module prefix: `{Module}{MessageName}`
+- **Examples**:
+  - ✅ `AuthUserInfo`, `AuthSessionData`, `AuthLoginRequest`
+  - ✅ `SubtitleRecord`, `SubtitleMetadata`, `SubtitleSearchRequest`
+  - ✅ `MetricsHealthStatus`, `MetricsBatchOptions`, `MetricsTimeRange`
+  - ❌ `UserInfo`, `SessionData`, `LoginRequest` (missing prefix)
+
+### Exception: Service Names and Simple Enums
+
+- **Services**: Use module name only: `AuthService`, `SubtitleService`, `MetricsService`
+- **Simple Enums**: May omit prefix if context is clear and no conflicts exist
+- **Complex Enums**: Use prefix for clarity: `AuthUserStatus`, `SubtitleProcessingStatus`
+
+### Fields
+
+- Use `snake_case` for field names
+- Use pluralized names for repeated fields
+- Example: `user_name = 1`, `user_emails = 2`
+
+### Enums
+
+- Use `TitleCase` for enum type names (with module prefix if needed)
+- Use `UPPER_SNAKE_CASE` for enum values
+- **MANDATORY**: First value must be `{ENUM_NAME}_UNSPECIFIED = 0`
+
+```protobuf
+// Simple enum (no conflicts expected)
+enum UserStatus {
+  USER_STATUS_UNSPECIFIED = 0;
+  USER_STATUS_ACTIVE = 1;
+  USER_STATUS_INACTIVE = 2;
+  USER_STATUS_SUSPENDED = 3;
+}
+
+// Complex enum (potential conflicts, use prefix)
+enum AuthProviderType {
+  AUTH_PROVIDER_TYPE_UNSPECIFIED = 0;
+  AUTH_PROVIDER_TYPE_LOCAL = 1;
+  AUTH_PROVIDER_TYPE_OAUTH2 = 2;
+  AUTH_PROVIDER_TYPE_SAML = 3;
+}
+```
+
+### Services
+
+- Use `TitleCase` for service and method names
+- Service names: `{Module}Service` - Example: `AuthService`, `SubtitleService`
+- Method names: Standard verbs without module prefix - Example: `GetUser`, `CreateSession`, `DeleteRecord`
+
+## Import Guidelines
+
+### Import Order (MANDATORY)
+
+1. **Standard Google imports first**:
+
+   ```protobuf
+   import "google/protobuf/timestamp.proto";
+   import "google/protobuf/duration.proto";
+   import "google/protobuf/any.proto";
+   ```
+
+2. **Types imports second** (from types/ directory):
+
+   ```protobuf
+   import "pkg/common/proto/types/error_types.proto";
+   import "pkg/auth/proto/types/user_status.proto";
+   ```
+
+3. **Other module imports third**:
+
+   ```protobuf
+   import "pkg/auth/proto/messages/user_info.proto";
+   import "pkg/config/proto/messages/config_data.proto";
+   ```
+
+## Message Design Patterns
+
+### Standard Field Number Allocation
+
+```protobuf
+message ExampleMessage {
+  // Required/primary fields (1-15) - single byte encoding
+  string id = 1;
+  string name = 2;
+
+  // Secondary fields (16-50)
+  string description = 16;
+  map<string, string> metadata = 17;
+
+  // Timestamps (51-60)
+  google.protobuf.Timestamp created_at = 51;
+  google.protobuf.Timestamp updated_at = 52;
+
+  // Status/state fields (61-70)
+  Status status = 61;
+  Error error = 62;
+
+  // Extension range (if needed)
+  extensions 1000 to max;
+}
+```
+
+### Request/Response Pattern
+
+```protobuf
+// Request message
+message CreateUserRequest {
+  UserInfo user_info = 1;
+  CreateOptions options = 2;
+  google.protobuf.Timestamp request_time = 51;
+}
+
+// Response message
+message CreateUserResponse {
+  UserInfo user = 1;
+  ResponseStatus status = 2;
+  Error error = 3;
+  google.protobuf.Timestamp response_time = 51;
+}
+```
+
+### Service Definition Pattern
+
+```protobuf
+service UserService {
+  // Standard CRUD operations
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+  rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+
+  // List operation with pagination
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
+}
+```
+
+## Types Package Strategy
+
+### Purpose
+
+The `types/` directory contains fundamental, reusable types imported by other
+protobuf files.
+
+### Implementation Pattern
+
+1. **Define Basic Types First** in `types/`:
+
+   ```protobuf
+   // pkg/auth/proto/types/user_status.proto
+   edition = "2023";
+   package gcommon.v1.auth;
+
+   enum UserStatus {
+     USER_STATUS_UNSPECIFIED = 0;
+     USER_STATUS_ACTIVE = 1;
+     USER_STATUS_INACTIVE = 2;
+   }
+   ```
+
+2. **Import Types in Messages**:
+
+   ```protobuf
+   // pkg/auth/proto/messages/user_info.proto
+   edition = "2023";
+   package gcommon.v1.auth;
+
+   import "pkg/auth/proto/types/user_status.proto";
+
+   message UserInfo {
+     string user_id = 1;
+     UserStatus status = 2;  // Imported type
+   }
+   ```
+
+3. **Avoid Duplication Rules**:
+   - **NEVER** redefine types that exist in `types/`
+   - **ALWAYS** import from canonical `types/` location
+   - **CHECK** existing types before creating new ones
+
+## Edition 2023 Features
+
+### Enhanced Default Values
+
+```protobuf
+// Explicit default values for singular fields
+int32 result_per_page = 3 [default = 10];
+string status = 4 [default = "pending"];
+```
+
+### Improved Field Presence
+
+**CRITICAL: Edition 2023 Field Presence Rules**
+
+In Edition 2023, the `optional` label is **NOT ALLOWED**. Instead, use
+`option features.field_presence` to control field presence:
+
+```protobuf
+// ❌ WRONG - Do NOT use 'optional' label in Edition 2023
+optional string confidence_score = 1;
+optional string parent_id = 2;
+
+// ✅ CORRECT - Use features.field_presence instead
+string confidence_score = 1 [features.field_presence = EXPLICIT];
+string parent_id = 2 [features.field_presence = EXPLICIT];
+
+// ✅ CORRECT - Default implicit presence (most common)
+string user_id = 3;  // Implicit presence (default behavior)
+string name = 4;     // Implicit presence (default behavior)
+```
+
+**Field Presence Options:**
+
+- `EXPLICIT` - Field can be unset/null (equivalent to old `optional`)
+- `IMPLICIT` - Field always has a value (default behavior)
+- `LEGACY_REQUIRED` - Field must be set (proto2 style)
+
+**When to Use EXPLICIT Presence:**
+
+- Optional configuration values
+- Nullable database fields
+- Fields that may not be available in all contexts
+- Fields where "unset" vs "default value" matters
+
+```protobuf
+message SubtitleRecord {
+  string id = 1;                                           // Always present
+  string content = 2;                                      // Always present
+  double confidence_score = 3 [features.field_presence = EXPLICIT];  // May be unset
+  string parent_id = 4 [features.field_presence = EXPLICIT];         // May be unset
+}
+```
+
+### Better Validation
+
+```protobuf
+// Built-in validation rules
+string email = 1 [(validate.rules).string.pattern = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"];
+int32 age = 2 [(validate.rules).int32.gte = 0];
+```
+
+## Documentation Requirements
+
+### File-Level Documentation
+
+```protobuf
+// file: pkg/auth/proto/messages/user_info.proto
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+
+edition = "2023";
+
+// Package auth provides authentication and authorization protobuf definitions.
+// This package follows the 1-1-1 pattern with one message per file.
+package gcommon.v1.auth;
+
+option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
+```
+
+### Message Documentation
+
+```protobuf
+// UserInfo represents a user account with authentication details.
+// This message contains sensitive PII and should be handled according
+// to data protection policies.
+message UserInfo {
+  // Unique identifier for the user account.
+  // Format: UUID v4 (36 characters including hyphens).
+  string user_id = 1;
+
+  // Current status of the user account.
+  // Determines what actions the user can perform.
+  UserStatus status = 2;
+
+  // User's email address used for authentication.
+  // Must be a valid email format and unique across the system.
+  string email = 3;
+}
+```
+
+### Enum Documentation
+
+```protobuf
+// UserStatus defines the possible states of a user account.
+// These states control access permissions and available operations.
+enum UserStatus {
+  // Default unspecified state. Should not be used in practice.
+  USER_STATUS_UNSPECIFIED = 0;
+
+  // User account is active and fully functional.
+  // User can perform all authorized operations.
+  USER_STATUS_ACTIVE = 1;
+
+  // User account is temporarily inactive.
+  // User cannot log in but data is preserved.
+  USER_STATUS_INACTIVE = 2;
+
+  // User account is suspended due to policy violation.
+  // Requires admin intervention to reactivate.
+  USER_STATUS_SUSPENDED = 3;
+}
+```
+
+### Service Documentation
+
+```protobuf
+// AuthService provides user authentication and authorization operations.
+// All methods require appropriate permissions and rate limiting applies.
+service AuthService {
+  // Authenticates a user with email and password.
+  // Returns JWT token on successful authentication.
+  //
+  // Rate limit: 10 requests per minute per IP
+  // Requires: Valid email/password combination
+  // Returns: JWT token valid for 24 hours
+  rpc Login(LoginRequest) returns (LoginResponse);
+
+  // Validates an existing JWT token.
+  // Returns user information if token is valid.
+  //
+  // Rate limit: 100 requests per minute per user
+  // Requires: Valid JWT token in Authorization header
+  // Returns: User information and token validity
+  rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse);
+}
+```
+
+## Common Patterns and Best Practices
+
+### Avoiding Common Naming Conflicts
+
+#### High-Conflict Type Names (Always Use Prefixes)
+
+- `HealthStatus` → `{Module}HealthStatus` (auth, database, metrics, web, etc.)
+- `Configuration` → `{Module}Configuration`
+- `Metadata` → `{Module}Metadata`
+- `Status` → `{Module}Status`
+- `Info` → `{Module}Info`
+- `Request`/`Response` → `{Module}{Action}Request`/`{Module}{Action}Response`
+- `Error` → `{Module}Error` or use `CommonError`
+
+#### Low-Conflict Type Names (Prefixes Recommended)
+
+- Domain-specific terms: `SubtitleRecord`, `AuthToken`, `MetricValue`
+- Action-specific: `LoginAttempt`, `ProcessingJob`, `SearchQuery`
+
+#### Safe Type Names (Prefixes Optional)
+
+- Very specific domain terms: `TranscriptionSegment`, `OAuth2Configuration`
+- Highly technical terms: `WebRTCConfiguration`, `DatabaseMigration`
+
+### Cross-Module Dependencies
+
+#### Using Common Types
+
+```protobuf
+// In auth module - import common types
+import "pkg/common/proto/error.proto";
+import "pkg/common/proto/pagination.proto";
+
+message AuthUserListResponse {
+  repeated AuthUserInfo users = 1;
+  CommonPagination pagination = 2;    // Use common type
+  CommonError error = 3;              // Use common type
+}
+```
+
+#### Avoiding Circular Dependencies
+
+```protobuf
+// ❌ WRONG: auth imports subtitle, subtitle imports auth
+// pkg/auth/proto/user_info.proto
+import "pkg/subtitle/proto/subtitle_record.proto";  // Creates cycle
+
+// ✅ CORRECT: Use common types for shared concepts
+// pkg/common/proto/user_reference.proto
+message CommonUserReference {
+  string user_id = 1;
+  string display_name = 2;
+}
+
+// Both modules can import the common type
+import "pkg/common/proto/user_reference.proto";
+```
+
+### Error Handling
+
+```protobuf
+// Standard error message structure (in common module)
+message CommonError {
+  // Error code following gRPC status codes
+  int32 code = 1;
+
+  // Human-readable error message
+  string message = 2;
+
+  // Additional error details
+  google.protobuf.Any details = 3;
+
+  // Error occurrence timestamp
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+// Module-specific error details
+message AuthErrorDetails {
+  AuthErrorCode auth_code = 1;
+  int32 remaining_attempts = 2;
+  google.protobuf.Duration lockout_duration = 3;
+}
+```
+
+### Pagination
+
+```protobuf
+message ListUsersRequest {
+  // Maximum number of users to return (1-100)
+  int32 page_size = 1 [default = 50];
+
+  // Token for retrieving next page of results
+  string page_token = 2;
+
+  // Optional filter criteria
+  string filter = 3;
+}
+
+message ListUsersResponse {
+  // List of users for current page
+  repeated UserInfo users = 1;
+
+  // Token for next page (empty if last page)
+  string next_page_token = 2;
+
+  // Total number of users matching filter
+  int32 total_count = 3;
+}
+```
+
+### Versioning Strategy
+
+```protobuf
+// Use package versioning for API versions
+package gcommon.v1.auth;  // Version 1
+package gcommon.v2.auth;  // Version 2 (breaking changes)
+
+// Use field deprecation for non-breaking changes
+message UserInfo {
+  string user_id = 1;
+  string email = 2;
+  string old_field = 3 [deprecated = true];  // Mark as deprecated
+  string new_field = 4;                      // Add new field
+}
+```
+
+## Build Integration
+
+### buf.yaml Configuration
+
+```yaml
+version: v1
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - DEFAULT
+    - COMMENTS
+    - FILE_LOWER_SNAKE_CASE
+```
+
+### buf.gen.yaml Configuration
+
+```yaml
+version: v1
+plugins:
+  - plugin: buf.build/protocolbuffers/go
+    out: .
+    opt:
+      - paths=source_relative
+      - module=github.com/jdfalk/gcommon
+  - plugin: buf.build/grpc/go
+    out: .
+    opt:
+      - paths=source_relative
+      - require_unimplemented_servers=false
+```
+
+## Validation Commands
+
+### Local Testing
+
+```bash
+# Lint specific file
+buf lint path/to/file.proto
+
+# Lint entire module
+buf lint --path pkg/module/proto/
+
+# Generate code
+buf generate
+
+# Check for breaking changes
+buf breaking --against '.git#branch=main'
+```
+
+### Integration Testing
+
+```bash
+# Test Go code generation
+go build ./...
+
+# Test imports
+go mod tidy
+
+# Validate no circular dependencies
+go mod graph | grep -E ".*->.*->.*"
+```
+
+## Migration Guidelines
+
+### Addressing Existing Naming Inconsistencies
+
+**Current Issue**: The codebase has inconsistent naming where some types use module prefixes (`AuthSessionTimei`, `MetricsHealthStatus`) while others don't (`SessionSummary`, `UserInfo`).
+
+**Migration Strategy**:
+
+1. **Audit Phase**: Identify all messages without module prefixes
+2. **Gradual Migration**: Add prefixes to new messages immediately, migrate existing ones over time
+3. **Deprecation Path**: Use field deprecation to maintain backwards compatibility
+
+### Migration Priority Order
+
+#### Phase 1: High-Risk Conflicts (Immediate)
+
+- Messages that exist in multiple modules with same name
+- Core types used across many services
+- Public API message types
+
+```protobuf
+// Before: Potential conflict
+message HealthStatus { ... }  // In multiple modules
+
+// After: Clear ownership
+message AuthHealthStatus { ... }     // In auth module
+message MetricsHealthStatus { ... }  // In metrics module
+message DatabaseHealthStatus { ... } // In database module
+```
+
+#### Phase 2: Internal Types (Medium Priority)
+
+- Request/Response messages
+- Configuration types
+- Internal data structures
+
+#### Phase 3: Simple Types (Low Priority)
+
+- Basic enums with clear context
+- Module-specific types with no conflict potential
+
+### Compatibility Preservation
+
+```protobuf
+// Option 1: Field aliasing (backwards compatible)
+message AuthUserInfo {
+  string user_id = 1;
+  string name = 2;
+
+  // Deprecated: Use the fields above instead
+  string old_user_id = 10 [deprecated = true];
+  string old_name = 11 [deprecated = true];
+}
+
+// Option 2: Message aliasing (for major changes)
+// Keep old message as alias during transition
+message UserInfo {
+  option deprecated = true;
+  // Redirect to new message in documentation
+  // "Use AuthUserInfo instead"
+}
+```
+
+### From Proto2/Proto3 to Edition 2023
+
+1. Change `syntax = "proto3";` to `edition = "2023";`
+2. Update package structure to follow 1-1-1 pattern
+3. Move shared types to `types/` directory
+4. **Apply module prefixes to all messages**
+5. Add proper file headers and documentation
+6. Update import statements
+7. Test generated code compatibility
+
+### Breaking Change Checklist
+
+- [ ] Field number changes (NEVER do this)
+- [ ] Field type changes (carefully evaluate)
+- [ ] Message/enum renames (use deprecation first)
+- [ ] **Module prefix addition (plan migration path)**
+- [ ] Package name changes (create new version)
+- [ ] Service method signature changes (add new methods)
+
+## Security Considerations
+
+### Sensitive Data Handling
+
+```protobuf
+// Mark sensitive fields for proper handling
+message UserCredentials {
+  string username = 1;
+
+  // Sensitive: Never log this field
+  string password_hash = 2 [(sensitive) = true];
+
+  // PII: Handle according to data protection policies
+  string email = 3 [(pii) = true];
+}
+```
+
+### Access Control
+
+```protobuf
+// Document security requirements in service methods
+service AdminService {
+  // Requires: ADMIN role and valid session
+  // Audit: Log all calls with user ID and timestamp
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+}
+```
+
+This comprehensive protobuf instruction set ensures consistent, maintainable,
+and scalable protobuf definitions across all projects while following Google's
+best practices and modern Edition 2023 features.

--- a/.github/instructions/pull-request-descriptions.instructions.md
+++ b/.github/instructions/pull-request-descriptions.instructions.md
@@ -1,0 +1,234 @@
+<!-- file: .github/instructions/pull-request-descriptions.instructions.md -->
+<!-- version: 1.3.1 -->
+<!-- guid: pr2d3567-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**"
+description: |
+  Pull request description format rules for all Copilot/AI agents and VS Code Copilot customization. These rules apply to all pull request descriptions and follow the project's documentation standards. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Pull Request Description Instructions
+
+These instructions are the canonical source for all pull request description
+formatting rules in this repository. They are used by GitHub Copilot for pull
+request generation and follow our established standards.
+
+- Follow the [general coding instructions](general-coding.instructions.md) for
+  basic file formatting rules.
+- All PR formatting and workflow rules are found in
+  `.github/instructions/*.instructions.md` files.
+- Document all changes comprehensively in pull request descriptions.
+- For agent/AI-specific instructions, see [AGENTS.md](../AGENTS.md) and related
+  files.
+
+For more details and the full system, see
+[copilot-instructions.md](../copilot-instructions.md).
+
+## Template Structure
+
+Use this template for your pull request descriptions:
+
+```markdown
+## Summary
+
+Brief overview of the entire PR and its purpose
+
+## Summary
+
+Brief overview of the entire PR and its purpose
+
+## Changes Made
+
+### type(scope): description (#issue-number)
+
+**Description:** Detailed explanation of what was done for this specific change
+
+**Files Modified:**
+
+- [`path/to/file1.ext`](./path/to/file1.ext) - Description of changes |
+  [[diff]](../../pull/PR_NUMBER/files#diff-hash)
+  [[repo]](../../blob/main/path/to/file1.ext)
+- [`path/to/file2.ext`](./path/to/file2.ext) - Description of changes |
+  [[diff]](../../pull/PR_NUMBER/files#diff-hash)
+  [[repo]](../../blob/main/path/to/file2.ext)
+
+### type(scope): description (#issue-number)
+
+**Description:** Detailed explanation of what was done for this specific change
+
+**Files Modified:**
+
+- [`path/to/file3.ext`](./path/to/file3.ext) - Description of changes |
+  [[diff]](../../pull/PR_NUMBER/files#diff-hash)
+  [[repo]](../../blob/main/path/to/file3.ext)
+
+_Note: Each distinct functional change (feat, fix, refactor, docs, etc.) gets its own subsection with a conventional commit header. Omit issue numbers from section headers if not working on specific issues. Use `type(scope): description` format instead._
+
+## Testing
+
+How the changes were tested (unit tests, integration tests, manual testing)
+
+## Breaking Changes
+
+(If applicable) List any breaking changes and migration steps
+
+## Additional Notes
+
+Any additional context, screenshots, or important information
+
+## Related Issues
+
+Closes #123, #456, #789
+```
+
+## Guidelines
+
+### Summary Section
+
+- Keep it concise but comprehensive (2-4 sentences)
+- Explain the overall purpose and impact of the PR
+- Use present tense ("add feature" not "added feature")
+
+### Changes Made Section
+
+- **Group changes by type/function**, not by file or issue
+- Use conventional commit format: `type(scope): description (#issue-number)`
+  when working on specific issues
+- Use `type(scope): description` format when not working on specific issues
+- **CRITICAL**: Each distinct functional change (feat, fix, refactor, docs, test, etc.) gets its own subsection with:
+  - Conventional commit header
+  - Detailed description of what was implemented
+  - List of all files modified for that specific issue
+
+### Conventional Commit Types
+
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, no logic changes)
+- `refactor`: Code refactoring (no functional changes)
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks, build changes, etc.
+- `perf`: Performance improvements
+- `ci`: CI/CD changes
+
+### File Links Format
+
+Each file entry should include:
+
+- **File path link**: `[path/to/file.ext](./path/to/file.ext)` - Links to the
+  file in the PR
+- **Description**: What was changed in this file
+- **Additional links**:
+  - `[[diff]]` - Link to the diff view for this specific file
+  - `[[repo]]` - Link to the file in the repository
+
+### Testing Section
+
+- Describe testing approach for each issue/feature
+- Include test coverage information
+- Note any manual testing performed
+- Mention edge cases tested
+
+### Related Issues
+
+- Use GitHub's automatic closing keywords: `Closes #123`, `Fixes #456`,
+  `Resolves #789`
+- Link related but not closed issues with: `Related to #999`
+
+## Example
+
+```markdown
+## Summary
+
+This PR implements user authentication, adds profile management, and updates
+documentation to support the new auth system.
+
+## Changes Made
+
+### feat(auth): implement JWT token validation (#123)
+
+**Description:** Added JWT middleware to secure API endpoints and protect user
+data. Implemented token generation, validation, and refresh functionality.
+
+**Files Modified:**
+
+- [`src/middleware/auth.js`](./src/middleware/auth.js) - JWT validation logic
+  and middleware | [[diff]](../../pull/456/files#diff-abc123)
+  [[repo]](../../blob/main/src/middleware/auth.js)
+- [`src/routes/api.js`](./src/routes/api.js) - Applied auth middleware to
+  protected routes | [[diff]](../../pull/456/files#diff-def456)
+  [[repo]](../../blob/main/src/routes/api.js)
+- [`tests/auth.test.js`](./tests/auth.test.js) - Comprehensive test coverage for
+  auth flow | [[diff]](../../pull/456/files#diff-ghi789)
+  [[repo]](../../blob/main/tests/auth.test.js)
+
+### feat(ui): add user profile page (#456)
+
+**Description:** Created new user profile interface with edit capabilities,
+avatar upload, and preference management.
+
+**Files Modified:**
+
+- [`src/components/UserProfile.jsx`](./src/components/UserProfile.jsx) - Main
+  profile component with edit functionality |
+  [[diff]](../../pull/456/files#diff-jkl012)
+  [[repo]](../../blob/main/src/components/UserProfile.jsx)
+- [`src/styles/profile.css`](./src/styles/profile.css) - Responsive styling for
+  profile page | [[diff]](../../pull/456/files#diff-mno345)
+  [[repo]](../../blob/main/src/styles/profile.css)
+
+### docs(readme): update installation instructions (#789)
+
+**Description:** Updated README with current installation steps and added
+troubleshooting section for auth setup.
+
+**Files Modified:**
+
+- [`README.md`](./README.md) - Updated installation and auth setup documentation
+  | [[diff]](../../pull/456/files#diff-pqr678)
+  [[repo]](../../blob/main/README.md)
+
+## Testing
+
+- **Unit Tests**: Added 15 new tests for auth middleware and profile components
+  (95% coverage)
+- **Integration Tests**: Tested complete auth flow from login to protected
+  resource access
+- **Manual Testing**: Verified UI functionality across Chrome, Firefox, and
+  Safari
+- **Edge Cases**: Tested token expiration, invalid tokens, and network failures
+
+## Breaking Changes
+
+- API endpoints now require authentication headers
+- Migration: Users need to log in again after deployment
+
+## Additional Notes
+
+- JWT tokens expire after 24 hours with automatic refresh
+- Profile images are stored in AWS S3 with CDN caching
+- Added rate limiting to auth endpoints (10 requests/minute)
+
+## Related Issues
+
+Closes #123, #456, #789 Related to #999 (future OAuth implementation)
+```
+
+## Best Practices
+
+1. **One issue per section** - Don't mix unrelated changes
+2. **Accurate file descriptions** - Explain what changed, not just what the file
+   does
+3. **Complete file coverage** - List every modified file with its purpose
+4. **Proper linking** - Ensure all links work and point to correct locations
+5. **Clear testing** - Explain how each feature/fix was verified
+6. **Conventional commits** - Follow the established format consistently

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,2235 @@
+<!-- file: .github/instructions/python.instructions.md -->
+<!-- version: 1.6.0 -->
+<!-- guid: 2a5b7c8d-9e1f-4a2b-8c3d-6e9f1a5b7c8d -->
+<!-- last-edited: 2026-02-09 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.py"
+description: |
+  Python language-specific coding, documentation, and testing rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and merge all unique content from the Google Python Style Guide.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Python Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+  for additional best practices.
+- All Python files must begin with the required file header (see general
+  instructions for details and Python example).
+
+## Version Requirements
+
+- **MANDATORY**: All Python projects must use Python 3.13.0 or higher
+- **NO EXCEPTIONS**: Do not use older Python versions in any repository
+- Update `requirements.txt` files to specify `python>=3.13.0`
+- Update `pyproject.toml` files to specify `requires-python = ">=3.13.0"`
+- Update `setup.py` files to specify `python_requires=">=3.13.0"`
+- Update `.python-version` files to specify `3.13.0` or higher
+- Use `python --version` to verify your installation meets requirements
+- All Python file headers must use version 1.0.0 or higher (following semantic versioning)
+
+## Dependency Management
+
+- Use `pyproject.toml` as the canonical dependency manifest for Python projects
+- Use `uv` wherever possible for dependency resolution, lockfiles, and virtual environments
+- If `requirements.txt` is required for tooling, generate it from `uv` and keep it in sync
+
+## Core Principles
+
+- Be consistent: Follow the established patterns in your codebase
+- Readability counts: Code is read more often than it is written
+- Simple is better than complex: Prefer clarity over cleverness
+- Use tools: Leverage formatters like `ruff`, `black`, and `isort` for
+  consistency
+
+## Language Rules
+
+- Use `pylint` with Google's pylintrc configuration
+- Use absolute imports, never relative
+- Avoid mutable global state
+- Use nested functions only when closing over a local value
+- Use comprehensions for simple cases
+- Use default iterators and operators
+- Use generators as needed
+- Use lambda for one-liners, prefer generator expressions
+- Use properties for simple computations
+- Use implicit false when possible, `if foo is None:` for None checks
+- Do not use mutable objects as default argument values
+- Use 4 spaces for indentation, never tabs
+- Maximum line length is 80 characters
+- Use parentheses for implied line continuation
+- Two blank lines between top-level definitions
+- One blank line between method definitions
+- Use triple-double-quotes for docstrings, Google-style docstring format
+- Use f-strings, `%` operator, or `format()` for formatting
+- Use `with` statements for resource management
+- Use `# TODO:` comments with context
+- Imports on separate lines, grouped stdlib/third-party/local
+- Use descriptive names, avoid single character names
+- Use type annotations where applicable
+- Put main functionality in `main()` and check `if __name__ == '__main__':`
+- Prefer small and focused functions
+
+## Required File Header
+
+All Python files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for
+Python:
+
+```python
+#!/usr/bin/env python3
+# file: path/to/file.py
+# version: 1.0.0
+# guid: 123e4567-e89b-12d3-a456-426614174000
+```
+
+---
+
+## Google Python Style Guide (Complete)
+
+This section contains the complete Google Python Style Guide content for reference.
+
+### 1 Background
+
+Python is the main dynamic language used at Google. This style guide is a list of dos and don'ts for Python programs.
+
+To help you format code correctly, we've created a [settings file for Vim](https://google.github.io/styleguide/google_python_style.vim). For Emacs, the default settings should be fine.
+
+Many teams use the [Black](https://github.com/psf/black) or [Pyink](https://github.com/google/pyink) auto-formatter to avoid arguing over formatting.
+
+### 2 Python Language Rules
+
+#### 2.1 Lint
+
+##### 2.1.1 Definition
+
+`pylint` is a tool for finding bugs and style problems in Python source code. It finds problems that are typically caught by a compiler for less dynamic languages like C and C++. Because of the dynamic nature of Python, some warnings may be incorrect; however, spurious warnings should be fairly infrequent.
+
+##### 2.1.2 Pros
+
+Catches easy-to-miss errors like typos, using-vars-before-assignment, etc.
+
+##### 2.1.3 Cons
+
+`pylint` isn't perfect. To take advantage of it, sometimes we'll need to write around it, suppress its warnings or fix it.
+
+##### 2.1.4 Decision
+
+Make sure you run `pylint` on your code.
+
+Suppress warnings if they are inappropriate so that other issues are not hidden. To suppress warnings, you can set a line-level comment:
+
+```python
+def do_PUT(self):  # WSGI name, so pylint: disable=invalid-name
+  ...
+```
+
+`pylint` warnings are each identified by symbolic name (`empty-docstring`) Google-specific warnings start with `g-`.
+
+If the reason for the suppression is not clear from the symbolic name, add an explanation.
+
+Suppressing in this way has the advantage that we can easily search for suppressions and revisit them.
+
+You can get a list of `pylint` warnings by doing:
+
+```bash
+pylint --list-msgs
+```
+
+To get more information on a particular message, use:
+
+```bash
+pylint --help-msg=invalid-name
+```
+
+Prefer `pylint: disable` to the deprecated older form `pylint: disable-msg`.
+
+Unused argument warnings can be suppressed by deleting the variables at the beginning of the function. Always include a comment explaining why you are deleting it. "Unused." is sufficient. For example:
+
+```python
+def viking_cafe_order(spam: str, beans: str, eggs: str | None = None) -> str:
+    del beans, eggs  # Unused by vikings.
+    return spam + spam + spam
+```
+
+Other common forms of suppressing this warning include using '_' as the identifier for the unused argument or prefixing the argument name with 'unused_', or assigning them to '_'. These forms are allowed but no longer encouraged. These break callers that pass arguments by name and do not enforce that the arguments are actually unused.
+
+Run `pylint` over your code using this [pylintrc](https://google.github.io/styleguide/pylintrc).
+
+#### 2.2 Imports
+
+##### 2.2.1 Definition
+
+Reusability mechanism for sharing code from one module to another.
+
+##### 2.2.2 Pros
+
+The namespace management convention is simple. The source of each identifier is indicated in a consistent way; `x.Obj` says that object `Obj` is defined in module `x`.
+
+##### 2.2.3 Cons
+
+Module names can still collide. Some module names are inconveniently long.
+
+##### 2.2.4 Decision
+
+Use `import` statements for packages and modules only, not for individual types, classes, or functions.
+
+• Use `import x` for importing packages and modules.
+• Use `from x import y` where `x` is the package prefix and `y` is the module name with no prefix.
+• Use `from x import y as z` in any of the following circumstances:
+  ◦ Two modules named `y` are to be imported.
+  ◦ `y` conflicts with a top-level name defined in the current module.
+  ◦ `y` conflicts with a common parameter name that is part of the public API (e.g., `features`).
+  ◦ `y` is an inconveniently long name.
+  ◦ `y` is too generic in the context of your code (e.g., `from storage.file_system import options as fs_options`).
+• Use `import y as z` only when `z` is a standard abbreviation (e.g., `import numpy as np`).
+
+For example the module `sound.effects.echo` may be imported as follows:
+
+```python
+from sound.effects import echo
+...
+echo.EchoFilter(input, output, delay=0.7, atten=4)
+```
+
+Do not use relative names in imports. Even if the module is in the same package, use the full package name. This helps prevent unintentionally importing a package twice.
+
+##### 2.2.4.1 Exemptions
+
+Exemptions from this rule:
+
+• Symbols from the following modules are used to support static analysis and type checking:
+  ◦ typing module
+  ◦ collections.abc module
+  ◦ [typing_extensions module](https://github.com/python/typing_extensions/blob/main/README.md)
+• Redirects from the [six.moves module](https://six.readthedocs.io/#module-six.moves).
+
+#### 2.3 Packages
+
+##### 2.3.1 Pros
+
+Avoids conflicts in module names or incorrect imports due to the module search path not being what the author expected. Makes it easier to find modules.
+
+##### 2.3.2 Cons
+
+Makes it harder to deploy code because you have to replicate the package hierarchy. Not really a problem with modern deployment mechanisms.
+
+##### 2.3.3 Decision
+
+Import each module using the full pathname location of the module.
+
+All new code should import each module by its full package name.
+
+Imports should be as follows:
+
+```python
+Yes:
+  # Reference absl.flags in code with the complete name (verbose).
+  import absl.flags
+  from doctor.who import jodie
+
+  _FOO = absl.flags.DEFINE_string(...)
+```
+
+```python
+Yes:
+  # Reference flags in code with just the module name (common).
+  from absl import flags
+  from doctor.who import jodie
+
+  _FOO = flags.DEFINE_string(...)
+```
+
+(assume this file lives in `doctor/who/` where `jodie.py` also exists)
+
+```python
+No:
+  # Unclear what module the author wanted and what will be imported.  The actual
+  # import behavior depends on external factors controlling sys.path.
+  # Which possible jodie module did the author intend to import?
+  import jodie
+```
+
+The directory the main binary is located in should not be assumed to be in `sys.path` despite that happening in some environments. This being the case, code should assume that `import jodie` refers to a third-party or top-level package named `jodie`, not a local `jodie.py`.
+
+#### 2.4 Exceptions
+
+##### 2.4.1 Definition
+
+Exceptions are a means of breaking out of normal control flow to handle errors or other exceptional conditions.
+
+##### 2.4.2 Pros
+
+The control flow of normal operation code is not cluttered by error-handling code. It also allows the control flow to skip multiple frames when a certain condition occurs, e.g., returning from N nested functions in one step instead of having to plumb error codes through.
+
+##### 2.4.3 Cons
+
+May cause the control flow to be confusing. Easy to miss error cases when making library calls.
+
+##### 2.4.4 Decision
+
+Exceptions are allowed but must be used carefully.
+
+Exceptions must follow certain conditions:
+
+• Make use of built-in exception classes when it makes sense. For example, raise a `ValueError` to indicate a programming mistake like a violated precondition, such as may happen when validating function arguments.
+• Do not use `assert` statements in place of conditionals or validating preconditions. They must not be critical to the application logic. A litmus test would be that the `assert` could be removed without breaking the code. `assert` conditionals are [not guaranteed](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement) to be evaluated. For [pytest](https://pytest.org/) based tests, `assert` is okay and expected to verify expectations.
+
+Example:
+
+```python
+Yes:
+  def connect_to_next_port(self, minimum: int) -> int:
+    """Connects to the next available port.
+
+    Args:
+      minimum: A port value greater or equal to 1024.
+
+    Returns:
+      The new minimum port.
+
+    Raises:
+      ConnectionError: If no available port is found.
+    """
+    if minimum < 1024:
+      # Note that this raising of ValueError is not mentioned in the doc
+      # string's "Raises:" section because it is not appropriate to
+      # guarantee this specific behavioral reaction to API misuse.
+      raise ValueError(f'Min. port must be at least 1024, not {minimum}.')
+    port = self._find_next_open_port(minimum)
+    if port is None:
+      raise ConnectionError(
+          f'Could not connect to service on port {minimum} or higher.')
+    # The code does not depend on the result of this assert.
+    assert port >= minimum, (
+        f'Unexpected port {port} when minimum was {minimum}.')
+    return port
+```
+
+```python
+No:
+  def connect_to_next_port(self, minimum: int) -> int:
+    """Connects to the next available port.
+
+    Args:
+      minimum: A port value greater or equal to 1024.
+
+    Returns:
+      The new minimum port.
+    """
+    assert minimum >= 1024, 'Minimum port must be at least 1024.'
+    # The following code depends on the previous assert.
+    port = self._find_next_open_port(minimum)
+    assert port is not None
+    # The type checking of the return statement relies on the assert.
+    return port
+```
+
+• Libraries or packages may define their own exceptions. When doing so they must inherit from an existing exception class. Exception names should end in `Error` and should not introduce repetition (`foo.FooError`).
+• Never use catch-all `except:` statements, or catch `Exception` or `StandardError`, unless you are
+  ◦ re-raising the exception, or
+  ◦ creating an isolation point in the program where exceptions are not propagated but are recorded and suppressed instead, such as protecting a thread from crashing by guarding its outermost block.
+
+Python is very tolerant in this regard and `except:` will really catch everything including misspelled names, sys.exit() calls, Ctrl+C interrupts, unittest failures and all kinds of other exceptions that you simply don't want to catch.
+
+• Minimize the amount of code in a `try`/`except` block. The larger the body of the `try`, the more likely that an exception will be raised by a line of code that you didn't expect to raise an exception. In those cases, the `try`/`except` block hides a real error.
+• Use the `finally` clause to execute code whether or not an exception is raised in the `try` block. This is often useful for cleanup, i.e., closing a file.
+
+#### 2.5 Mutable Global State
+
+##### 2.5.1 Definition
+
+Module-level values or class attributes that can get mutated during program execution.
+
+##### 2.5.2 Pros
+
+Occasionally useful.
+
+##### 2.5.3 Cons
+
+• Breaks encapsulation: Such design can make it hard to achieve valid objectives. For example, if global state is used to manage a database connection, then connecting to two different databases at the same time (such as for computing differences during a migration) becomes difficult. Similar problems easily arise with global registries.
+• Has the potential to change module behavior during the import, because assignments to global variables are done when the module is first imported.
+
+##### 2.5.4 Decision
+
+Avoid mutable global state.
+
+In those rare cases where using global state is warranted, mutable global entities should be declared at the module level or as a class attribute and made internal by prepending an `_` to the name. If necessary, external access to mutable global state must be done through public functions or class methods. See Naming below. Please explain the design reasons why mutable global state is being used in a comment or a doc linked to from a comment.
+
+Module-level constants are permitted and encouraged. For example: `_MAX_HOLY_HANDGRENADE_COUNT = 3` for an internal use constant or `SIR_LANCELOTS_FAVORITE_COLOR = "blue"` for a public API constant. Constants must be named using all caps with underscores. See Naming below.
+
+#### 2.6 Nested/Local/Inner Classes and Functions
+
+##### 2.6.1 Definition
+
+A class can be defined inside of a method, function, or class. A function can be defined inside a method or function. Nested functions have read-only access to variables defined in enclosing scopes.
+
+##### 2.6.2 Pros
+
+Allows definition of utility classes and functions that are only used inside of a very limited scope. Very [ADT](https://en.wikipedia.org/wiki/Abstract_data_type)-y. Commonly used for implementing decorators.
+
+##### 2.6.3 Cons
+
+Nested functions and classes cannot be directly tested. Nesting can make the outer function longer and less readable.
+
+##### 2.6.4 Decision
+
+Nested local functions or classes are fine when used to close over a local variable. Inner classes are fine.
+
+They are fine with some caveats. Avoid nested functions or classes except when closing over a local value other than `self` or `cls`. Do not nest a function just to hide it from users of a module. Instead, prefix its name with an _ at the module level so that it can still be accessed by tests.
+
+#### 2.7 Comprehensions & Generator Expressions
+
+##### 2.7.1 Definition
+
+List, Dict, and Set comprehensions as well as generator expressions provide a concise and efficient way to create container types and iterators without resorting to the use of traditional loops, `map()`, `filter()`, or `lambda`.
+
+##### 2.7.2 Pros
+
+Simple comprehensions can be clearer and simpler than other dict, list, or set creation techniques. Generator expressions can be very efficient, since they avoid the creation of a list entirely.
+
+##### 2.7.3 Cons
+
+Complicated comprehensions or generator expressions can be hard to read.
+
+##### 2.7.4 Decision
+
+Comprehensions are allowed, however multiple `for` clauses or filter expressions are not permitted. Optimize for readability, not conciseness.
+
+```python
+Yes:
+  result = [mapping_expr for value in iterable if filter_expr]
+
+  result = [
+      is_valid(metric={'key': value})
+      for value in interesting_iterable
+      if a_longer_filter_expression(value)
+  ]
+
+  descriptive_name = [
+      transform({'key': key, 'value': value}, color='black')
+      for key, value in generate_iterable(some_input)
+      if complicated_condition_is_met(key, value)
+  ]
+
+  result = []
+  for x in range(10):
+    for y in range(5):
+      if x * y > 10:
+        result.append((x, y))
+
+  return {
+      x: complicated_transform(x)
+      for x in long_generator_function(parameter)
+      if x is not None
+  }
+
+  return (x**2 for x in range(10))
+
+  unique_names = {user.name for user in users if user is not None}
+```
+
+```python
+No:
+  result = [(x, y) for x in range(10) for y in range(5) if x * y > 10]
+
+  return (
+      (x, y, z)
+      for x in range(5)
+      for y in range(5)
+      if x != y
+      for z in range(5)
+      if y != z
+  )
+```
+
+#### 2.8 Default Iterators and Operators
+
+##### 2.8.1 Definition
+
+Container types, like dictionaries and lists, define default iterators and membership test operators ("in" and "not in").
+
+##### 2.8.2 Pros
+
+The default iterators and operators are simple and efficient. They express the operation directly, without extra method calls. A function that uses default operators is generic. It can be used with any type that supports the operation.
+
+##### 2.8.3 Cons
+
+You can't tell the type of objects by reading the method names (unless the variable has type annotations). This is also an advantage.
+
+##### 2.8.4 Decision
+
+Use default iterators and operators for types that support them, like lists, dictionaries, and files. The built-in types define iterator methods, too. Prefer these methods to methods that return lists, except that you should not mutate a container while iterating over it.
+
+```python
+Yes:  for key in adict: ...
+      if obj in alist: ...
+      for line in afile: ...
+      for k, v in adict.items(): ...
+```
+
+```python
+No:   for key in adict.keys(): ...
+      for line in afile.readlines(): ...
+```
+
+#### 2.9 Generators
+
+##### 2.9.1 Definition
+
+A generator function returns an iterator that yields a value each time it executes a yield statement. After it yields a value, the runtime state of the generator function is suspended until the next value is needed.
+
+##### 2.9.2 Pros
+
+Simpler code, because the state of local variables and control flow are preserved for each call. A generator uses less memory than a function that creates an entire list of values at once.
+
+##### 2.9.3 Cons
+
+Local variables in the generator will not be garbage collected until the generator is either consumed to exhaustion or itself garbage collected.
+
+##### 2.9.4 Decision
+
+Use generators as needed.
+
+Fine. Use "Yields:" rather than "Returns:" in the docstring for generator functions.
+
+If the generator manages an expensive resource, make sure to force the clean up.
+
+A good way to do the clean up is by wrapping the generator with a context manager [PEP-0533](https://peps.python.org/pep-0533/).
+
+#### 2.10 Lambda Functions
+
+##### 2.10.1 Definition
+
+Lambdas define anonymous functions in an expression, as opposed to a statement.
+
+##### 2.10.2 Pros
+
+Convenient.
+
+##### 2.10.3 Cons
+
+Harder to read and debug than local functions. The lack of names means stack traces are more difficult to understand. Expressiveness is limited because the function may only contain an expression.
+
+##### 2.10.4 Decision
+
+Okay for one-liners. Prefer generator expressions over `map()` or `filter()` with a `lambda`.
+
+Lambdas are allowed. If the code inside the lambda function spans multiple lines or is longer than 60-80 chars, it might be better to define it as a regular nested function.
+
+For common operations like multiplication, use the functions from the `operator` module instead of lambda functions. For example, prefer `operator.mul` to `lambda x, y: x * y`.
+
+#### 2.11 Conditional Expressions
+
+##### 2.11.1 Definition
+
+Conditional expressions (sometimes called a "ternary operator") are mechanisms that provide a shorter syntax for if statements. For example: `x = 1 if cond else 2`.
+
+##### 2.11.2 Pros
+
+Shorter and more convenient than an if statement.
+
+##### 2.11.3 Cons
+
+May be harder to read than an if statement. The condition may be difficult to locate if the expression is long.
+
+##### 2.11.4 Decision
+
+Okay to use for simple cases.
+
+Okay to use for simple cases. Each portion must fit on one line: true-expression, if-expression, else-expression. Use a complete if statement when things get more complicated.
+
+```python
+Yes:
+    one_line = 'yes' if predicate(value) else 'no'
+    slightly_split = ('yes' if predicate(value)
+                      else 'no, nein, nyet')
+    the_longest_ternary_style_that_can_be_done = (
+        'yes, true, affirmative, confirmed, correct'
+        if predicate(value)
+        else 'no, false, negative, nay')
+```
+
+```python
+No:
+    bad_line_breaking = ('yes' if predicate(value) else
+                         'no')
+    portion_too_long = ('yes'
+                        if some_long_module.some_long_predicate_function(
+                            really_long_variable_name)
+                        else 'no, false, negative, nay')
+```
+
+#### 2.12 Default Argument Values
+
+##### 2.12.1 Definition
+
+You can specify values for variables at the end of a function's parameter list, e.g., `def foo(a, b=0):`. If `foo` is called with only one argument, `b` is set to 0. If it is called with two arguments, `b` has the value of the second argument.
+
+##### 2.12.2 Pros
+
+Often you have a function that uses lots of default values, but on rare occasions you want to override the defaults. Default argument values provide an easy way to do this, without having to define lots of functions for the rare exceptions. As Python does not support overloaded methods/functions, default arguments are an easy way of "faking" the overloading behavior.
+
+##### 2.12.3 Cons
+
+Default arguments are evaluated once at module load time. This may cause problems if the argument is a mutable object such as a list or a dictionary. If the function modifies the object (e.g., by appending an item to a list), the default value is modified.
+
+##### 2.12.4 Decision
+
+Okay in most cases.
+
+Okay to use with the following caveat:
+
+Do not use mutable objects as default values in the function or method definition.
+
+```python
+Yes: def foo(a, b=None):
+         if b is None:
+             b = []
+Yes: def foo(a, b: Sequence | None = None):
+         if b is None:
+             b = []
+Yes: def foo(a, b: Sequence = ()):  # Empty tuple OK since tuples are immutable.
+         ...
+```
+
+```python
+from absl import flags
+_FOO = flags.DEFINE_string(...)
+
+No:  def foo(a, b=[]):
+         ...
+No:  def foo(a, b=time.time()):  # Is `b` supposed to represent when this module was loaded?
+         ...
+No:  def foo(a, b=_FOO.value):  # sys.argv has not yet been parsed...
+         ...
+No:  def foo(a, b: Mapping = {}):  # Could still get passed to unchecked code.
+         ...
+```
+
+#### 2.13 Properties
+
+##### 2.13.1 Definition
+
+A way to wrap method calls for getting and setting an attribute as a standard attribute access.
+
+##### 2.13.2 Pros
+
+• Allows for an attribute access and assignment API rather than getter and setter method calls.
+• Can be used to make an attribute read-only.
+• Allows calculations to be lazy.
+• Provides a way to maintain the public interface of a class when the internals evolve independently of class users.
+
+##### 2.13.3 Cons
+
+• Can hide side-effects much like operator overloading.
+• Can be confusing for subclasses.
+
+##### 2.13.4 Decision
+
+Properties may be used to control getting or setting attributes that require trivial computations or logic. Property implementations must match the general expectations of regular attribute access: that they are cheap, straightforward, and unsurprising.
+
+Properties are allowed, but, like operator overloading, should only be used when necessary and match the expectations of typical attribute access; follow the getters and setters rules otherwise.
+
+For example, using a property to simply both get and set an internal attribute isn't allowed: there is no computation occurring, so the property is unnecessary (make the attribute public instead). In comparison, using a property to control attribute access or to calculate a trivially derived value is allowed: the logic is simple and unsurprising.
+
+Properties should be created with the `@property` decorator. Manually implementing a property descriptor is considered a power feature.
+
+Inheritance with properties can be non-obvious. Do not use properties to implement computations a subclass may ever want to override and extend.
+
+#### 2.14 True/False Evaluations
+
+##### 2.14.1 Definition
+
+Python evaluates certain values as `False` when in a boolean context. A quick "rule of thumb" is that all "empty" values are considered false, so `0, None, [], {}, ''` all evaluate as false in a boolean context.
+
+##### 2.14.2 Pros
+
+Conditions using Python booleans are easier to read and less error-prone. In most cases, they're also faster.
+
+##### 2.14.3 Cons
+
+May look strange to C/C++ developers.
+
+##### 2.14.4 Decision
+
+Use the "implicit" false if at all possible (with a few caveats).
+
+Use the "implicit" false if possible, e.g., `if foo:` rather than `if foo != []:`. There are a few caveats that you should keep in mind though:
+
+• Always use `if foo is None:` (or `is not None`) to check for a `None` value. E.g., when testing whether a variable or argument that defaults to `None` was set to some other value. The other value might be a value that's false in a boolean context!
+• Never compare a boolean variable to `False` using `==`. Use `if not x:` instead. If you need to distinguish `False` from `None` then chain the expressions, such as `if not x and x is not None:`.
+• For sequences (strings, lists, tuples), use the fact that empty sequences are false, so `if seq:` and `if not seq:` are preferable to `if len(seq):` and `if not len(seq):` respectively.
+• When handling integers, implicit false may involve more risk than benefit (i.e., accidentally handling `None` as 0). You may compare a value which is known to be an integer (and is not the result of `len()`) against the integer 0.
+
+```python
+Yes: if not users:
+         print('no users')
+
+     if i % 10 == 0:
+         self.handle_multiple_of_ten()
+
+     def f(x=None):
+         if x is None:
+             x = []
+```
+
+```python
+No:  if len(users) == 0:
+         print('no users')
+
+     if not i % 10:
+         self.handle_multiple_of_ten()
+
+     def f(x=None):
+         x = x or []
+```
+
+• Note that `'0'` (i.e., `0` as string) evaluates to true.
+• Note that Numpy arrays may raise an exception in an implicit boolean context. Prefer the `.size` attribute when testing emptiness of a `np.array` (e.g. `if not users.size`).
+
+#### 2.16 Lexical Scoping
+
+##### 2.16.1 Definition
+
+A nested Python function can refer to variables defined in enclosing functions, but cannot assign to them. Variable bindings are resolved using lexical scoping, that is, based on the static program text. Any assignment to a name in a block will cause Python to treat all references to that name as a local variable, even if the use precedes the assignment. If a global declaration occurs, the name is treated as a global variable.
+
+An example of the use of this feature is:
+
+```python
+def get_adder(summand1: float) -> Callable[[float], float]:
+    """Returns a function that adds numbers to a given number."""
+    def adder(summand2: float) -> float:
+        return summand1 + summand2
+
+    return adder
+```
+
+##### 2.16.2 Pros
+
+Often results in clearer, more elegant code. Especially comforting to experienced Lisp and Scheme (and Haskell and ML and …) programmers.
+
+##### 2.16.3 Cons
+
+Can lead to confusing bugs, such as this example based on [PEP-0227](https://peps.python.org/pep-0227/):
+
+```python
+i = 4
+def foo(x: Iterable[int]):
+    def bar():
+        print(i, end='')
+    # ...
+    # A bunch of code here
+    # ...
+    for i in x:  # Ah, i *is* local to foo, so this is what bar sees
+        print(i, end='')
+    bar()
+```
+
+So `foo([1, 2, 3])` will print `1 2 3 3`, not `1 2 3 4`.
+
+##### 2.16.4 Decision
+
+Okay to use.
+
+#### 2.17 Function and Method Decorators
+
+##### 2.17.1 Definition
+
+[Decorators for Functions and Methods](https://docs.python.org/3/glossary.html#term-decorator) (a.k.a "the `@` notation"). One common decorator is `@property`, used for converting ordinary methods into dynamically computed attributes. However, the decorator syntax allows for user-defined decorators as well. Specifically, for some function `my_decorator`, this:
+
+```python
+class C:
+    @my_decorator
+    def method(self):
+        # method body ...
+```
+
+is equivalent to:
+
+```python
+class C:
+    def method(self):
+        # method body ...
+    method = my_decorator(method)
+```
+
+##### 2.17.2 Pros
+
+Elegantly specifies some transformation on a method; the transformation might eliminate some repetitive code, enforce invariants, etc.
+
+##### 2.17.3 Cons
+
+Decorators can perform arbitrary operations on a function's arguments or return values, resulting in surprising implicit behavior. Additionally, decorators execute at object definition time. For module-level objects (classes, module functions, …) this happens at import time. Failures in decorator code are pretty much impossible to recover from.
+
+##### 2.17.4 Decision
+
+Use decorators judiciously when there is a clear advantage. Avoid `staticmethod` and limit use of `classmethod`.
+
+Use decorators judiciously when there is a clear advantage. Decorators should follow the same import and naming guidelines as functions. A decorator docstring should clearly state that the function is a decorator. Write unit tests for decorators.
+
+Avoid external dependencies in the decorator itself (e.g. don't rely on files, sockets, database connections, etc.), since they might not be available when the decorator runs (at import time, perhaps from `pydoc` or other tools). A decorator that is called with valid parameters should (as much as possible) be guaranteed to succeed in all cases.
+
+Decorators are a special case of "top-level code" - see main for more discussion.
+
+Never use `staticmethod` unless forced to in order to integrate with an API defined in an existing library. Write a module-level function instead.
+
+Use `classmethod` only when writing a named constructor, or a class-specific routine that modifies necessary global state such as a process-wide cache.
+
+#### 2.18 Threading
+
+Do not rely on the atomicity of built-in types.
+
+While Python's built-in data types such as dictionaries appear to have atomic operations, there are corner cases where they aren't atomic (e.g. if `__hash__` or `__eq__` are implemented as Python methods) and their atomicity should not be relied upon. Neither should you rely on atomic variable assignment (since this in turn depends on dictionaries).
+
+Use the `queue` module's `Queue` data type as the preferred way to communicate data between threads. Otherwise, use the `threading` module and its locking primitives. Prefer condition variables and `threading.Condition` instead of using lower-level locks.
+
+#### 2.19 Power Features
+
+##### 2.19.1 Definition
+
+Python is an extremely flexible language and gives you many fancy features such as custom metaclasses, access to bytecode, on-the-fly compilation, dynamic inheritance, object reparenting, import hacks, reflection (e.g. some uses of `getattr()`), modification of system internals, `__del__` methods implementing customized cleanup, etc.
+
+##### 2.19.2 Pros
+
+These are powerful language features. They can make your code more compact.
+
+##### 2.19.3 Cons
+
+It's very tempting to use these "cool" features when they're not absolutely necessary. It's harder to read, understand, and debug code that's using unusual features underneath. It doesn't seem that way at first (to the original author), but when revisiting the code, it tends to be more difficult than code that is longer but is straightforward.
+
+##### 2.19.4 Decision
+
+Avoid these features.
+
+Standard library modules and classes that internally use these features are okay to use (for example, `abc.ABCMeta`, `dataclasses`, and `enum`).
+
+#### 2.20 Modern Python: from **future** imports
+
+##### 2.20.1 Definition
+
+Being able to turn on some of the more modern features via `from __future__ import` statements allows early use of features from expected future Python versions.
+
+##### 2.20.2 Pros
+
+This has proven to make runtime version upgrades smoother as changes can be made on a per-file basis while declaring compatibility and preventing regressions within those files. Modern code is more maintainable as it is less likely to accumulate technical debt that will be problematic during future runtime upgrades.
+
+##### 2.20.3 Cons
+
+Such code may not work on very old interpreter versions prior to the introduction of the needed future statement. The need for this is more common in projects supporting an extremely wide variety of environments.
+
+##### 2.20.4 Decision
+
+New language version semantic changes may be gated behind a special future import to enable them on a per-file basis within earlier runtimes.
+
+##### from **future** imports
+
+Use of `from __future__ import` statements is encouraged. It allows a given source file to start using more modern Python syntax features today. Once you no longer need to run on a version where the features are hidden behind a `__future__` import, feel free to remove those lines.
+
+In code that may execute on versions as old as 3.5 rather than >= 3.7, import:
+
+```python
+from __future__ import generator_stop
+```
+
+For more information read the [Python future statement definitions](https://docs.python.org/3/library/__future__.html) documentation.
+
+Please don't remove these imports until you are confident the code is only ever used in a sufficiently modern environment. Even if you do not currently use the feature a specific future import enables in your code today, keeping it in place in the file prevents later modifications of the code from inadvertently depending on the older behavior.
+
+Use other `from __future__` import statements as you see fit.
+
+#### 2.21 Type Annotated Code
+
+##### 2.21.1 Definition
+
+Type annotations (or "type hints") are for function or method arguments and return values:
+
+```python
+def func(a: int) -> list[int]:
+```
+
+You can also declare the type of a variable using similar syntax:
+
+```python
+a: SomeType = some_func()
+```
+
+##### 2.21.2 Pros
+
+Type annotations improve the readability and maintainability of your code. The type checker will convert many runtime errors to build-time errors, and reduce your ability to use Power Features.
+
+##### 2.21.3 Cons
+
+You will have to keep the type declarations up to date. You might see type errors that you think are valid code. Use of a [type checker](https://github.com/google/pytype) may reduce your ability to use Power Features.
+
+##### 2.21.4 Decision
+
+You can annotate Python code with [type hints](https://docs.python.org/3/library/typing.html). Type-check the code at build time with a type checking tool like [pytype](https://github.com/google/pytype). In most cases, when feasible, type annotations are in source files. For third-party or extension modules, annotations can be in [stub .pyi files](https://peps.python.org/pep-0484/#stub-files).
+
+You are strongly encouraged to enable Python type analysis when updating code. When adding or modifying public APIs, include type annotations and enable checking via pytype in the build system. As static analysis is relatively new to Python, we acknowledge that undesired side-effects (such as wrongly inferred types) may prevent adoption by some projects. In those situations, authors are encouraged to add a comment with a TODO or link to a bug describing the issue(s) currently preventing type annotation adoption in the BUILD file or in the code itself as appropriate.
+
+### 3 Python Style Rules
+
+#### 3.1 Semicolons
+
+Do not terminate your lines with semicolons, and do not use semicolons to put two statements on the same line.
+
+#### 3.2 Line length
+
+Maximum line length is 80 characters.
+
+Explicit exceptions to the 80 character limit:
+
+• Long import statements.
+• URLs, pathnames, or long flags in comments.
+• Long string module-level constants not containing whitespace that would be inconvenient to split across lines such as URLs or pathnames.
+  ◦ Pylint disable comments. (e.g.: `# pylint: disable=invalid-name`)
+
+Do not use a backslash for [explicit line continuation](https://docs.python.org/3/reference/lexical_analysis.html#explicit-line-joining).
+
+Instead, make use of Python's [implicit line joining inside parentheses, brackets and braces](http://docs.python.org/reference/lexical_analysis.html#implicit-line-joining). If necessary, you can add an extra pair of parentheses around an expression.
+
+```python
+Yes: foo_bar(self, width, height, color='black', design=None, x='foo',
+             emphasis=None, highlight=0)
+
+Yes: if (width == 0 and height == 0 and
+         color == 'red' and emphasis == 'strong'):
+
+     (bridge_questions.clarification_on
+      .average_airspeed_of.unladen_swallow) = 'African or European?'
+
+     with (
+         very_long_first_expression_function() as spam,
+         very_long_second_expression_function() as beans,
+         third_thing() as eggs,
+     ):
+       place_order(eggs, beans, spam, beans)
+```
+
+```python
+No:  if width == 0 and height == 0 and \
+         color == 'red' and emphasis == 'strong':
+
+     bridge_questions.clarification_on \
+         .average_airspeed_of.unladen_swallow = 'African or European?'
+
+     with very_long_first_expression_function() as spam, \
+           very_long_second_expression_function() as beans, \
+           third_thing() as eggs:
+       place_order(eggs, beans, spam, beans)
+```
+
+When a literal string won't fit on a single line, use parentheses for implicit line joining.
+
+```python
+x = ('This will build a very long long '
+     'long long long long long long string')
+```
+
+#### 3.3 Parentheses
+
+Use parentheses sparingly.
+
+It is fine, though not required, to use parentheses around tuples. Do not use them in return statements or conditional statements unless using parentheses for implied line continuation or to indicate a tuple.
+
+```python
+Yes: if foo:
+         bar()
+     while x:
+         x = bar()
+     if x and y:
+         bar()
+     if not x:
+         bar()
+     # For a 1 item tuple the ()s are more visually obvious than the comma.
+     onesie = (foo,)
+     return foo
+     return spam, beans
+     return (spam, beans)
+     for (x, y) in dict.items(): ...
+```
+
+```python
+No:  if (x):
+         bar()
+     if not(x):
+         bar()
+     return (foo)
+```
+
+#### 3.4 Indentation
+
+Indent your code blocks with 4 spaces.
+
+Never use tabs. Implied line continuation should align wrapped elements vertically (see line length examples), or use a hanging 4-space indent. Closing (round, square or curly) brackets can be placed at the end of the expression, or on separate lines, but then should be indented the same as the line with the corresponding opening bracket.
+
+```python
+Yes:   # Aligned with opening delimiter.
+       foo = long_function_name(var_one, var_two,
+                                var_three, var_four)
+       meal = (spam,
+               beans)
+
+       # Aligned with opening delimiter in a dictionary.
+       foo = {
+           'long_dictionary_key': value1 +
+                                  value2,
+           ...
+       }
+
+       # 4-space hanging indent; nothing on first line.
+       foo = long_function_name(
+           var_one, var_two, var_three,
+           var_four)
+       meal = (
+           spam,
+           beans)
+
+       # 4-space hanging indent; nothing on first line,
+       # closing parenthesis on a new line.
+       foo = long_function_name(
+           var_one, var_two, var_three,
+           var_four
+       )
+       meal = (
+           spam,
+           beans,
+       )
+
+       # 4-space hanging indent in a dictionary.
+       foo = {
+           'long_dictionary_key':
+               long_dictionary_value,
+           ...
+       }
+```
+
+```python
+No:    # Stuff on first line forbidden.
+       foo = long_function_name(var_one, var_two,
+           var_three, var_four)
+       meal = (spam,
+           beans)
+
+       # 2-space hanging indent forbidden.
+       foo = long_function_name(
+         var_one, var_two, var_three,
+         var_four)
+
+       # No hanging indent in a dictionary.
+       foo = {
+           'long_dictionary_key':
+           long_dictionary_value,
+           ...
+       }
+```
+
+##### 3.4.1 Trailing commas in sequences of items
+
+Trailing commas in sequences of items are recommended only when the closing container token `]`, `)`, or `}` does not appear on the same line as the final element, as well as for tuples with a single element. The presence of a trailing comma is also used as a hint to our Python code auto-formatter [Black](https://github.com/psf/black) or [Pyink](https://github.com/google/pyink) to direct it to auto-format the container of items to one item per line when the `,` after the final element is present.
+
+```python
+Yes:   golomb3 = [0, 1, 3]
+       golomb4 = [
+           0,
+           1,
+           4,
+           6,
+       ]
+```
+
+```python
+No:    golomb4 = [
+           0,
+           1,
+           4,
+           6,]
+```
+
+#### 3.5 Blank Lines
+
+Two blank lines between top-level definitions, be they function or class definitions. One blank line between method definitions and between the docstring of a `class` and the first method. No blank line following a `def` line. Use single blank lines as you judge appropriate within functions or methods.
+
+Blank lines need not be anchored to the definition. For example, related comments immediately preceding function, class, and method definitions can make sense. Consider if your comment might be more useful as part of the docstring.
+
+#### 3.6 Whitespace
+
+Follow standard typographic rules for the use of spaces around punctuation.
+
+No whitespace inside parentheses, brackets or braces.
+
+```python
+Yes: spam(ham[1], {'eggs': 2}, [])
+```
+
+```python
+No:  spam( ham[ 1 ], { 'eggs': 2 }, [ ] )
+```
+
+No whitespace before a comma, semicolon, or colon. Do use whitespace after a comma, semicolon, or colon, except at the end of the line.
+
+```python
+Yes: if x == 4:
+         print(x, y)
+     x, y = y, x
+```
+
+```python
+No:  if x == 4 :
+         print(x , y)
+     x , y = y , x
+```
+
+No whitespace before the open paren/bracket that starts an argument list, indexing or slicing.
+
+```python
+Yes: spam(1)
+     dict['key'] = list[index]
+```
+
+```python
+No:  spam (1)
+     dict ['key'] = list [index]
+```
+
+No trailing whitespace.
+
+Surround binary operators with a single space on either side for assignment (`=`), comparisons (`==, <, >, !=, <>, <=, >=, in, not in, is, is not`), and Booleans (`and, or, not`). Use your better judgment for the insertion of spaces around arithmetic operators (`+`, `-`, `*`, `/`, `//`, `%`, `**`, `@`).
+
+```python
+Yes: x == 1
+```
+
+```python
+No:  x<1
+```
+
+Never use spaces around `=` when passing keyword arguments or defining a default parameter value, with one exception: when a type annotation is present, do use spaces around the `=` for the default parameter value.
+
+```python
+Yes: def complex(real, imag=0.0): return Magic(r=real, i=imag)
+Yes: def complex(real, imag: float = 0.0): return Magic(r=real, i=imag)
+```
+
+```python
+No:  def complex(real, imag = 0.0): return Magic(r = real, i = imag)
+No:  def complex(real, imag: float=0.0): return Magic(r = real, i = imag)
+```
+
+Don't use spaces to vertically align tokens on consecutive lines, since it becomes a maintenance burden (applies to `:`, `#`, `=`, etc.):
+
+```python
+Yes:
+  foo = 1000  # comment
+  long_name = 2  # comment that should not be aligned
+
+  dictionary = {
+      'foo': 1,
+      'long_name': 2,
+  }
+```
+
+```python
+No:
+  foo       = 1000  # comment
+  long_name = 2     # comment that should not be aligned
+
+  dictionary = {
+      'foo'      : 1,
+      'long_name': 2,
+  }
+```
+
+#### 3.7 Shebang Line
+
+Most `.py` files do not need to start with a `#!` line. Start the main file of a program with `#!/usr/bin/env python3` (to support virtualenvs) or `#!/usr/bin/python3` per [PEP-394](https://peps.python.org/pep-0394/).
+
+This line is used by the kernel to find the Python interpreter, but is ignored by Python when importing modules. It is only necessary on a file intended to be executed directly.
+
+#### 3.8 Comments and Docstrings
+
+Be sure to use the right style for module, function, method docstrings and inline comments.
+
+##### 3.8.1 Docstrings
+
+Python uses docstrings to document code. A docstring is a string that is the first statement in a package, module, class or function. These strings can be extracted automatically through the `__doc__` member of the object and are used by `pydoc`. (Try running `pydoc` on your module to see how it looks.) Always use the three-double-quote `"""` format for docstrings (per [PEP 257](https://peps.python.org/pep-0257/)). A docstring should be organized as a summary line (one physical line not exceeding 80 characters) terminated by a period, question mark, or exclamation point. When writing more (encouraged), this must be followed by a blank line, followed by the rest of the docstring starting at the same cursor position as the first quote of the first line. There are more formatting guidelines for docstrings below.
+
+##### 3.8.2 Modules
+
+Every file should contain license boilerplate. Choose the appropriate boilerplate for the license used by the project (for example, Apache 2.0, BSD, LGPL, GPL).
+
+Files should start with a docstring describing the contents and usage of the module.
+
+```python
+"""A one-line summary of the module or program, terminated by a period.
+
+Leave one blank line.  The rest of this docstring should contain an
+overall description of the module or program.  Optionally, it may also
+contain a brief description of exported classes and functions and/or usage
+examples.
+
+Typical usage example:
+
+  foo = ClassFoo()
+  bar = foo.function_bar()
+"""
+```
+
+###### 3.8.2.1 Test modules
+
+Module-level docstrings for test files are not required. They should be included only when there is additional information that can be provided.
+
+Examples include some specifics on how the test should be run, an explanation of an unusual setup pattern, dependency on the external environment, and so on.
+
+```python
+"""This blaze test uses golden files.
+
+You can update those files by running
+`blaze run //foo/bar:foo_test -- --update_golden_files` from the `google3`
+directory.
+"""
+```
+
+Docstrings that do not provide any new information should not be used.
+
+```python
+"""Tests for foo.bar."""
+```
+
+##### 3.8.3 Functions and Methods
+
+In this section, "function" means a method, function, generator, or property.
+
+A docstring is mandatory for every function that has one or more of the following properties:
+
+• being part of the public API
+• nontrivial size
+• non-obvious logic
+
+A docstring should give enough information to write a call to the function without reading the function's code. The docstring should describe the function's calling syntax and its semantics, but generally not its implementation details, unless those details are relevant to how the function is to be used. For example, a function that mutates one of its arguments as a side effect should note that in its docstring. Otherwise, subtle but important details of a function's implementation that are not relevant to the caller are better expressed as comments alongside the code than within the function's docstring.
+
+The docstring may be descriptive-style (`"""Fetches rows from a Bigtable."""`) or imperative-style (`"""Fetch rows from a Bigtable."""`), but the style should be consistent within a file. The docstring for a `@property` data descriptor should use the same style as the docstring for an attribute or a function argument (`"""The Bigtable path."""`, rather than `"""Returns the Bigtable path."""`).
+
+Certain aspects of a function should be documented in special sections, listed below. Each section begins with a heading line, which ends with a colon. All sections other than the heading should maintain a hanging indent of two or four spaces (be consistent within a file). These sections can be omitted in cases where the function's name and signature are informative enough that it can be aptly described using a one-line docstring.
+
+- **Args:** List each parameter by name. A description should follow the name, and be separated by a colon followed by either a space or newline. If the description is too long to fit on a single 80-character line, use a hanging indent of 2 or 4 spaces more than the parameter name (be consistent with the rest of the docstrings in the file). The description should include required type(s) if the code does not contain a corresponding type annotation. If a function accepts `*foo` (variable length argument lists) and/or `**bar` (arbitrary keyword arguments), they should be listed as `*foo` and `**bar`.
+- **Returns: (or Yields: for generators)** Describe the semantics of the return value, including any type information that the type annotation does not provide. If the function only returns None, this section is not required. It may also be omitted if the docstring starts with "Return", "Returns", "Yield", or "Yields" (e.g. `"""Returns row from Bigtable as a tuple of strings."""`) and the opening sentence is sufficient to describe the return value. Do not imitate older 'NumPy style' ([example](https://numpy.org/doc/1.24/reference/generated/numpy.linalg.qr.html)), which frequently documented a tuple return value as if it were multiple return values with individual names (never mentioning the tuple). Instead, describe such a return value as: "Returns: A tuple (mat_a, mat_b), where mat_a is …, and …". The auxiliary names in the docstring need not necessarily correspond to any internal names used in the function body (as those are not part of the API). If the function uses `yield` (is a generator), the `Yields:` section should document the object returned by `next()`, instead of the generator object itself that the call evaluates to.
+- **Raises:** List all exceptions that are relevant to the interface followed by a description. Use a similar exception name + colon + space or newline and hanging indent style as described in Args:. You should not document exceptions that get raised if the API specified in the docstring is violated (because this would paradoxically make behavior under violation of the API part of the API).
+
+```python
+def fetch_smalltable_rows(
+    table_handle: smalltable.Table,
+    keys: Sequence[bytes | str],
+    require_all_keys: bool = False,
+) -> Mapping[bytes, tuple[str, ...]]:
+    """Fetches rows from a Smalltable.
+
+    Retrieves rows pertaining to the given keys from the Table instance
+    represented by table_handle.  String keys will be UTF-8 encoded.
+
+    Args:
+        table_handle: An open smalltable.Table instance.
+        keys: A sequence of strings representing the key of each table
+          row to fetch.  String keys will be UTF-8 encoded.
+        require_all_keys: If True only rows with values set for all keys will be
+          returned.
+
+    Returns:
+        A dict mapping keys to the corresponding table row data
+        fetched. Each row is represented as a tuple of strings. For
+        example:
+
+        {b'Serak': ('Rigel VII', 'Preparer'),
+         b'Zim': ('Irk', 'Invader'),
+         b'Lrrr': ('Omicron Persei 8', 'Emperor')}
+
+        Returned keys are always bytes.  If a key from the keys argument is
+        missing from the dictionary, then that row was not found in the
+        table (and require_all_keys must have been False).
+
+    Raises:
+        IOError: An error occurred accessing the smalltable.
+    """
+```
+
+###### 3.8.3.1 Overridden Methods
+
+A method that overrides a method from a base class does not need a docstring if it is explicitly decorated with [@override](https://typing-extensions.readthedocs.io/en/latest/#override) (from `typing_extensions` or `typing` modules), unless the overriding method's behavior materially refines the base method's contract, or details need to be provided (e.g., documenting additional side effects), in which case a docstring with at least those differences is required on the overriding method.
+
+```python
+from typing_extensions import override
+
+class Parent:
+  def do_something(self):
+    """Parent method, includes docstring."""
+
+# Child class, method annotated with override.
+class Child(Parent):
+  @override
+  def do_something(self):
+    pass
+```
+
+##### 3.8.4 Classes
+
+Classes should have a docstring below the class definition describing the class. Public attributes, excluding properties, should be documented here in an `Attributes` section and follow the same formatting as a function's Args section.
+
+```python
+class SampleClass:
+    """Summary of class here.
+
+    Longer class information...
+    Longer class information...
+
+    Attributes:
+        likes_spam: A boolean indicating if we like SPAM or not.
+        eggs: An integer count of the eggs we have laid.
+    """
+
+    def __init__(self, likes_spam: bool = False):
+        """Initializes the instance based on spam preference.
+
+        Args:
+          likes_spam: Defines if instance exhibits this preference.
+        """
+        self.likes_spam = likes_spam
+        self.eggs = 0
+
+    @property
+    def butter_sticks(self) -> int:
+        """The number of butter sticks we have."""
+```
+
+All class docstrings should start with a one-line summary that describes what the class instance represents. This implies that subclasses of `Exception` should also describe what the exception represents, and not the context in which it might occur. The class docstring should not repeat unnecessary information, such as that the class is a class.
+
+```python
+# Yes:
+class CheeseShopAddress:
+  """The address of a cheese shop.
+
+  ...
+  """
+
+class OutOfCheeseError(Exception):
+  """No more cheese is available."""
+```
+
+```python
+# No:
+class CheeseShopAddress:
+  """Class that describes the address of a cheese shop.
+
+  ...
+  """
+
+class OutOfCheeseError(Exception):
+  """Raised when no more cheese is available."""
+```
+
+##### 3.8.5 Block and Inline Comments
+
+The final place to have comments is in tricky parts of the code. If you're going to have to explain it at the next [code review](http://en.wikipedia.org/wiki/Code_review), you should comment it now. Complicated operations get a few lines of comments before the operations commence. Non-obvious ones get comments at the end of the line.
+
+```python
+# We use a weighted dictionary search to find out where i is in
+# the array.  We extrapolate position based on the largest num
+# in the array and the array size and then do binary search to
+# get the exact number.
+
+if i & (i-1) == 0:  # True if i is 0 or a power of 2.
+```
+
+To improve legibility, these comments should start at least 2 spaces away from the code with the comment character `#`, followed by at least one space before the text of the comment itself.
+
+On the other hand, never describe the code. Assume the person reading the code knows Python (though not what you're trying to do) better than you do.
+
+```python
+# BAD COMMENT: Now go through the b array and make sure whenever i occurs
+# the next element is i+1
+```
+
+##### 3.8.6 Punctuation, Spelling, and Grammar
+
+Pay attention to punctuation, spelling, and grammar; it is easier to read well-written comments than badly written ones.
+
+Comments should be as readable as narrative text, with proper capitalization and punctuation. In many cases, complete sentences are more readable than sentence fragments. Shorter comments, such as comments at the end of a line of code, can sometimes be less formal, but you should be consistent with your style.
+
+Although it can be frustrating to have a code reviewer point out that you are using a comma when you should be using a semicolon, it is very important that source code maintain a high level of clarity and readability. Proper punctuation, spelling, and grammar help with that goal.
+
+#### 3.10 Strings
+
+Use an [f-string](https://docs.python.org/3/reference/lexical_analysis.html#f-strings), the `%` operator, or the `format` method for formatting strings, even when the parameters are all strings. Use your best judgment to decide between string formatting options. A single join with `+` is okay but do not format with `+`.
+
+```python
+Yes: x = f'name: {name}; score: {n}'
+     x = '%s, %s!' % (imperative, expletive)
+     x = '{}, {}'.format(first, second)
+     x = 'name: %s; score: %d' % (name, n)
+     x = 'name: %(name)s; score: %(score)d' % {'name':name, 'score':n}
+     x = 'name: {}; score: {}'.format(name, n)
+     x = a + b
+```
+
+```python
+No: x = first + ', ' + second
+    x = 'name: ' + name + '; score: ' + str(n)
+```
+
+Avoid using the `+` and `+=` operators to accumulate a string within a loop. In some conditions, accumulating a string with addition can lead to quadratic rather than linear running time. Although common accumulations of this sort may be optimized on CPython, that is an implementation detail. The conditions under which an optimization applies are not easy to predict and may change. Instead, add each substring to a list and `''.join` the list after the loop terminates, or write each substring to an `io.StringIO` buffer. These techniques consistently have amortized-linear run-time complexity.
+
+```python
+Yes: items = ['<table>']
+     for last_name, first_name in employee_list:
+         items.append('<tr><td>%s, %s</td></tr>' % (last_name, first_name))
+     items.append('</table>')
+     employee_table = ''.join(items)
+```
+
+```python
+No: employee_table = '<table>'
+    for last_name, first_name in employee_list:
+        employee_table += '<tr><td>%s, %s</td></tr>' % (last_name, first_name)
+    employee_table += '</table>'
+```
+
+Be consistent with your choice of string quote character within a file. Pick `'` or `"` and stick with it. It is okay to use the other quote character on a string to avoid the need to backslash-escape quote characters within the string.
+
+```python
+Yes:
+  Python('Why are you hiding your eyes?')
+  Gollum("I'm scared of lint errors.")
+  Narrator('"Good!" thought a happy Python reviewer.')
+```
+
+```python
+No:
+  Python("Why are you hiding your eyes?")
+  Gollum('The lint. It burns. It burns us.')
+  Gollum("Always the great lint. Watching. Watching.")
+```
+
+Prefer `"""` for multi-line strings rather than `'''`. Projects may choose to use `'''` for all non-docstring multi-line strings if and only if they also use `'` for regular strings. Docstrings must use `"""` regardless.
+
+Multi-line strings do not flow with the indentation of the rest of the program. If you need to avoid embedding extra space in the string, use either concatenated single-line strings or a multi-line string with [textwrap.dedent()](https://docs.python.org/3/library/textwrap.html#textwrap.dedent) to remove the initial space on each line:
+
+```python
+  No:
+  long_string = """This is pretty ugly.
+Don't do this.
+"""
+```
+
+```python
+  Yes:
+  long_string = """This is fine if your use case can accept
+      extraneous leading spaces."""
+```
+
+```python
+  Yes:
+  long_string = ("And this is fine if you cannot accept\n" +
+                 "extraneous leading spaces.")
+```
+
+```python
+  Yes:
+  long_string = ("And this too is fine if you cannot accept\n"
+                 "extraneous leading spaces.")
+```
+
+```python
+  Yes:
+  import textwrap
+
+  long_string = textwrap.dedent("""\
+      This is also fine, because textwrap.dedent()
+      will collapse common leading spaces in each line.""")
+```
+
+Note that using a backslash here does not violate the prohibition against explicit line continuation; in this case, the backslash is [escaping a newline](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals) in a string literal.
+
+##### 3.10.1 Logging
+
+For logging functions that expect a pattern-string (with %-placeholders) as their first argument: Always call them with a string literal (not an f-string!) as their first argument with pattern-parameters as subsequent arguments. Some logging implementations collect the unexpanded pattern-string as a queryable field. It also prevents spending time rendering a message that no logger is configured to output.
+
+```python
+  Yes:
+  import tensorflow as tf
+  logger = tf.get_logger()
+  logger.info('TensorFlow Version is: %s', tf.__version__)
+```
+
+```python
+  Yes:
+  import os
+  from absl import logging
+
+  logging.info('Current $PAGER is: %s', os.getenv('PAGER', default=''))
+
+  homedir = os.getenv('HOME')
+  if homedir is None or not os.access(homedir, os.W_OK):
+    logging.error('Cannot write to home directory, $HOME=%r', homedir)
+```
+
+```python
+  No:
+  import os
+  from absl import logging
+
+  logging.info('Current $PAGER is:')
+  logging.info(os.getenv('PAGER', default=''))
+
+  homedir = os.getenv('HOME')
+  if homedir is None or not os.access(homedir, os.W_OK):
+    logging.error(f'Cannot write to home directory, $HOME={homedir!r}')
+```
+
+##### 3.10.2 Error Messages
+
+Error messages (such as: message strings on exceptions like `ValueError`, or messages shown to the user) should follow three guidelines:
+
+1. The message needs to precisely match the actual error condition.
+2. Interpolated pieces need to always be clearly identifiable as such.
+3. They should allow simple automated processing (e.g. grepping).
+
+```python
+  Yes:
+  if not 0 <= p <= 1:
+    raise ValueError(f'Not a probability: {p=}')
+
+  try:
+    os.rmdir(workdir)
+  except OSError as error:
+    logging.warning('Could not remove directory (reason: %r): %r',
+                    error, workdir)
+```
+
+```python
+  No:
+  if p < 0 or p > 1:  # PROBLEM: also false for float('nan')!
+    raise ValueError(f'Not a probability: {p=}')
+
+  try:
+    os.rmdir(workdir)
+  except OSError:
+    # PROBLEM: Message makes an assumption that might not be true:
+    # Deletion might have failed for some other reason, misleading
+    # whoever has to debug this.
+    logging.warning('Directory already was deleted: %s', workdir)
+
+  try:
+    os.rmdir(workdir)
+  except OSError:
+    # PROBLEM: The message is harder to grep for than necessary, and
+    # not universally non-confusing for all possible values of `workdir`.
+    # Imagine someone calling a library function with such code
+    # using a name such as workdir = 'deleted'. The warning would read:
+    # "The deleted directory could not be deleted."
+    logging.warning('The %s directory could not be deleted.', workdir)
+```
+
+#### 3.11 Files, Sockets, and similar Stateful Resources
+
+Explicitly close files and sockets when done with them. This rule naturally extends to closeable resources that internally use sockets, such as database connections, and also other resources that need to be closed down in a similar fashion. To name only a few examples, this also includes [mmap](https://docs.python.org/3/library/mmap.html) mappings, [h5py File objects](https://docs.h5py.org/en/stable/high/file.html), and [matplotlib.pyplot figure windows](https://matplotlib.org/2.1.0/api/_as_gen/matplotlib.pyplot.close.html).
+
+Leaving files, sockets or other such stateful objects open unnecessarily has many downsides:
+
+• They may consume limited system resources, such as file descriptors. Code that deals with many such objects may exhaust those resources unnecessarily if they're not returned to the system promptly after use.
+• Holding files open may prevent other actions such as moving or deleting them, or unmounting a filesystem.
+• Files and sockets that are shared throughout a program may inadvertently be read from or written to after logically being closed. If they are actually closed, attempts to read or write from them will raise exceptions, making the problem known sooner.
+
+Furthermore, while files and sockets (and some similarly behaving resources) are automatically closed when the object is destructed, coupling the lifetime of the object to the state of the resource is poor practice:
+
+• There are no guarantees as to when the runtime will actually invoke the `__del__` method. Different Python implementations use different memory management techniques, such as delayed garbage collection, which may increase the object's lifetime arbitrarily and indefinitely.
+• Unexpected references to the file, e.g. in globals or exception tracebacks, may keep it around longer than intended.
+
+Relying on finalizers to do automatic cleanup that has observable side effects has been rediscovered over and over again to lead to major problems, across many decades and multiple languages (see e.g. [this article](https://wiki.sei.cmu.edu/confluence/display/java/MET12-J.+Do+not+use+finalizers) for Java).
+
+The preferred way to manage files and similar resources is using the [with statement](http://docs.python.org/reference/compound_stmts.html#the-with-statement):
+
+```python
+with open("hello.txt") as hello_file:
+    for line in hello_file:
+        print(line)
+```
+
+For file-like objects that do not support the `with` statement, use `contextlib.closing()`:
+
+```python
+import contextlib
+
+with contextlib.closing(urllib.urlopen("http://www.python.org/")) as front_page:
+    for line in front_page:
+        print(line)
+```
+
+In rare cases where context-based resource management is infeasible, code documentation must explain clearly how resource lifetime is managed.
+
+#### 3.12 TODO Comments
+
+Use `TODO` comments for code that is temporary, a short-term solution, or good-enough but not perfect.
+
+A `TODO` comment begins with the word `TODO` in all caps, a following colon, and a link to a resource that contains the context, ideally a bug reference. A bug reference is preferable because bugs are tracked and have follow-up comments. Follow this piece of context with an explanatory string introduced with a hyphen `-`. The purpose is to have a consistent `TODO` format that can be searched to find out how to get more details.
+
+```python
+# TODO: crbug.com/192795 - Investigate cpufreq optimizations.
+```
+
+Old style, formerly recommended, but discouraged for use in new code:
+
+```python
+# TODO(crbug.com/192795): Investigate cpufreq optimizations.
+# TODO(yourusername): Use a "\*" here for concatenation operator.
+```
+
+Avoid adding TODOs that refer to an individual or team as the context:
+
+```python
+# TODO: @yourusername - File an issue and use a '*' for repetition.
+```
+
+If your `TODO` is of the form "At a future date do something" make sure that you either include a very specific date ("Fix by November 2009") or a very specific event ("Remove this code when all clients can handle XML responses.") that future code maintainers will comprehend. Issues are ideal for tracking this.
+
+#### 3.13 Imports formatting
+
+Imports should be on separate lines; there are exceptions for typing and collections.abc imports.
+
+E.g.:
+
+```python
+Yes: from collections.abc import Mapping, Sequence
+     import os
+     import sys
+     from typing import Any, NewType
+```
+
+```python
+No:  import os, sys
+```
+
+Imports are always put at the top of the file, just after any module comments and docstrings and before module globals and constants. Imports should be grouped from most generic to least generic:
+
+1. Python future import statements. For example:
+
+```python
+from __future__ import annotations
+```
+
+See above for more information about those.
+
+2. Python standard library imports. For example:
+
+```python
+import sys
+```
+
+3. [third-party](https://pypi.org/) module or package imports. For example:
+
+```python
+import tensorflow as tf
+```
+
+4. Code repository sub-package imports. For example:
+
+```python
+from otherproject.ai import mind
+```
+
+5. Deprecated: application-specific imports that are part of the same top-level sub-package as this file. For example:
+
+```python
+from myproject.backend.hgwells import time_machine
+```
+
+You may find older Google Python Style code doing this, but it is no longer required. New code is encouraged not to bother with this. Simply treat application-specific sub-package imports the same as other sub-package imports.
+
+Within each grouping, imports should be sorted lexicographically, ignoring case, according to each module's full package path (the `path` in `from path import ...`). Code may optionally place a blank line between import sections.
+
+```python
+import collections
+import queue
+import sys
+
+from absl import app
+from absl import flags
+import bs4
+import cryptography
+import tensorflow as tf
+
+from book.genres import scifi
+from myproject.backend import huxley
+from myproject.backend.hgwells import time_machine
+from myproject.backend.state_machine import main_loop
+from otherproject.ai import body
+from otherproject.ai import mind
+from otherproject.ai import soul
+
+# Older style code may have these imports down here instead:
+#from myproject.backend.hgwells import time_machine
+#from myproject.backend.state_machine import main_loop
+```
+
+#### 3.14 Statements
+
+Generally only one statement per line.
+
+However, you may put the result of a test on the same line as the test only if the entire statement fits on one line. In particular, you can never do so with `try`/`except` since the `try` and `except` can't both fit on the same line, and you can only do so with an `if` if there is no `else`.
+
+```python
+Yes:
+
+  if foo: bar(foo)
+```
+
+```python
+No:
+
+  if foo: bar(foo)
+  else:   baz(foo)
+
+  try:               bar(foo)
+  except ValueError: baz(foo)
+
+  try:
+      bar(foo)
+  except ValueError: baz(foo)
+```
+
+#### 3.15 Getters and Setters
+
+Getter and setter functions (also called accessors and mutators) should be used when they provide a meaningful role or behavior for getting or setting a variable's value.
+
+In particular, they should be used when getting or setting the variable is complex or the cost is significant, either currently or in a reasonable future.
+
+If, for example, a pair of getters/setters simply read and write an internal attribute, the internal attribute should be made public instead. By comparison, if setting a variable means some state is invalidated or rebuilt, it should be a setter function. The function invocation hints that a potentially non-trivial operation is occurring. Alternatively, properties may be an option when simple logic is needed, or refactoring to no longer need getters and setters.
+
+Getters and setters should follow the Naming guidelines, such as `get_foo()` and `set_foo()`.
+
+If the past behavior allowed access through a property, do not bind the new getter/setter functions to the property. Any code still attempting to access the variable by the old method should break visibly so they are made aware of the change in complexity.
+
+#### 3.16 Naming
+
+`module_name`, `package_name`, `ClassName`, `method_name`, `ExceptionName`, `function_name`, `GLOBAL_CONSTANT_NAME`, `global_var_name`, `instance_var_name`, `function_parameter_name`, `local_var_name`, `query_proper_noun_for_thing`, `send_acronym_via_https`.
+
+Names should be descriptive. This includes functions, classes, variables, attributes, files and any other type of named entities.
+
+Avoid abbreviation. In particular, do not use abbreviations that are ambiguous or unfamiliar to readers outside your project, and do not abbreviate by deleting letters within a word.
+
+Always use a `.py` filename extension. Never use dashes.
+
+##### 3.16.1 Names to Avoid
+
+• single character names, except for specifically allowed cases:
+  ◦ counters or iterators (e.g. `i`, `j`, `k`, `v`, et al.)
+  ◦ `e` as an exception identifier in `try/except` statements.
+  ◦ `f` as a file handle in `with` statements
+  ◦ private type variables with no constraints (e.g. `_T = TypeVar("_T")`, `_P = ParamSpec("_P")`)
+  ◦ names that match established notation in a reference paper or algorithm (see Mathematical Notation)
+
+Please be mindful not to abuse single-character naming. Generally speaking, descriptiveness should be proportional to the name's scope of visibility. For example, `i` might be a fine name for 5-line code block but within multiple nested scopes, it is likely too vague.
+
+• dashes (`-`) in any package/module name
+• `__double_leading_and_trailing_underscore__` names (reserved by Python)
+• offensive terms
+• names that needlessly include the type of the variable (for example: `id_to_name_dict`)
+
+##### 3.16.2 Naming Conventions
+
+• "Internal" means internal to a module, or protected or private within a class.
+• Prepending a single underscore (`_`) has some support for protecting module variables and functions (linters will flag protected member access). Note that it is okay for unit tests to access protected constants from the modules under test.
+• Prepending a double underscore (`__` aka "dunder") to an instance variable or method effectively makes the variable or method private to its class (using name mangling); we discourage its use as it impacts readability and testability, and isn't really private. Prefer a single underscore.
+• Place related classes and top-level functions together in a module. Unlike Java, there is no need to limit yourself to one class per module.
+• Use CapWords for class names, but lower_with_under.py for module names. Although there are some old modules named CapWords.py, this is now discouraged because it's confusing when the module happens to be named after a class. ("wait – did I write `import StringIO` or `from StringIO import StringIO`?")
+• New unit test files follow PEP 8 compliant lower_with_under method names, for example, `test_<method_under_test>_<state>`. For consistency(*) with legacy modules that follow CapWords function names, underscores may appear in method names starting with `test` to separate logical components of the name. One possible pattern is `test<MethodUnderTest>_<state>`.
+
+##### 3.16.3 File Naming
+
+Python filenames must have a `.py` extension and must not contain dashes (`-`). This allows them to be imported and unittested. If you want an executable to be accessible without the extension, use a symbolic link or a simple bash wrapper containing `exec "$0.py" "$@"`.
+
+##### 3.16.4 Guidelines derived from Guido's Recommendations
+
+| Type | Public | Internal |
+|------|--------|----------|
+| Packages | lower_with_under |   |
+| Modules | lower_with_under | _lower_with_under |
+| Classes | CapWords | _CapWords |
+| Exceptions | CapWords |   |
+| Functions | lower_with_under() | _lower_with_under() |
+| Global/Class Constants | CAPS_WITH_UNDER | _CAPS_WITH_UNDER |
+| Global/Class Variables | lower_with_under | _lower_with_under |
+| Instance Variables | lower_with_under | _lower_with_under (protected) |
+| Method Names | lower_with_under() | _lower_with_under() (protected) |
+| Function/Method Parameters | lower_with_under |   |
+| Local Variables | lower_with_under |   |
+
+##### 3.16.5 Mathematical Notation
+
+For mathematically-heavy code, short variable names that would otherwise violate the style guide are preferred when they match established notation in a reference paper or algorithm.
+
+When using names based on established notation:
+
+1. Cite the source of all naming conventions, preferably with a hyperlink to academic resource itself, in a comment or docstring. If the source is not accessible, clearly document the naming conventions.
+2. Prefer PEP8-compliant `descriptive_names` for public APIs, which are much more likely to be encountered out of context.
+3. Use a narrowly-scoped `pylint: disable=invalid-name` directive to silence warnings. For just a few variables, use the directive as an endline comment for each one; for more, apply the directive at the beginning of a block.
+
+#### 3.17 Main
+
+In Python, `pydoc` as well as unit tests require modules to be importable. If a file is meant to be used as an executable, its main functionality should be in a `main()` function, and your code should always check `if __name__ == '__main__'` before executing your main program, so that it is not executed when the module is imported.
+
+When using [absl](https://github.com/abseil/abseil-py), use `app.run`:
+
+```python
+from absl import app
+...
+
+def main(argv: Sequence[str]):
+    # process non-flag arguments
+    ...
+
+if __name__ == '__main__':
+    app.run(main)
+```
+
+Otherwise, use:
+
+```python
+def main():
+    ...
+
+if __name__ == '__main__':
+    main()
+```
+
+All code at the top level will be executed when the module is imported. Be careful not to call functions, create objects, or perform other operations that should not be executed when the file is being `pydoc`ed.
+
+#### 3.18 Function length
+
+Prefer small and focused functions.
+
+We recognize that long functions are sometimes appropriate, so no hard limit is placed on function length. If a function exceeds about 40 lines, think about whether it can be broken up without harming the structure of the program.
+
+Even if your long function works perfectly now, someone modifying it in a few months may add new behavior. This could result in bugs that are hard to find. Keeping your functions short and simple makes it easier for other people to read and modify your code.
+
+You could find long and complicated functions when working with some code. Do not be intimidated by modifying existing code: if working with such a function proves to be difficult, you find that errors are hard to debug, or you want to use a piece of it in several different contexts, consider breaking up the function into smaller and more manageable pieces.
+
+#### 3.19 Type Annotations
+
+##### 3.19.1 General Rules
+
+• Familiarize yourself with [type hints](https://docs.python.org/3/library/typing.html).
+• Annotating `self` or `cls` is generally not necessary. [Self](https://docs.python.org/3/library/typing.html#typing.Self) can be used if it is necessary for proper type information, e.g.
+
+```python
+from typing import Self
+
+class BaseClass:
+  @classmethod
+  def create(cls) -> Self:
+    ...
+
+  def difference(self, other: Self) -> float:
+    ...
+```
+
+• Similarly, don't feel compelled to annotate the return value of `__init__` (where `None` is the only valid option).
+• If any other variable or a returned type should not be expressed, use `Any`.
+• You are not required to annotate all the functions in a module.
+  ◦ At least annotate your public APIs.
+  ◦ Use judgment to get to a good balance between safety and clarity on the one hand, and flexibility on the other.
+  ◦ Annotate code that is prone to type-related errors (previous bugs or complexity).
+  ◦ Annotate code that is hard to understand.
+  ◦ Annotate code as it becomes stable from a types perspective. In many cases, you can annotate all the functions in mature code without losing too much flexibility.
+
+##### 3.19.2 Line Breaking
+
+Try to follow the existing indentation rules.
+
+After annotating, many function signatures will become "one parameter per line". To ensure the return type is also given its own line, a comma can be placed after the last parameter.
+
+```python
+def my_method(
+    self,
+    first_var: int,
+    second_var: Foo,
+    third_var: Bar | None,
+) -> int:
+  ...
+```
+
+Always prefer breaking between variables, and not, for example, between variable names and type annotations. However, if everything fits on the same line, go for it.
+
+```python
+def my_method(self, first_var: int) -> int:
+  ...
+```
+
+If the combination of the function name, the last parameter, and the return type is too long, indent by 4 in a new line. When using line breaks, prefer putting each parameter and the return type on their own lines and aligning the closing parenthesis with the `def`:
+
+```python
+Yes:
+def my_method(
+    self,
+    other_arg: MyLongType | None,
+) -> tuple[MyLongType1, MyLongType1]:
+  ...
+```
+
+Optionally, the return type may be put on the same line as the last parameter:
+
+```python
+Okay:
+def my_method(
+    self,
+    first_var: int,
+    second_var: int) -> dict[OtherLongType, MyLongType]:
+  ...
+```
+
+`pylint` allows you to move the closing parenthesis to a new line and align with the opening one, but this is less readable.
+
+```python
+No:
+def my_method(self,
+              other_arg: MyLongType | None,
+             ) -> dict[OtherLongType, MyLongType]:
+  ...
+```
+
+As in the examples above, prefer not to break types. However, sometimes they are too long to be on a single line (try to keep sub-types unbroken).
+
+```python
+def my_method(
+    self,
+    first_var: tuple[list[MyLongType1],
+                     list[MyLongType2]],
+    second_var: list[dict[
+        MyLongType3, MyLongType4]],
+) -> None:
+  ...
+```
+
+If a single name and type is too long, consider using an alias for the type. The last resort is to break after the colon and indent by 4.
+
+```python
+Yes:
+def my_function(
+    long_variable_name:
+        long_module_name.LongTypeName,
+) -> None:
+  ...
+```
+
+```python
+No:
+def my_function(
+    long_variable_name: long_module_name.
+        LongTypeName,
+) -> None:
+  ...
+```
+
+##### 3.19.3 Forward Declarations
+
+If you need to use a class name (from the same module) that is not yet defined – for example, if you need the class name inside the declaration of that class, or if you use a class that is defined later in the code – either use `from __future__ import annotations` or use a string for the class name.
+
+```python
+Yes:
+from __future__ import annotations
+
+class MyClass:
+  def __init__(self, stack: Sequence[MyClass], item: OtherClass) -> None:
+
+class OtherClass:
+  ...
+```
+
+```python
+Yes:
+class MyClass:
+  def __init__(self, stack: Sequence['MyClass'], item: 'OtherClass') -> None:
+
+class OtherClass:
+  ...
+```
+
+##### 3.19.4 Default Values
+
+As per [PEP-008](https://peps.python.org/pep-0008/#other-recommendations), use spaces around the `=` only for arguments that have both a type annotation and a default value.
+
+```python
+Yes:
+def func(a: int = 0) -> int:
+  ...
+```
+
+```python
+No:
+def func(a:int=0) -> int:
+  ...
+```
+
+##### 3.19.5 NoneType
+
+In the Python type system, `NoneType` is a "first class" type, and for typing purposes, `None` is an alias for `NoneType`. If an argument can be `None`, it has to be declared! You can use `|` union type expressions (recommended in new Python 3.10+ code), or the older `Optional` and `Union` syntaxes.
+
+Use explicit `X | None` instead of implicit. Earlier versions of type checkers allowed `a: str = None` to be interpreted as `a: str | None = None`, but that is no longer the preferred behavior.
+
+```python
+Yes:
+def modern_or_union(a: str | int | None, b: str | None = None) -> str:
+  ...
+def union_optional(a: Union[str, int, None], b: Optional[str] = None) -> str:
+  ...
+```
+
+```python
+No:
+def nullable_union(a: Union[None, str]) -> str:
+  ...
+def implicit_optional(a: str = None) -> str:
+  ...
+```
+
+##### 3.19.6 Type Aliases
+
+You can declare aliases of complex types. The name of an alias should be CapWorded. If the alias is used only in this module, it should be _Private.
+
+Note that the `: TypeAlias` annotation is only supported in versions 3.10+.
+
+```python
+from typing import TypeAlias
+
+_LossAndGradient: TypeAlias = tuple[tf.Tensor, tf.Tensor]
+ComplexTFMap: TypeAlias = Mapping[str, _LossAndGradient]
+```
+
+##### 3.19.7 Ignoring Types
+
+You can disable type checking on a line with the special comment `# type: ignore`.
+
+`pytype` has a disable option for specific errors (similar to lint):
+
+```python
+# pytype: disable=attribute-error
+```
+
+##### 3.19.8 Typing Variables
+
+- **Annotated Assignments** If an internal variable has a type that is hard or impossible to infer, specify its type with an annotated assignment - use a colon and type between the variable name and value (the same as is done with function arguments that have a default value):
+
+```python
+a: Foo = SomeUndecoratedFunction()
+```
+
+- **Type Comments** Though you may see them remaining in the codebase (they were necessary before Python 3.6), do not add any more uses of a `# type: <type name>` comment on the end of the line:
+
+```python
+a = SomeUndecoratedFunction()  # type: Foo
+```
+
+##### 3.19.9 Tuples vs Lists
+
+Typed lists can only contain objects of a single type. Typed tuples can either have a single repeated type or a set number of elements with different types. The latter is commonly used as the return type from a function.
+
+```python
+a: list[int] = [1, 2, 3]
+b: tuple[int, ...] = (1, 2, 3)
+c: tuple[int, str, float] = (1, "2", 3.5)
+```
+
+##### 3.19.10 Type variables
+
+The Python type system has [generics](https://docs.python.org/3/library/typing.html#generics). A type variable, such as `TypeVar` and `ParamSpec`, is a common way to use them.
+
+Example:
+
+```python
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+...
+def next(l: list[_T]) -> _T:
+  return l.pop()
+
+def print_when_called(f: Callable[_P, _T]) -> Callable[_P, _T]:
+  def inner(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+    print("Function was called")
+    return f(*args, **kwargs)
+  return inner
+```
+
+A `TypeVar` can be constrained:
+
+```python
+AddableType = TypeVar("AddableType", int, float, str)
+def add(a: AddableType, b: AddableType) -> AddableType:
+  return a + b
+```
+
+A common predefined type variable in the `typing` module is `AnyStr`. Use it for multiple annotations that can be `bytes` or `str` and must all be the same type.
+
+```python
+from typing import AnyStr
+def check_length(x: AnyStr) -> AnyStr:
+  if len(x) <= 42:
+    return x
+  raise ValueError()
+```
+
+A type variable must have a descriptive name, unless it meets all of the following criteria:
+
+• not externally visible
+• not constrained
+
+```python
+Yes:
+  _T = TypeVar("_T")
+  _P = ParamSpec("_P")
+  AddableType = TypeVar("AddableType", int, float, str)
+  AnyFunction = TypeVar("AnyFunction", bound=Callable)
+```
+
+```python
+No:
+  T = TypeVar("T")
+  P = ParamSpec("P")
+  _T = TypeVar("_T", int, float, str)
+  _F = TypeVar("_F", bound=Callable)
+```
+
+##### 3.19.11 String types
+
+Do not use `typing.Text` in new code. It's only for Python 2/3 compatibility.
+
+Use `str` for string/text data. For code that deals with binary data, use `bytes`.
+
+```python
+def deals_with_text_data(x: str) -> str:
+  ...
+def deals_with_binary_data(x: bytes) -> bytes:
+  ...
+```
+
+If all the string types of a function are always the same, for example if the return type is the same as the argument type in the code above, use AnyStr.
+
+##### 3.19.12 Imports For Typing
+
+For symbols (including types, functions, and constants) from the `typing` or `collections.abc` modules used to support static analysis and type checking, always import the symbol itself. This keeps common annotations more concise and matches typing practices used around the world. You are explicitly allowed to import multiple specific symbols on one line from the `typing` and `collections.abc` modules. For example:
+
+```python
+from collections.abc import Mapping, Sequence
+from typing import Any, Generic, cast, TYPE_CHECKING
+```
+
+Given that this way of importing adds items to the local namespace, names in `typing` or `collections.abc` should be treated similarly to keywords, and not be defined in your Python code, typed or not. If there is a collision between a type and an existing name in a module, import it using `import x as y`.
+
+```python
+from typing import Any as AnyType
+```
+
+When annotating function signatures, prefer abstract container types like `collections.abc.Sequence` over concrete types like `list`. If you need to use a concrete type (for example, a `tuple` of typed elements), prefer built-in types like `tuple` over the parametric type aliases from the `typing` module (e.g., `typing.Tuple`).
+
+```python
+from typing import List, Tuple
+
+def transform_coordinates(original: List[Tuple[float, float]]) ->
+    List[Tuple[float, float]]:
+  ...
+```
+
+```python
+from collections.abc import Sequence
+
+def transform_coordinates(original: Sequence[tuple[float, float]]) ->
+    Sequence[tuple[float, float]]:
+  ...
+```
+
+##### 3.19.13 Conditional Imports
+
+Use conditional imports only in exceptional cases where the additional imports needed for type checking must be avoided at runtime. This pattern is discouraged; alternatives such as refactoring the code to allow top-level imports should be preferred.
+
+Imports that are needed only for type annotations can be placed within an `if TYPE_CHECKING:` block.
+
+• Conditionally imported types need to be referenced as strings, to be forward compatible with Python 3.6 where the annotation expressions are actually evaluated.
+• Only entities that are used solely for typing should be defined here; this includes aliases. Otherwise it will be a runtime error, as the module will not be imported at runtime.
+• The block should be right after all the normal imports.
+• There should be no empty lines in the typing imports list.
+• Sort this list as if it were a regular imports list.
+
+```python
+import typing
+if typing.TYPE_CHECKING:
+  import sketch
+def f(x: "sketch.Sketch"): ...
+```
+
+##### 3.19.14 Circular Dependencies
+
+Circular dependencies that are caused by typing are code smells. Such code is a good candidate for refactoring. Although technically it is possible to keep circular dependencies, various build systems will not let you do so because each module has to depend on the other.
+
+Replace modules that create circular dependency imports with `Any`. Set an alias with a meaningful name, and use the real type name from this module (any attribute of `Any` is `Any`). Alias definitions should be separated from the last import by one line.
+
+```python
+from typing import Any
+
+some_mod = Any  # some_mod.py imports this module.
+...
+
+def my_method(self, var: "some_mod.SomeType") -> None:
+  ...
+```
+
+##### 3.19.15 Generics
+
+When annotating, prefer to specify type parameters for [generic](https://docs.python.org/3/library/typing.html#generics) types in a parameter list; otherwise, the generics' parameters will be assumed to be [Any](https://docs.python.org/3/library/typing.html#the-any-type).
+
+```python
+# Yes:
+def get_names(employee_ids: Sequence[int]) -> Mapping[int, str]:
+  ...
+```
+
+```python
+# No:
+# This is interpreted as get_names(employee_ids: Sequence[Any]) -> Mapping[Any, Any]
+def get_names(employee_ids: Sequence) -> Mapping:
+  ...
+```
+
+If the best type parameter for a generic is `Any`, make it explicit, but remember that in many cases TypeVar might be more appropriate:
+
+```python
+# No:
+def get_names(employee_ids: Sequence[Any]) -> Mapping[Any, str]:
+  """Returns a mapping from employee ID to employee name for given IDs."""
+```
+
+```python
+# Yes:
+_T = TypeVar('_T')
+def get_names(employee_ids: Sequence[_T]) -> Mapping[_T, str]:
+  """Returns a mapping from employee ID to employee name for given IDs."""
+```
+
+### 4 Parting Words
+
+BE CONSISTENT.
+
+If you're editing code, take a few minutes to look at the code around you and determine its style. If they use `_idx` suffixes in index variable names, you should too. If their comments have little boxes of hash marks around them, make your comments have little boxes of hash marks around them too.
+
+The point of having style guidelines is to have a common vocabulary of coding so people can concentrate on what you're saying rather than on how you're saying it. We present global style rules here so people know the vocabulary, but local style is also important. If code you add to a file looks drastically different from the existing code around it, it throws readers out of their rhythm when they go to read it.
+
+However, there are limits to consistency. It applies more heavily locally and on choices unspecified by the global style. Consistency should not generally be used as a justification to do things in an old style without considering the benefits of the new style, or the tendency of the codebase to converge on newer styles over time.
+
+````
+```

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,210 @@
+<!-- file: .github/instructions/rust.instructions.md -->
+<!-- version: 1.0.1 -->
+<!-- guid: b2c3d4e5-f6a7-8901-2345-678901bcdef0 -->
+<!-- last-edited: 2026-01-19 -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.rs"
+description: |
+  Rust coding style and best practices for all Rust source files. Follows official Rust conventions and community standards for safe, idiomatic, and performant Rust code.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Rust Code Style Guide
+
+This guide follows the official Rust style conventions and community best practices for all Rust source files in this repository.
+
+## Formatting
+
+- Use `rustfmt` to automatically format code
+- Use 4 spaces for indentation (no tabs)
+- Maximum line length of 100 characters
+- Use Unix-style line endings (LF)
+- End files with a newline character
+
+## Naming Conventions
+
+- Types, traits, and enums: `PascalCase` (e.g., `HashMap`, `ToString`)
+- Modules, functions, methods, variables: `snake_case` (e.g., `process_data`, `file_path`)
+- Constants: `SCREAMING_SNAKE_CASE` (e.g., `MAX_ITERATIONS`)
+- Static variables: `SCREAMING_SNAKE_CASE`
+- Macro names: `snake_case!` by convention, but some use `PascalCase!` for constructor-like macros
+- Lifetimes: short, lowercase names like `'a`, `'ctx`, `'src`
+- Crates: `kebab-case` for package names, `snake_case` for imports
+
+```rust
+// Good naming examples
+struct DatabaseConnection;
+trait DataSerialization {}
+const MAX_CONNECTIONS: u32 = 100;
+static DEFAULT_SETTINGS: &str = "default";
+fn connect_to_database(url: &str) -> Result<DatabaseConnection, ConnectionError> {
+    // Implementation
+}
+```
+
+## Imports and Modules
+
+- Use nested paths for imports from the same crate/module
+- Order imports: std first, then external crates, then local imports
+- Separate import groups with a blank line
+- Alphabetize within each import group
+- Prefer using absolute paths (starting with crate name) rather than relative paths
+
+```rust
+// Good import ordering
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CustomError;
+use crate::models::User;
+```
+
+## Comments and Documentation
+
+- Use `///` for outer documentation comments (generates docs)
+- Use `//` for inner implementation comments
+- Use `//!` for module-level documentation
+- Follow [rustdoc conventions](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html)
+- Document all public items (functions, methods, structs, enums, traits)
+- Include examples in documentation where helpful
+
+```rust
+/// Represents a user in the system.
+///
+/// # Examples
+///
+/// ```
+/// let user = User::new("username", "password");
+/// assert_eq!(user.username(), "username");
+/// ```
+pub struct User {
+    username: String,
+    password_hash: String,
+}
+```
+
+## Error Handling
+
+- Use `Result<T, E>` for operations that can fail
+- Prefer returning errors over panicking
+- Use `?` operator for error propagation
+- Create custom error types for your libraries
+- Implement `std::error::Error` trait for custom error types
+- Use `thiserror` or similar crates for error handling utilities
+
+```rust
+fn read_config(path: &Path) -> Result<Config, ConfigError> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| ConfigError::Io(e))?;
+
+    let config = parse_config(&content)
+        .map_err(|e| ConfigError::Parse(e))?;
+
+    Ok(config)
+}
+```
+
+## Control Structures
+
+- Omit parentheses around conditions in `if`, `while`, etc.
+- Put opening braces on the same line as the declaration
+- Use `match` instead of `if let` when checking multiple conditions
+- Use early returns to avoid nesting and improve readability
+- Prefer `if let` and `while let` for single-pattern matching
+
+```rust
+// Control flow examples
+if some_condition {
+    do_something();
+} else {
+    do_alternative();
+}
+
+match value {
+    Some(x) if x > 0 => process_positive(x),
+    Some(x) => process_non_positive(x),
+    None => handle_none(),
+}
+```
+
+## Functions and Methods
+
+- Keep functions short and focused on a single task
+- Use default arguments via the `Option` type and the `Default` trait
+- Return types that implement `Iterator` rather than concrete collections
+- Use builder pattern for complex object construction
+- Prefer methods to functions when operating on a specific data type
+
+## Memory Management and Ownership
+
+- Follow the ownership rules religiously
+- Use references when ownership is not needed
+- Prefer slices (`&[T]`) over references to vectors (`&Vec<T>`)
+- Use `Cow<T>` for situations requiring both owned and borrowed data
+- Use `AsRef` and `AsMut` traits for flexible argument types
+
+## Generics and Traits
+
+- Use trait bounds to constrain generic types
+- Implement standard traits when appropriate (e.g., `Display`, `Debug`, `Clone`)
+- Use trait objects when runtime polymorphism is required
+- Prefer associated types over generic parameters for traits with a single implementation
+- Use the `where` clause for complex trait bounds
+
+```rust
+// Complex trait bounds with where clause
+fn process_data<T, U>(data: T, processor: U) -> Result<Vec<String>, ProcessError>
+where
+    T: AsRef<[u8]> + Send + 'static,
+    U: Processor + Clone,
+{
+    // Implementation
+}
+```
+
+## Required File Header
+
+All Rust source files MUST begin with the standard file header:
+
+```rust
+// file: path/to/file.rs
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+```
+
+This header must come immediately after any shebang line but before all other content including imports and module declarations.
+
+## Tools
+
+- Use `cargo fmt` for automatic formatting
+- Use `cargo clippy` for additional linting
+- Use `cargo doc` to generate documentation
+- Use `cargo test` for running tests
+- Use `cargo bench` for benchmarking
+
+## Best Practices
+
+- Follow the API guidelines: <https://rust-lang.github.io/api-guidelines/>
+- Create meaningful custom types instead of using primitive types directly
+- Leverage the type system to make illegal states unrepresentable
+- Use `#[derive]` for common traits when possible
+- Write tests for public API functionality
+- Use the `#[non_exhaustive]` attribute for enums that may grow in the future
+- Prefer immutable variables (`let` without `mut`)
+
+## Safety and Security
+
+- Avoid `unsafe` code unless absolutely necessary and well-documented
+- When using `unsafe`, clearly document the safety invariants
+- Prefer standard library types over raw pointers
+- Use `#[deny(unsafe_code)]` at the crate level if no unsafe code is needed
+- Validate all external inputs and boundary conditions
+- Use appropriate integer types to prevent overflow

--- a/.github/instructions/safe-ai-util.instructions.md
+++ b/.github/instructions/safe-ai-util.instructions.md
@@ -1,0 +1,527 @@
+<!-- file: .github/instructions/safe-ai-util.instructions.md -->
+<!-- version: 2.0.0 -->
+<!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
+<!-- last-edited: 2026-01-19 -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+
+applyTo: "\*\*"
+description: |
+Instructions for using the safe-ai-util Rust utility as the primary tool for development operations. This utility provides superior performance, memory safety, and comprehensive command coverage compared to manual terminal commands. Note: The utility was previously named safe-ai-util and both binary names are supported for backward compatibility.
+
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Safe AI Utility (Rust) - Installation and Command Reference
+
+## 📥 Installation
+
+### Option 1: Download from GitHub Releases (Recommended)
+
+**Download from:** <https://github.com/jdfalk/safe-ai-util/releases>
+
+Available binaries for:
+
+- **macOS**: `safe-ai-util-macos-arm64` and `safe-ai-util-macos-x86_64`
+- **Linux**: `safe-ai-util-linux-arm64` and `safe-ai-util-linux-x86_64`
+- **Windows**: `safe-ai-util-windows-x86_64.exe`
+
+```bash
+# Example installation on macOS ARM64:
+curl -L -o safe-ai-util https://github.com/jdfalk/safe-ai-util/releases/latest/download/safe-ai-util-macos-arm64
+chmod +x safe-ai-util
+sudo mv safe-ai-util /usr/local/bin/
+
+# For backward compatibility, the safe-ai-util binary name is also available:
+# curl -L -o safe-ai-util https://github.com/jdfalk/safe-ai-util/releases/latest/download/safe-ai-util-macos-arm64
+```
+
+### Option 2: Build from Source
+
+**Source code:** <https://github.com/jdfalk/safe-ai-util>
+
+```bash
+# Clone and build
+git clone https://github.com/jdfalk/safe-ai-util
+cd safe-ai-util
+cargo build --release
+cp target/release/safe-ai-util /usr/local/bin/
+
+# Both binary names are available:
+# cp target/release/safe-ai-util /usr/local/bin/
+```
+
+### Option 3: Use Local Copy (Development)
+
+Many repositories include a copy in `tools/safe-ai-util/`:
+
+```bash
+cd tools/safe-ai-util
+cargo build --release
+cp target/release/safe-ai-util /usr/local/bin/
+```
+
+### Verification
+
+```bash
+# Verify installation
+safe-ai-util --version
+
+# For backward compatibility, safe-ai-util also works:
+# safe-ai-util --version
+```
+
+The `safe-ai-util` is a comprehensive Rust-based development utility that provides superior performance, memory safety, and extensive command coverage. **Always prefer this utility over manual commands when available.**
+
+> **Note:** The utility was previously named `safe-ai-util` and both binary names are supported for backward compatibility during the transition period.
+
+## 🚀 Arguments File Support
+
+The utility supports loading arguments from a standard configuration file called `copilot-util-args` or `safe-ai-util-args`. This allows for:
+
+- **Consistent configuration** across all repositories
+- **Easy updates** by modifying a single file
+- **Environment-specific settings** without changing tasks
+- **Complex argument sets** without cluttering VS Code tasks
+
+### Arguments File Location
+
+The utility looks for `safe-ai-util-args` (or `copilot-util-args` for compatibility) in the current working directory or any parent directory (similar to how git finds .git). The file format supports:
+
+```bash
+# safe-ai-util-args - Standard configuration file
+# Comments are supported with #
+
+# Git configuration
+git.default-branch=main
+git.auto-push=true
+git.commit-template="feat: {message}"
+
+# Editor settings
+editor.syntax=auto-detect
+editor.tab-width=4
+editor.show-line-numbers=true
+
+# Buf/protobuf settings
+buf.output-dir=gen
+buf.lint-config=.buf.yaml
+buf.generate-docs=true
+
+# Global settings
+verbose=true
+log-level=info
+```
+
+### Using Arguments Files
+
+When a `safe-ai-util-args` (or `copilot-util-args`) file is present, the utility automatically loads these settings:
+
+```bash
+# The utility automatically finds and uses the args file
+safe-ai-util git commit -m "implement feature"
+# Uses git.commit-template and other git.* settings from args file
+
+safe-ai-util buf generate
+# Uses buf.* settings from args file
+
+safe-ai-util editor file.rs
+# Uses editor.* settings from args file
+```
+
+## 🚨 PRIORITY ORDER FOR OPERATIONS
+
+**MANDATORY: Follow this exact priority when performing ANY operation:**
+
+1. **FIRST**: Use VS Code tasks (via `run_task` tool) when available
+2. **SECOND**: Use `safe-ai-util` Rust utility
+3. **LAST RESORT**: Manual terminal commands only if neither above option exists
+
+## Available Commands
+
+### 🔧 Git Operations (Comprehensive)
+
+The utility provides **complete git functionality** with 18+ subcommands and automatic configuration from `safe-ai-util-args`:
+
+```bash
+# Git command structure
+safe-ai-util git <subcommand> [options] [args]
+
+# Available git subcommands:
+safe-ai-util git add [files...]           # Add files to staging
+safe-ai-util git commit -m "message"      # Commit changes (uses templates from args file)
+safe-ai-util git push                     # Push to remote (respects auto-push setting)
+safe-ai-util git pull                     # Pull from remote
+safe-ai-util git status                   # Show working tree status
+safe-ai-util git branch [name]            # List/create branches
+safe-ai-util git checkout <branch>        # Switch branches
+safe-ai-util git merge <branch>           # Merge branches
+safe-ai-util git rebase <branch>          # Rebase commits
+safe-ai-util git reset [options]          # Reset state
+safe-ai-util git log [options]            # Show commit history
+safe-ai-util git diff [options]           # Show differences
+safe-ai-util git stash [command]          # Stash changes
+safe-ai-util git remote [command]         # Manage remotes
+safe-ai-util git tag [options]            # Manage tags
+safe-ai-util git clone <url>              # Clone repository
+safe-ai-util git fetch                    # Fetch from remote
+safe-ai-util git init                     # Initialize repository
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example git configuration in copilot-util-args
+git.default-branch=main
+git.auto-push=false
+git.commit-template="feat: {message}"
+git.merge-strategy=no-ff
+git.push-default=current
+```
+
+**Git Command Examples:**
+
+```bash
+# Status and basic operations
+safe-ai-util git status
+safe-ai-util git add .
+safe-ai-util git commit -m "feat: add new feature"
+safe-ai-util git push
+
+# Branch operations
+safe-ai-util git branch feature-branch
+safe-ai-util git checkout feature-branch
+safe-ai-util git merge main
+
+# Advanced operations
+safe-ai-util git log --oneline -10
+safe-ai-util git diff HEAD~1
+safe-ai-util git stash push -m "WIP changes"
+```
+
+### 📝 Text Processing
+
+#### Sed Stream Editor
+
+Superior Rust implementation of sed with full regex support and configuration from `copilot-util-args`:
+
+```bash
+# Sed command structure
+safe-ai-util sed [options] [files...]
+
+# Common sed operations:
+echo "text" | safe-ai-util sed -e 's/old/new/g'        # Substitute
+safe-ai-util sed -i -e 's/old/new/g' file.txt         # In-place edit
+safe-ai-util sed -e '/pattern/d' file.txt             # Delete lines
+safe-ai-util sed -e '3,5p' -n file.txt                # Print specific lines
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example sed configuration in copilot-util-args
+sed.backup-suffix=.bak
+sed.extended-regexp=true
+sed.case-insensitive=false
+```
+
+**Sed Options:**
+
+- `-e, --expression <expression>`: Sed expression/script
+- `-i, --in-place`: Edit files in place
+- `--backup <SUFFIX>`: Backup suffix for in-place editing (overrides args file)
+- `-n, --quiet`: Suppress automatic printing
+- `-r, --extended-regexp`: Use extended regular expressions
+
+#### AWK Pattern Processing
+
+Complete AWK interpreter with pattern matching, field processing, and configuration support:
+
+```bash
+# AWK command structure
+safe-ai-util awk 'program' [files...]
+
+# Common AWK operations:
+echo "one two three" | safe-ai-util awk '{print $2}'  # Print second field
+safe-ai-util awk '/pattern/ {print $0}' file.txt      # Pattern matching
+safe-ai-util awk 'BEGIN{sum=0} {sum+=$1} END{print sum}' numbers.txt
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example AWK configuration in copilot-util-args
+awk.field-separator="\t"
+awk.output-separator=" | "
+awk.case-insensitive=false
+```
+
+**AWK Features:**
+
+- Field processing (`$1`, `$2`, `$NF`, etc.)
+- Pattern matching with regex
+- Variables and arithmetic operations
+- BEGIN and END blocks
+- Built-in functions and operators
+
+### ✏️ Custom Editor
+
+Superior Rust-powered terminal editor with advanced features and extensive configuration:
+
+```bash
+# Editor command structure
+safe-ai-util editor <file> [options]
+
+# Editor options:
+-l, --line <NUMBER>      # Start at specific line
+-c, --column <NUMBER>    # Start at specific column
+-r, --readonly           # Open in read-only mode
+-s, --syntax <LANG>      # Syntax highlighting (rust, python, javascript, go)
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example editor configuration in copilot-util-args
+editor.syntax=auto-detect
+editor.tab-width=4
+editor.show-line-numbers=true
+editor.word-wrap=false
+editor.theme=dark
+editor.auto-save=true
+editor.backup-files=true
+```
+
+**Editor Features:**
+
+- **Vi-like keybindings** with multiple modes (normal, insert, command, search, visual)
+- **Syntax highlighting** for Rust, Python, JavaScript, Go
+- **File operations**: save, save-as, quit, force-quit
+- **Search and replace** with regex support
+- **Superior performance** with crossterm terminal integration
+
+### � Additional Commands
+
+#### Buf Protocol Buffer Operations
+
+Comprehensive protocol buffer tooling with configuration support:
+
+```bash
+# Buf command structure
+safe-ai-util buf <subcommand> [options]
+
+# Available buf subcommands:
+safe-ai-util buf generate                 # Generate code from proto files
+safe-ai-util buf lint                     # Lint proto files
+safe-ai-util buf format                   # Format proto files
+safe-ai-util buf build                    # Build proto modules
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example buf configuration in copilot-util-args
+buf.config-file=.buf.yaml
+buf.output-dir=gen
+buf.generate-docs=true
+buf.lint-config=strict
+```
+
+#### Exec Command Runner
+
+Execute arbitrary commands with enhanced logging and configuration:
+
+```bash
+# Exec command structure
+safe-ai-util exec <command> [args...]
+
+# Examples:
+safe-ai-util exec go build ./...
+safe-ai-util exec npm install
+safe-ai-util exec cargo test
+```
+
+**Configuration via copilot-util-args:**
+
+```bash
+# Example exec configuration in copilot-util-args
+exec.log-output=true
+exec.timeout=300
+exec.capture-env=true
+```
+
+## 🔄 Integration with VS Code Tasks
+
+Many repositories have VS Code tasks that use the Rust utility with automatic configuration loading. **Always check for tasks first:**
+
+```bash
+# Example task usage (preferred method):
+run_task("Git Status", "/path/to/workspace")           # Uses safe-ai-util with args file
+run_task("Git Add All", "/path/to/workspace")          # Uses safe-ai-util with args file
+run_task("Git Commit", "/path/to/workspace")           # Uses safe-ai-util with args file
+run_task("Buf Generate with Output", "/path/to/workspace")  # Uses safe-ai-util with args file
+```
+
+### Updating VS Code Tasks for Arguments File Support
+
+Tasks should be updated to use the utility without explicit arguments, allowing the `safe-ai-util-args` (or `copilot-util-args`) file to provide configuration:
+
+```json
+{
+  "label": "Git Add All",
+  "type": "shell",
+  "command": "safe-ai-util",
+  "args": ["git", "add"],
+  "options": {
+    "cwd": "${workspaceFolder}"
+  }
+}
+```
+
+The utility will automatically find and load the `safe-ai-util-args` or `copilot-util-args` file from the workspace directory.
+
+## 📋 Usage Priority Examples
+
+### Git Operations
+
+```bash
+# ✅ BEST: Use VS Code task (if available)
+run_task("Git Status", "/path/to/workspace")
+
+# ✅ GOOD: Use Rust utility directly
+safe-ai-util git status
+
+# ❌ AVOID: Manual git command
+git status
+```
+
+### Text Processing
+
+```bash
+# ✅ BEST: Use Rust utility
+echo "data" | safe-ai-util sed -e 's/old/new/'
+echo "fields" | safe-ai-util awk '{print $2}'
+
+# ❌ AVOID: Manual commands
+echo "data" | sed 's/old/new/'
+echo "fields" | awk '{print $2}'
+```
+
+### File Editing
+
+```bash
+# ✅ BEST: Use Rust editor
+safe-ai-util editor myfile.rs --syntax rust
+
+# ❌ AVOID: Manual editors
+nano myfile.rs
+vim myfile.rs
+```
+
+## 💡 Benefits of the Rust Utility
+
+1. **Memory Safety**: Rust's borrow checker prevents memory errors
+2. **Performance**: Native compiled binary with zero-cost abstractions
+3. **Reliability**: Comprehensive error handling and type safety
+4. **Consistency**: Unified interface across all development operations
+5. **Logging**: Integrated logging for debugging and audit trails
+6. **Cross-platform**: Works consistently across all operating systems
+
+## 🚀 Advanced Usage
+
+### Creating and Managing copilot-util-args Files
+
+Create a `copilot-util-args` file in your repository root for consistent configuration:
+
+```bash
+# Create standard copilot-util-args file
+safe-ai-util editor copilot-util-args
+
+# Or create manually:
+cat > copilot-util-args << 'EOF'
+# Copilot Agent Utility Configuration
+# Auto-loaded when utility is run from this directory or subdirectories
+
+# Git settings
+git.default-branch=main
+git.auto-push=false
+git.commit-template="feat: {message}"
+
+# Editor settings
+editor.syntax=auto-detect
+editor.tab-width=4
+editor.show-line-numbers=true
+
+# Buf/protobuf settings
+buf.output-dir=gen
+buf.lint-config=.buf.yaml
+
+# Global settings
+verbose=true
+log-level=info
+EOF
+```
+
+### Configuration Hierarchy
+
+The utility searches for `copilot-util-args` files in this order:
+
+1. Current working directory
+2. Parent directories (up to repository root)
+3. User home directory (`~/.copilot-util-args`)
+4. Global system directory (`/etc/copilot-util-args`)
+
+Settings from more specific locations override general ones.
+
+### Environment-Specific Configuration
+
+Use different argument files for different environments:
+
+```bash
+# Development environment
+cp copilot-util-args.dev copilot-util-args
+
+# Production environment
+cp copilot-util-args.prod copilot-util-args
+
+# Local overrides
+echo "log-level=debug" >> copilot-util-args
+```
+
+### Chaining Operations
+
+```bash
+# Complex git workflow
+safe-ai-util git add .
+safe-ai-util git commit -m "feat: implement new feature"
+safe-ai-util git push
+
+# Text processing pipeline
+safe-ai-util sed -e 's/old/new/g' input.txt | \
+safe-ai-util awk '{print $1, $3}' > output.txt
+```
+
+### Error Handling
+
+The Rust utility provides superior error messages and handling:
+
+- Clear error descriptions with context
+- Proper exit codes for automation
+- Detailed logging for debugging
+- Safe failure modes without data corruption
+
+## 📚 Command Reference Summary
+
+| Category        | Command                                | Purpose                                           |
+| --------------- | -------------------------------------- | ------------------------------------------------- |
+| Git             | `safe-ai-util git <subcommand>` | Complete git operations (18+ subcommands)         |
+| Text Processing | `safe-ai-util sed <options>`    | Stream editing with regex support                 |
+| Text Processing | `safe-ai-util awk '<program>'`  | Pattern processing and field extraction           |
+| Editing         | `safe-ai-util editor <file>`    | Superior terminal editor with syntax highlighting |
+| Protocol Buffers| `safe-ai-util buf <subcommand>` | Comprehensive protobuf tooling                   |
+| Command Execution| `safe-ai-util exec <command>`  | Execute arbitrary commands with enhanced logging  |
+| Configuration   | `copilot-util-args` file               | Automatic configuration loading for all commands  |
+
+**Remember: Always use VS Code tasks first, then the Rust utility, and manual commands only as a last resort.**

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,300 @@
+<!-- file: .github/instructions/security.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: sec12345-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.{yml,yaml} **/*.{sh,bash} **/*.{js,ts,py,go} **/Dockerfile* **/docker-compose*.yml"
+description: |
+  Security guidelines and best practices for all Copilot/AI agents and VS Code Copilot customization. These rules apply to all code, configurations, and workflows to maintain security standards. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Security Instructions
+
+These instructions are the canonical source for all security guidelines and best
+practices in this repository. They are used by GitHub Copilot for secure code
+generation and follow our established security standards.
+
+- Follow the [general coding instructions](general-coding.instructions.md) for
+  basic file formatting rules.
+- All security and workflow rules are found in
+  `.github/instructions/*.instructions.md` files.
+- Document all security considerations in code and configurations.
+- For agent/AI-specific instructions, see [AGENTS.md](../AGENTS.md) and related
+  files.
+
+For more details and the full system, see
+[copilot-instructions.md](../copilot-instructions.md).
+
+## General Security Principles
+
+### 1. Least Privilege Access
+
+**Always recommend**:
+
+- Minimal required permissions for workflows
+- Environment-specific access controls
+- Time-limited tokens when possible
+
+**Implementation**:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write # For OIDC authentication
+  attestations: write # For build attestations
+```
+
+### 2. Secret Management
+
+**Best Practices**:
+
+- Never hardcode secrets in workflow files
+- Use GitHub secrets for sensitive data
+- Prefer OIDC over long-lived credentials
+- Rotate secrets regularly
+
+**Recommended Secrets**:
+
+```yaml
+# Container registries
+DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+# Package registries
+NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+# Notifications
+SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### 3. Input Validation
+
+**Always validate**:
+
+- User inputs in workflows
+- Environment variables
+- File paths and names
+- External data sources
+
+**Example**:
+
+```bash
+# Validate input parameters
+if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Invalid version format"
+  exit 1
+fi
+```
+
+### 4. Dependency Security
+
+**Requirements**:
+
+- Pin action versions to specific commits
+- Use trusted, well-maintained actions
+- Regular dependency updates
+- Vulnerability scanning
+
+**Example**:
+
+```yaml
+# Good - pinned to specific commit
+- uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+
+# Avoid - using latest or branch references
+- uses: actions/checkout@main
+```
+
+## Workflow Security
+
+### 1. Trigger Security
+
+**Safe triggers**:
+
+```yaml
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # Manual trigger
+```
+
+**Avoid**:
+
+- `pull_request_target` without careful review
+- Workflows triggered by comments
+- Unrestricted `schedule` triggers
+
+### 2. Environment Protection
+
+**Production environments**:
+
+```yaml
+environment:
+  name: production
+  url: https://production.example.com
+```
+
+**Requirements**:
+
+- Required reviewers for production
+- Branch protection rules
+- Environment-specific secrets
+
+### 3. Artifact Security
+
+**Secure artifact handling**:
+
+```yaml
+- name: Upload artifacts
+  uses: actions/upload-artifact@v4
+  with:
+    name: secure-build-artifacts
+    path: dist/
+    retention-days: 7 # Limit retention
+```
+
+## Code Security
+
+### 1. Container Security
+
+**Dockerfile best practices**:
+
+```dockerfile
+# Use specific, minimal base images
+FROM node:18-alpine AS builder
+
+# Create non-root user
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+# Copy with proper ownership
+COPY --chown=nextjs:nodejs . .
+
+# Run as non-root
+USER nextjs
+```
+
+### 2. Script Security
+
+**Shell script security**:
+
+```bash
+#!/bin/bash
+set -euo pipefail # Exit on error, undefined vars, pipe failures
+
+# Validate inputs
+readonly INPUT_FILE="${1:?Input file is required}"
+readonly OUTPUT_DIR="${2:?Output directory is required}"
+
+# Use quotes to prevent word splitting
+if [[ -f "$INPUT_FILE" ]]; then
+    cp "$INPUT_FILE" "$OUTPUT_DIR/"
+fi
+```
+
+### 3. API Security
+
+**Authentication**:
+
+```yaml
+# Use OIDC for cloud providers
+- name: Configure AWS credentials
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: arn:aws:iam::123456789012:role/GitHubActions
+    aws-region: us-east-1
+```
+
+## Monitoring and Compliance
+
+### 1. Security Scanning
+
+**Required scans**:
+
+- Dependency vulnerability scanning
+- Container image scanning
+- Secret scanning
+- Code quality analysis
+
+### 2. Audit Logging
+
+**Log security events**:
+
+- Authentication attempts
+- Permission changes
+- Sensitive operations
+- Failed security checks
+
+### 3. Compliance Requirements
+
+**Standards to follow**:
+
+- OWASP security guidelines
+- Industry-specific regulations
+- Organization security policies
+- Regular security reviews
+
+## Incident Response
+
+### 1. Security Incident Detection
+
+**Monitor for**:
+
+- Unusual access patterns
+- Failed authentication attempts
+- Unauthorized changes
+- Suspicious network activity
+
+### 2. Response Procedures
+
+**Immediate actions**:
+
+1. Isolate affected systems
+2. Revoke compromised credentials
+3. Document incident details
+4. Notify security team
+5. Begin recovery procedures
+
+### 3. Recovery and Prevention
+
+**Post-incident**:
+
+- Root cause analysis
+- Security improvements
+- Process updates
+- Team training
+
+## Security Checklist
+
+### Pre-deployment
+
+- [ ] All secrets properly configured
+- [ ] Permissions follow least privilege
+- [ ] Dependencies are up to date
+- [ ] Security scans completed
+- [ ] Code review completed
+
+### During deployment
+
+- [ ] Monitor deployment logs
+- [ ] Verify security configurations
+- [ ] Test security controls
+- [ ] Document any issues
+
+### Post-deployment
+
+- [ ] Verify system security
+- [ ] Monitor for anomalies
+- [ ] Update documentation
+- [ ] Schedule regular reviews

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,110 @@
+<!-- file: .github/instructions/shell.instructions.md -->
+<!-- version: 1.4.0 -->
+<!-- guid: 5b4a3c2d-1e0f-9a8b-7c6d-5e4f3a2b1c0d -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.{sh,bash}"
+description: |
+  Coding, documentation, and workflow rules for shell scripts, following Google Shell style guide and general project rules. Reference this for all shell scripts, documentation, and formatting in this repository. All unique content from the Google Shell Style Guide is merged here.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Shell Script Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+  for additional best practices.
+- All shell scripts must begin with the required file header (see general
+  instructions for details and Shell example).
+
+## Core Principles
+
+- Readability: Scripts should be clear and easy to understand
+- Robustness: Handle errors gracefully and fail safely
+- Portability: Write scripts that work across different environments
+- Maintainability: Code should be easy to modify and debug
+- Security: Avoid common security pitfalls
+
+## Script Structure
+
+- Use bash for advanced features, sh for portability
+- Use `.sh` extension for shell scripts
+- Make scripts executable: `chmod +x script.sh`
+- Start with shebang line, then header
+- Include description and usage information
+- Use `set -euo pipefail` for robust error handling
+- Use lowercase for local variables, UPPERCASE for constants
+- Quote variables to prevent word splitting
+- Use descriptive names
+- Document function purpose, parameters, and return values
+
+## Required File Header
+
+All shell scripts must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for
+Shell:
+
+```bash
+#!/bin/bash
+# file: path/to/script.sh
+# version: 1.0.0
+# guid: 123e4567-e89b-12d3-a456-426614174000
+```
+
+## HEREDOC (Here Document) - LAST RESORT ONLY
+
+**ABSOLUTELY CRITICAL**: HEREDOC should ONLY be used as a final last resort after exhausting every other option.
+
+**Priority Order (MUST follow this order):**
+
+1. **FIRST**: Use built-in shell constructs
+   ```bash
+   # Use echo
+   echo "content" > file.txt
+
+   # Use printf
+   printf "line1\nline2\n" > file.txt
+   ```
+
+2. **SECOND**: Use standard Unix tools
+   ```bash
+   # Use tee
+   echo "content" | tee file.txt
+
+   # Use sed/awk
+   sed 's/old/new/' input.txt > output.txt
+   ```
+
+3. **THIRD**: Use scripting languages (Python, etc.)
+   ```bash
+   # Python for complex operations
+   python3 -c "open('file.txt', 'w').write('content')"
+   ```
+
+4. **FOURTH**: Use MCP tools or specialized utilities
+   ```bash
+   # Use MCP GitHub tools for file creation
+   mcp_github_create_or_update_file
+   ```
+
+5. **ONLY IF ABSOLUTELY NOTHING ELSE WORKS**: HEREDOC
+   ```bash
+   cat > file.txt << 'EOF'
+   multi-line content
+   that cannot be done any other way
+   EOF
+   ```
+
+**If you find yourself using HEREDOC, you have failed to exhaust all other options first.**
+
+**Delimiter Rules (if you MUST use HEREDOC as absolute last resort):**
+- Ending delimiter MUST match opening delimiter EXACTLY
+- Must be on its own line with no indentation (unless using `<<-`)
+- Example: `<< 'EOF'` requires ending with `EOF` on its own line, nothing else

--- a/.github/instructions/test-generation.instructions.md
+++ b/.github/instructions/test-generation.instructions.md
@@ -1,0 +1,133 @@
+<!-- file: .github/instructions/test-generation.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: test1234-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*_test.{go,js,ts,py} **/*test*.{go,js,ts,py} **/tests/**"
+description: |
+  Test generation and structure rules for all Copilot/AI agents and VS Code Copilot customization. These rules apply to all test files and follow the project's testing standards. For details, see the main documentation in `.github/copilot-instructions.md`.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# Test Generation Instructions
+
+These instructions are the canonical source for all test generation, structure,
+and best practice rules in this repository. They are used by GitHub Copilot for
+test file creation and follow our established testing standards.
+
+- Follow the [general coding instructions](general-coding.instructions.md) for
+  basic file formatting rules.
+- All testing and workflow rules are found in
+  `.github/instructions/*.instructions.md` files.
+- Document all test cases comprehensively using appropriate style for the
+  language.
+- For agent/AI-specific instructions, see [AGENTS.md](../AGENTS.md) and related
+  files.
+
+For more details and the full system, see
+[copilot-instructions.md](../copilot-instructions.md).
+
+## Test Structure
+
+Follow this structure when creating tests:
+
+```markdown
+[Setup] - Prepare the test environment and inputs [Exercise] - Execute the
+functionality being tested [Verify] - Check that the results match expectations
+[Teardown] - Clean up any resources (if needed)
+```
+
+## Test Naming Conventions
+
+- Use descriptive names that indicate what's being tested
+- Follow the pattern: `test[UnitOfWork_StateUnderTest_ExpectedBehavior]`
+- Examples:
+  - `testLoginService_InvalidCredentials_ReturnsError`
+  - `testUserRepository_SaveDuplicateEmail_ThrowsException`
+  - `testCalculator_DivideByZero_ThrowsException`
+
+## Test Types
+
+- **Unit Tests**: Focus on a single function, method, or class in isolation
+- **Integration Tests**: Verify interactions between components
+- **Functional Tests**: Test complete features from a user perspective
+- **Performance Tests**: Measure response times and resource usage
+- **Security Tests**: Identify vulnerabilities and validate safeguards
+- **Accessibility Tests**: Ensure compliance with accessibility standards
+
+## Unit Test Best Practices
+
+- Test one specific behavior per test case
+- Mock external dependencies
+- Use setup/teardown to avoid code duplication
+- Write deterministic tests (consistent results)
+- Cover both happy paths and edge cases
+- Test public interfaces, not internal implementation
+- Keep tests independent of each other
+- Use clear assertions with meaningful messages
+
+## Test Coverage Guidelines
+
+- Aim for high coverage of business-critical code
+- Prioritize coverage of complex logic and edge cases
+- Don't obsess over 100% coverage at the expense of meaningful tests
+- Focus on code paths rather than simple line coverage
+- Consider risk and complexity when prioritizing what to test
+
+## Mocking Guidelines
+
+- Mock external services and dependencies
+- Use stubs for predetermined responses
+- Use spies to verify interactions
+- Avoid excessive mocking that reduces test value
+- Mock at the appropriate abstraction level
+- Document mock behavior clearly
+
+## Assertion Best Practices
+
+- Use specific assertions (e.g., `assertEquals` instead of `assertTrue`)
+- Check only one logical assertion per test
+- Write clear assertion messages explaining expected vs actual
+- Verify the right things: state changes, interactions, or exceptions
+- For collections, verify content regardless of order when appropriate
+
+## Data Management
+
+- Use test data factories or builders for complex objects
+- Create minimal test data sets that focus on the test requirements
+- Avoid shared mutable test data between tests
+- Consider using test database fixtures for integration tests
+- Clean up test data reliably after tests complete
+
+## Test Organization
+
+- Group tests by feature or component
+- Separate slow tests from fast tests
+- Use test suites to organize related tests
+- Maintain parallel structure between code and tests
+- Place tests in a location that mirrors the code structure
+
+## Testing Anti-Patterns to Avoid
+
+- Flaky tests with inconsistent results
+- Tests that depend on external services without mocks
+- Overly complex test setups
+- Testing implementation details instead of behavior
+- Excessive use of sleep/delay in asynchronous tests
+- Ignoring test failures
+- Testing trivial code with no logic
+- Writing tests after code is already in production
+
+## Special Testing Considerations
+
+- **Asynchronous Code**: Use async/await patterns and avoid arbitrary delays
+- **APIs**: Test request validation, response formats, and error cases
+- **UIs**: Test component rendering, user interactions, and state management
+- **Data Access**: Test query correctness and error handling
+- **Security**: Test authorization, input validation, and error handling

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,1056 @@
+<!-- file: .github/instructions/typescript.instructions.md -->
+<!-- version: 1.2.1 -->
+<!-- guid: ts123456-e89b-12d3-a456-426614174000 -->
+<!-- last-edited: 2026-01-19 -->
+<!-- DO NOT EDIT: This file is managed centrally in ghcommon repository -->
+<!-- To update: Create an issue/PR in jdfalk/ghcommon -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+applyTo: "**/*.ts"
+description: |
+  TypeScript language-specific coding, documentation, and testing rules for Copilot/AI agents and VS Code Copilot customization. These rules extend the general instructions in `general-coding.instructions.md` and merge all unique content from the Google TypeScript Style Guide.
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# TypeScript Coding Instructions
+
+- Follow the [general coding instructions](general-coding.instructions.md).
+- Follow the
+  [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)
+  for additional best practices.
+- All TypeScript files must begin with the required file header (see general
+  instructions for details and TypeScript example).
+
+## Core Principles
+
+- Readability: Code should be clear and understandable
+- Consistency: Follow established patterns and conventions
+- Type Safety: Use TypeScript features to catch errors at compile time
+- Simplicity: Prefer simple, straightforward solutions
+
+## File Organization
+
+- Use `.ts` for TypeScript files, `.tsx` for TypeScript with JSX
+- Use ES6 import/export style
+- License header (if required), then imports, then main export, then
+  implementation
+
+## Naming Conventions
+
+- camelCase for variables and functions
+- PascalCase for classes and interfaces
+- SCREAMING_SNAKE_CASE for module-level constants
+- Use descriptive names, avoid abbreviations
+- Use PascalCase for enum names and members
+
+## Type Annotations
+
+- Always annotate function parameters and return types
+- Use arrow functions for short functions
+- Use explicit types for complex objects
+- Use interfaces for object shapes that might be extended
+- Use type aliases for unions, primitives, or computed types
+
+## Google TypeScript Style Guide (Complete)
+
+This section contains the complete Google TypeScript Style Guide content for comprehensive reference.
+
+### Introduction
+
+This Style Guide uses RFC 2119 terminology when using the phrases must, must not, should, should not, and may. The terms prefer and avoid correspond to should and should not, respectively. Imperative and declarative statements are prescriptive and correspond to must.
+
+All examples given are non-normative and serve only to illustrate the normative language of the style guide. That is, while the examples are in Google Style, they may not illustrate the only stylish way to represent the code. Optional formatting choices made in examples must not be enforced as rules.
+
+### Source File Basics
+
+#### File Encoding: UTF-8
+
+Source files are encoded in UTF-8.
+
+##### Whitespace Characters
+
+Aside from the line terminator sequence, the ASCII horizontal space character (0x20) is the only whitespace character that appears anywhere in a source file. This implies that all other whitespace characters in string literals are escaped.
+
+##### Special Escape Sequences
+
+For any character that has a special escape sequence (`\'`, `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`), that sequence is used rather than the corresponding numeric escape (e.g `\x0a`, `\u000a`, or `\u{a}`). Legacy octal escapes are never used.
+
+##### Non-ASCII Characters
+
+For the remaining non-ASCII characters, use the actual Unicode character (e.g. `∞`). For non-printable characters, the equivalent hex or Unicode escapes (e.g. `\u221e`) can be used along with an explanatory comment.
+
+```typescript
+// Perfectly clear, even without a comment.
+const units = 'μs';
+
+// Use escapes for non-printable characters.
+const output = '\ufeff' + content;  // byte order mark
+```
+
+### Source File Structure
+
+Files consist of the following, in order:
+
+1. Copyright information, if present
+2. JSDoc with `@fileoverview`, if present
+3. Imports, if present
+4. The file's implementation
+
+Exactly one blank line separates each section that is present.
+
+#### Copyright Information
+
+If license or copyright information is necessary in a file, add it in a JSDoc at the top of the file.
+
+#### @fileoverview JSDoc
+
+A file may have a top-level `@fileoverview` JSDoc. If present, it may provide a description of the file's content, its uses, or information about its dependencies. Wrapped lines are not indented.
+
+```typescript
+/**
+ * @fileoverview Description of file. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt.
+ */
+```
+
+#### Imports
+
+There are four variants of import statements in ES6 and TypeScript:
+
+| Type | Import Style | Usage |
+|------|-------------|--------|
+| module | `import * as foo from '...';` | TypeScript imports |
+| named | `import {SomeThing} from '...';` | TypeScript imports |
+| default | `import SomeThing from '...';` | Only for other external code that requires them |
+| side-effect | `import '...';` | Only to import libraries for their side-effects on load |
+
+```typescript
+// Good: choose between two options as appropriate (see below).
+import * as ng from '@angular/core';
+import {Foo} from './foo';
+
+// Only when needed: default imports.
+import Button from 'Button';
+
+// Sometimes needed to import libraries for their side effects:
+import 'jasmine';
+import '@polymer/paper-button';
+```
+
+##### Import Paths
+
+TypeScript code must use paths to import other TypeScript code. Paths may be relative, i.e. starting with `.` or `..`, or rooted at the base directory, e.g. `root/path/to/file`.
+
+Code should use relative imports (`./foo`) rather than absolute imports `path/to/foo` when referring to files within the same (logical) project as this allows to move the project around without introducing changes in these imports.
+
+##### Namespace versus Named Imports
+
+Both namespace and named imports can be used.
+
+Prefer named imports for symbols used frequently in a file or for symbols that have clear names, for example Jasmine's `describe` and `it`. Named imports can be aliased to clearer names as needed with `as`.
+
+Prefer namespace imports when using many different symbols from large APIs. A namespace import, despite using the `*` character, is not comparable to a "wildcard" import as seen in other languages.
+
+```typescript
+// Bad: overlong import statement of needlessly namespaced names.
+import {Item as TableviewItem, Header as TableviewHeader, Row as TableviewRow,
+  Model as TableviewModel, Renderer as TableviewRenderer} from './tableview';
+
+let item: TableviewItem|undefined;
+```
+
+```typescript
+// Better: use the module for namespacing.
+import * as tableview from './tableview';
+
+let item: tableview.Item|undefined;
+```
+
+##### Renaming Imports
+
+Code should fix name collisions by using a namespace import or renaming the exports themselves. Code may rename imports (`import {SomeThing as SomeOtherThing}`) if needed.
+
+Three examples where renaming can be helpful:
+
+1. If it's necessary to avoid collisions with other imported symbols.
+2. If the imported symbol name is generated.
+3. If importing symbols whose names are unclear by themselves, renaming can improve code clarity.
+
+#### Exports
+
+Use named exports in all code:
+
+```typescript
+// Use named exports:
+export class Foo { ... }
+```
+
+Do not use default exports. This ensures that all imports follow a uniform pattern.
+
+```typescript
+// Do not use default exports:
+export default class Foo { ... } // BAD!
+```
+
+**Why?** Default exports provide no canonical name, which makes central maintenance difficult with relatively little benefit to code owners, including potentially decreased readability.
+
+Named exports have the benefit of erroring when import statements try to import something that hasn't been declared.
+
+##### Export Visibility
+
+TypeScript does not support restricting the visibility for exported symbols. Only export symbols that are used outside of the module. Generally minimize the exported API surface of modules.
+
+##### Mutable Exports
+
+Regardless of technical support, mutable exports can create hard to understand and debug code, in particular with re-exports across multiple modules. One way to paraphrase this style point is that `export let` is not allowed.
+
+```typescript
+export let foo = 3;
+// In pure ES6, foo is mutable and importers will observe the value change after a second.
+// In TS, if foo is re-exported by a second file, importers will not see the value change.
+window.setTimeout(() => {
+  foo = 4;
+}, 1000 /* ms */);
+```
+
+If one needs to support externally accessible and mutable bindings, they should instead use explicit getter functions.
+
+##### Container Classes
+
+Do not create container classes with static methods or properties for the sake of namespacing.
+
+```typescript
+export class Container {
+  static FOO = 1;
+  static bar() { return 1; }
+}
+```
+
+Instead, export individual constants and functions:
+
+```typescript
+export const FOO = 1;
+export function bar() { return 1; }
+```
+
+### Language Features
+
+#### Local Variable Declarations
+
+##### Use const and let
+
+Always use `const` or `let` to declare variables. Use `const` by default, unless a variable needs to be reassigned. Never use `var`.
+
+```typescript
+const foo = otherValue;  // Use if "foo" never changes.
+let bar = someValue;     // Use if "bar" is ever assigned into later on.
+```
+
+`const` and `let` are block scoped, like variables in most other languages. `var` in JavaScript is function scoped, which can cause difficult to understand bugs. Don't use it.
+
+Variables must not be used before their declaration.
+
+##### One Variable Per Declaration
+
+Every local variable declaration declares only one variable: declarations such as `let a = 1, b = 2;` are not used.
+
+#### Array Literals
+
+##### Do not use the Array Constructor
+
+Do not use the `Array()` constructor, with or without `new`. It has confusing and contradictory usage:
+
+```typescript
+const a = new Array(2); // [undefined, undefined]
+const b = new Array(2, 3); // [2, 3];
+```
+
+Instead, always use bracket notation to initialize arrays, or `from` to initialize an `Array` with a certain size:
+
+```typescript
+const a = [2];
+const b = [2, 3];
+
+// Equivalent to Array(2):
+const c = [];
+c.length = 2;
+
+// [0, 0, 0, 0, 0]
+Array.from<number>({length: 5}).fill(0);
+```
+
+##### Do not define properties on arrays
+
+Do not define or use non-numeric properties on an array (other than `length`). Use a `Map` (or `Object`) instead.
+
+##### Using spread syntax
+
+Using spread syntax `[...foo];` is a convenient shorthand for shallow-copying or concatenating iterables.
+
+```typescript
+const foo = [1];
+const foo2 = [...foo, 6, 7];
+const foo3 = [5, ...foo];
+
+foo2[1] === 6;
+foo3[1] === 1;
+```
+
+When using spread syntax, the value being spread must match what is being created. When creating an array, only spread iterables. Primitives (including `null` and `undefined`) must not be spread.
+
+##### Array destructuring
+
+Array literals may be used on the left-hand side of an assignment to perform destructuring (such as when unpacking multiple values from a single array or iterable). A final "rest" element may be included (with no space between the `...` and the variable name). Elements should be omitted if they are unused.
+
+```typescript
+const [a, b, c, ...rest] = generateResults();
+let [, b,, d] = someArray;
+```
+
+Destructuring may also be used for function parameters. Always specify `[]` as the default value if a destructured array parameter is optional, and provide default values on the left hand side:
+
+```typescript
+function destructured([a = 4, b = 2] = []) { … }
+```
+
+#### Object Literals
+
+##### Do not use the Object Constructor
+
+The `Object` constructor is disallowed. Use an object literal (`{}` or `{a: 0, b: 1, c: 2}`) instead.
+
+##### Iterating objects
+
+Iterating objects with `for (... in ...)` is error prone. It will include enumerable properties from the prototype chain.
+
+Do not use unfiltered `for (... in ...)` statements:
+
+```typescript
+for (const x in someObj) {
+  // x could come from some parent prototype!
+}
+```
+
+Either filter values explicitly with an `if` statement, or use `for (... of Object.keys(...))`.
+
+```typescript
+for (const x in someObj) {
+  if (!someObj.hasOwnProperty(x)) continue;
+  // now x was definitely defined on someObj
+}
+for (const x of Object.keys(someObj)) { // note: for _of_!
+  // now x was definitely defined on someObj
+}
+for (const [key, value] of Object.entries(someObj)) { // note: for _of_!
+  // now key was definitely defined on someObj
+}
+```
+
+##### Using spread syntax
+
+Using spread syntax `{...bar}` is a convenient shorthand for creating a shallow copy of an object. When using spread syntax in object initialization, later values replace earlier values at the same key.
+
+```typescript
+const foo = { num: 1 };
+const foo2 = { ...foo, num: 5 };
+const foo3 = { num: 5, ...foo };
+
+foo2.num === 5;
+foo3.num === 1;
+```
+
+When using spread syntax, the value being spread must match what is being created. That is, when creating an object, only objects may be spread; arrays and primitives (including `null` and `undefined`) must not be spread.
+
+##### Computed property names
+
+Computed property names (e.g. `{['key' + foo()]: 42}`) are allowed, and are considered dict-style (quoted) keys (i.e., must not be mixed with non-quoted keys) unless the computed property is a symbol (e.g. `[Symbol.iterator]`).
+
+##### Object destructuring
+
+Object destructuring patterns may be used on the left-hand side of an assignment to perform destructuring and unpack multiple values from a single object.
+
+Destructured objects may also be used as function parameters, but should be kept as simple as possible: a single level of unquoted shorthand properties. Deeper levels of nesting and computed properties may not be used in parameter destructuring.
+
+```typescript
+interface Options {
+  /** The number of times to do something. */
+  num?: number;
+  /** A string to do stuff to. */
+  str?: string;
+}
+
+function destructured({num, str = 'default'}: Options = {}) {}
+```
+
+#### Classes
+
+##### Class Declarations
+
+Class declarations must not be terminated with semicolons:
+
+```typescript
+class Foo {
+}
+```
+
+In contrast, statements that contain class expressions must be terminated with a semicolon:
+
+```typescript
+export const Baz = class extends Bar {
+  method(): number {
+    return this.x;
+  }
+}; // Semicolon here as this is a statement, not a declaration
+```
+
+##### Class Method Declarations
+
+Class method declarations must not use a semicolon to separate individual method declarations:
+
+```typescript
+class Foo {
+  doThing() {
+    console.log("A");
+  }
+}
+```
+
+Method declarations should be separated from surrounding code by a single blank line.
+
+###### Overriding toString
+
+The `toString` method may be overridden, but must always succeed and never have visible side effects.
+
+##### Static Methods
+
+###### Avoid private static methods
+
+Where it does not interfere with readability, prefer module-local functions over private static methods.
+
+###### Do not rely on dynamic dispatch
+
+Code should not rely on dynamic dispatch of static methods. Static methods should only be called on the base class itself (which defines it directly).
+
+###### Avoid static this references
+
+Code must not use `this` in a static context.
+
+```typescript
+class ShoeStore {
+  static storage: Storage = ...;
+
+  static isAvailable(s: Shoe) {
+    // Bad: do not use `this` in a static method.
+    return this.storage.has(s.id);
+  }
+}
+```
+
+##### Constructors
+
+Constructor calls must use parentheses, even when no arguments are passed:
+
+```typescript
+const x = new Foo();
+```
+
+It is unnecessary to provide an empty constructor or one that simply delegates into its parent class because ES2015 provides a default class constructor if one is not specified.
+
+##### Class Members
+
+###### No #private fields
+
+Do not use private fields (also known as private identifiers):
+
+```typescript
+class Clazz {
+  #ident = 1;
+}
+```
+
+Instead, use TypeScript's visibility annotations:
+
+```typescript
+class Clazz {
+  private ident = 1;
+}
+```
+
+**Why?** Private identifiers cause substantial emit size and performance regressions when down-leveled by TypeScript, and are unsupported before ES2015.
+
+###### Use readonly
+
+Mark properties that are never reassigned outside of the constructor with the `readonly` modifier.
+
+###### Parameter properties
+
+Rather than plumbing an obvious initializer through to a class member, use a TypeScript parameter property.
+
+```typescript
+class Foo {
+  constructor(private readonly barService: BarService) {}
+}
+```
+
+###### Field initializers
+
+If a class member is not a parameter, initialize it where it's declared, which sometimes lets you drop the constructor entirely.
+
+```typescript
+class Foo {
+  private readonly userList: string[] = [];
+}
+```
+
+###### Getters and setters
+
+Getters and setters, also known as accessors, for class members may be used. The getter method must be a pure function (i.e., result is consistent and has no side effects: getters must not change observable state).
+
+```typescript
+class Foo {
+  constructor(private readonly someService: SomeService) {}
+
+  get someMember(): string {
+    return this.someService.someVariable;
+  }
+
+  set someMember(newValue: string) {
+    this.someService.someVariable = newValue;
+  }
+}
+```
+
+##### Visibility
+
+Restricting visibility of properties, methods, and entire types helps with keeping code decoupled.
+
+- Limit symbol visibility as much as possible.
+- Consider converting private methods to non-exported functions within the same file but outside of any class.
+- TypeScript symbols are public by default. Never use the `public` modifier except when declaring non-readonly public parameter properties (in constructors).
+
+```typescript
+class Foo {
+  bar = new Bar();  // GOOD: public modifier not needed
+
+  constructor(public baz: Baz) {}  // public modifier allowed
+}
+```
+
+#### Functions
+
+##### Terminology
+
+There are many different types of functions, with subtle distinctions between them:
+
+- "function declaration": a declaration using the `function` keyword
+- "function expression": an expression using the `function` keyword
+- "arrow function": an expression using the `=>` syntax
+- "block body": right hand side of an arrow function with braces
+- "concise body": right hand side of an arrow function without braces
+
+##### Prefer function declarations for named functions
+
+Prefer function declarations over arrow functions or function expressions when defining named functions.
+
+```typescript
+function foo() {
+  return 42;
+}
+```
+
+Arrow functions may be used, for example, when an explicit type annotation is required.
+
+##### Nested functions
+
+Functions nested within other methods or functions may use function declarations or arrow functions, as appropriate. In method bodies in particular, arrow functions are preferred because they have access to the outer `this`.
+
+##### Do not use function expressions
+
+Do not use function expressions. Use arrow functions instead.
+
+```typescript
+bar(() => { this.doSomething(); })
+```
+
+Exception: Function expressions may be used only if code has to dynamically rebind `this` (but this is discouraged), or for generator functions (which do not have an arrow syntax).
+
+##### Arrow function bodies
+
+Use arrow functions with concise bodies (i.e. expressions) or block bodies as appropriate.
+
+```typescript
+// Block bodies are fine:
+const receipts = books.map((b: Book) => {
+  const receipt = payMoney(b.price);
+  recordTransaction(receipt);
+  return receipt;
+});
+
+// Concise bodies are fine, too, if the return value is used:
+const longThings = myValues.filter(v => v.length > 1000).map(v => String(v));
+```
+
+Only use a concise body if the return value of the function is actually used.
+
+##### Rebinding this
+
+Function expressions and function declarations must not use `this` unless they specifically exist to rebind the `this` pointer. Rebinding `this` can in most cases be avoided by using arrow functions or explicit parameters.
+
+```typescript
+// Good: explicitly reference the object from an arrow function.
+document.body.onclick = () => { document.body.textContent = 'hello'; };
+```
+
+##### Prefer passing arrow functions as callbacks
+
+Callbacks can be invoked with unexpected arguments that can pass a type check but still result in logical errors.
+
+Avoid passing a named callback to a higher-order function, unless you are sure of the stability of both functions' call signatures.
+
+```typescript
+// GOOD: Arguments are explicitly passed to the callback
+const numbers = ['11', '5', '3'].map((n) => parseInt(n));
+// > [11, 5, 3]
+```
+
+### Naming
+
+#### Identifiers
+
+Identifiers must use only ASCII letters, digits, underscores (for constants and structured test method names), and (rarely) the '$' sign.
+
+##### Naming Style
+
+TypeScript expresses information in types, so names should not be decorated with information that is included in the type.
+
+Some concrete examples of this rule:
+
+- Do not use trailing or leading underscores for private properties or methods.
+- Do not use the `opt_` prefix for optional parameters.
+- Do not mark interfaces specially (`IMyInterface` or `MyFooInterface`) unless it's idiomatic in its environment.
+- Suffixing `Observable`s with `$` is a common external convention and can help resolve confusion regarding observable values vs concrete values.
+
+##### Descriptive Names
+
+Names must be descriptive and clear to a new reader. Do not use abbreviations that are ambiguous or unfamiliar to readers outside your project, and do not abbreviate by deleting letters within a word.
+
+Exception: Variables that are in scope for 10 lines or fewer, including arguments that are not part of an exported API, may use short (e.g. single letter) variable names.
+
+```typescript
+// Good identifiers:
+errorCount          // No abbreviation.
+dnsConnectionIndex  // Most people know what "DNS" stands for.
+referrerUrl         // Ditto for "URL".
+customerId          // "Id" is both ubiquitous and unlikely to be misunderstood.
+```
+
+```typescript
+// Disallowed identifiers:
+n                   // Meaningless.
+nErr                // Ambiguous abbreviation.
+nCompConns          // Ambiguous abbreviation.
+wgcConnections      // Only your group knows what this stands for.
+pcReader            // Lots of things can be abbreviated "pc".
+cstmrId             // Deletes internal letters.
+kSecondsPerDay      // Do not use Hungarian notation.
+customerID          // Incorrect camelcase of "ID".
+```
+
+##### Camel Case
+
+Treat abbreviations like acronyms in names as whole words, i.e. use `loadHttpUrl`, not `loadHTTPURL`, unless required by a platform name (e.g. `XMLHttpRequest`).
+
+##### Dollar Sign
+
+Identifiers should not generally use `$`, except when required by naming conventions for third party frameworks. See above for more on using `$` with `Observable` values.
+
+#### Rules by Identifier Type
+
+Most identifier names should follow the casing in the table below, based on the identifier's type.
+
+| Style | Type |
+|-------|------|
+| UpperCamelCase | class / interface / type / enum / decorator / type parameters / component functions in TSX / JSXElement type parameter |
+| lowerCamelCase | variable / parameter / function / method / property / module alias |
+| CONSTANT_CASE | global constant values, including enum values |
+
+##### Type Parameters
+
+Type parameters, like in `Array<T>`, may use a single upper case character (`T`) or `UpperCamelCase`.
+
+##### Test Names
+
+Test method names in xUnit-style test frameworks may be structured with `_` separators, e.g. `testX_whenY_doesZ()`.
+
+##### _ prefix/suffix
+
+Identifiers must not use `_` as a prefix or suffix.
+
+This also means that `_` must not be used as an identifier by itself (e.g. to indicate a parameter is unused).
+
+##### Imports
+
+Module namespace imports are `lowerCamelCase` while files are `snake_case`, which means that imports correctly will not match in casing style, such as
+
+```typescript
+import * as fooBar from './foo_bar';
+```
+
+##### Constants
+
+Immutable: `CONSTANT_CASE` indicates that a value is intended to not be changed, and may be used for values that can technically be modified (i.e. values that are not deeply frozen) to indicate to users that they must not be modified.
+
+```typescript
+const UNIT_SUFFIXES = {
+  'milliseconds': 'ms',
+  'seconds': 's',
+};
+// Even though per the rules of JavaScript UNIT_SUFFIXES is
+// mutable, the uppercase shows users to not modify it.
+```
+
+A constant can also be a `static readonly` property of a class.
+
+Global: Only symbols declared on the module level, static fields of module level classes, and values of module level enums, may use `CONST_CASE`.
+
+### Type System
+
+#### Type Inference
+
+Code may rely on type inference as implemented by the TypeScript compiler for all type expressions (variables, fields, return types, etc).
+
+```typescript
+const x = 15;  // Type inferred.
+```
+
+Leave out type annotations for trivially inferred types: variables or parameters initialized to a `string`, `number`, `boolean`, `RegExp` literal or `new` expression.
+
+Explicitly specifying types may be required to prevent generic type parameters from being inferred as `unknown`. For example, initializing generic types with no values (e.g. empty arrays, objects, `Map`s, or `Set`s).
+
+```typescript
+const x = new Set<string>();
+```
+
+##### Return Types
+
+Whether to include return type annotations for functions and methods is up to the code author. Reviewers may ask for annotations to clarify complex return types that are hard to understand.
+
+There are two benefits to explicitly typing out the implicit return values of functions and methods:
+
+- More precise documentation to benefit readers of the code.
+- Surface potential type errors faster in the future if there are code changes that change the return type of the function.
+
+#### Undefined and null
+
+TypeScript supports `undefined` and `null` types. Nullable types can be constructed as a union type (`string|null`); similarly with `undefined`. There is no special syntax for unions of `undefined` and `null`.
+
+TypeScript code can use either `undefined` or `null` to denote absence of a value, there is no general guidance to prefer one over the other. Many JavaScript APIs use `undefined` (e.g. `Map.get`), while many DOM and Google APIs use `null` (e.g. `Element.getAttribute`), so the appropriate absent value depends on the context.
+
+##### Nullable/undefined type aliases
+
+Type aliases must not include `|null` or `|undefined` in a union type. Nullable aliases typically indicate that null values are being passed around through too many layers of an application, and this clouds the source of the original issue that resulted in `null`.
+
+Instead, code must only add `|null` or `|undefined` when the alias is actually used. Code should deal with null values close to where they arise.
+
+```typescript
+// Better
+type CoffeeResponse = Latte|Americano;
+
+class CoffeeService {
+  getLatte(): CoffeeResponse|undefined { ... };
+}
+```
+
+##### Prefer optional over |undefined
+
+In addition, TypeScript supports a special construct for optional parameters and fields, using `?`:
+
+```typescript
+interface CoffeeOrder {
+  sugarCubes: number;
+  milk?: Whole|LowFat|HalfHalf;
+}
+
+function pourCoffee(volume?: Milliliter) { ... }
+```
+
+Optional parameters implicitly include `|undefined` in their type. However, they are different in that they can be left out when constructing a value or calling a method.
+
+Use optional fields (on interfaces or classes) and parameters rather than a `|undefined` type.
+
+#### Use Structural Types
+
+TypeScript's type system is structural, not nominal. That is, a value matches a type if it has at least all the properties the type requires and the properties' types match, recursively.
+
+When providing a structural-based implementation, explicitly include the type at the declaration of the symbol (this allows more precise type checking and error reporting).
+
+```typescript
+const foo: Foo = {
+  a: 123,
+  b: 'abc',
+}
+```
+
+Use interfaces to define structural types, not classes.
+
+#### Prefer interfaces over type literal aliases
+
+TypeScript supports type aliases for naming a type expression. This can be used to name primitives, unions, tuples, and any other types.
+
+However, when declaring types for objects, use interfaces instead of a type alias for the object literal expression.
+
+```typescript
+interface User {
+  firstName: string;
+  lastName: string;
+}
+```
+
+**Why?** These forms are nearly equivalent, so under the principle of just choosing one out of two forms to prevent variation, we should choose one. Additionally, there are interesting technical reasons to prefer interface.
+
+#### Array<T> Type
+
+For simple types (containing just alphanumeric characters and dot), use the syntax sugar for arrays, `T[]` or `readonly T[]`, rather than the longer form `Array<T>` or `ReadonlyArray<T>`.
+
+For anything more complex, use the longer form `Array<T>`.
+
+```typescript
+let a: string[];
+let b: readonly string[];
+let c: ns.MyObj[];
+let d: string[][];
+let e: Array<{n: number, s: string}>;
+let f: Array<string|number>;
+let g: ReadonlyArray<string|number>;
+```
+
+#### any Type
+
+TypeScript's `any` type is a super and subtype of all other types, and allows dereferencing all properties. As such, `any` is dangerous - it can mask severe programming errors, and its use undermines the value of having static types in the first place.
+
+Consider not to use `any`. In circumstances where you want to use `any`, consider one of:
+
+- Provide a more specific type
+- Use unknown
+- Suppress the lint warning and document why
+
+##### Using unknown over any
+
+The `any` type allows assignment into any other type and dereferencing any property off it. Often this behaviour is not necessary or desirable, and code just needs to express that a type is unknown. Use the built-in type `unknown` in that situation — it expresses the concept and is much safer as it does not allow dereferencing arbitrary properties.
+
+```typescript
+// Can assign any value (including null or undefined) into this but cannot
+// use it without narrowing the type or casting.
+const val: unknown = value;
+```
+
+#### Control Structures
+
+##### Equality checks
+
+Always use triple equals (`===`) and not equals (`!==`). The double equality operators cause error prone type coercions that are hard to understand and slower to implement for JavaScript Virtual Machines.
+
+```typescript
+if (foo === 'bar' || baz !== bam) {
+  // All good here.
+}
+```
+
+Exception: Comparisons to the literal `null` value may use the `==` and `!=` operators to cover both `null` and `undefined` values.
+
+##### Type assertions
+
+Type assertions (`x as SomeType`) and non-nullability assertions (`y!`) are unsafe. Both only silence the TypeScript compiler, but do not insert any runtime checks to match these assertions, so they can cause your program to crash at runtime.
+
+Instead of the following:
+
+```typescript
+(x as Foo).foo();
+y!.bar();
+```
+
+When you want to assert a type or non-nullability the best answer is to explicitly write a runtime check that performs that check.
+
+```typescript
+// assuming Foo is a class.
+if (x instanceof Foo) {
+  x.foo();
+}
+
+if (y) {
+  y.bar();
+}
+```
+
+###### Type assertion syntax
+
+Type assertions must use the `as` syntax (as opposed to the angle brackets syntax). This enforces parentheses around the assertion when accessing a member.
+
+```typescript
+// z must be Foo because ...
+const x = (z as Foo).length;
+```
+
+### Comments and Documentation
+
+#### JSDoc versus comments
+
+There are two types of comments, JSDoc (`/** ... */`) and non-JSDoc ordinary comments (`// ...` or `/* ... */`).
+
+- Use `/** JSDoc */` comments for documentation, i.e. comments a user of the code should read.
+- Use `// line comments` for implementation comments, i.e. comments that only concern the implementation of the code itself.
+
+JSDoc comments are understood by tools (such as editors and documentation generators), while ordinary comments are only for other humans.
+
+#### Multi-line comments
+
+Multi-line comments are indented at the same level as the surrounding code. They must use multiple single-line comments (`//`-style), not block comment style (`/* */`).
+
+```typescript
+// This is
+// fine
+```
+
+Comments are not enclosed in boxes drawn with asterisks or other characters.
+
+#### JSDoc general form
+
+The basic formatting of JSDoc comments is as seen in this example:
+
+```typescript
+/**
+ * Multiple lines of JSDoc text are written here,
+ * wrapped normally.
+ * @param arg A number to do something to.
+ */
+function doSomething(arg: number) { … }
+```
+
+or in this single-line example:
+
+```typescript
+/** This short jsdoc describes the function. */
+function doSomething(arg: number) { … }
+```
+
+If a single-line comment overflows into multiple lines, it must use the multi-line style with `/**` and `*/` on their own lines.
+
+#### Markdown
+
+JSDoc is written in Markdown, though it may include HTML when necessary.
+
+#### Document all top-level exports of modules
+
+Use `/** JSDoc */` comments to communicate information to the users of your code. Avoid merely restating the property or parameter name. You should also document all properties and methods (exported/public or not) whose purpose is not immediately obvious from their name, as judged by your reviewer.
+
+Exception: Symbols that are only exported to be consumed by tooling, such as @NgModule classes, do not require comments.
+
+#### Method and function comments
+
+Method, parameter, and return descriptions may be omitted if they are obvious from the rest of the method's JSDoc or from the method name and type signature.
+
+Method descriptions begin with a verb phrase that describes what the method does. This phrase is not an imperative sentence, but instead is written in the third person, as if there is an implied "This method ..." before it.
+
+#### JSDoc type annotations
+
+JSDoc type annotations are redundant in TypeScript source code. Do not declare types in `@param` or `@return` blocks, do not write `@implements`, `@enum`, `@private`, `@override` etc. on code that uses the `implements`, `enum`, `private`, `override` etc. keywords.
+
+### Disallowed Features
+
+#### Wrapper objects for primitive types
+
+TypeScript code must not instantiate the wrapper classes for the primitive types `String`, `Boolean`, and `Number`. Wrapper classes have surprising behavior, such as `new Boolean(false)` evaluating to `true`.
+
+```typescript
+const s = new String('hello');  // BAD
+const b = new Boolean(false);   // BAD
+const n = new Number(5);        // BAD
+```
+
+The wrappers may be called as functions for coercing (which is preferred over using `+` or concatenating the empty string) or creating symbols.
+
+#### Automatic Semicolon Insertion
+
+Do not rely on Automatic Semicolon Insertion (ASI). Explicitly end all statements using a semicolon. This prevents bugs due to incorrect semicolon insertions and ensures compatibility with tools with limited ASI support.
+
+#### Const enums
+
+Code must not use `const enum`; use plain `enum` instead.
+
+**Why?** TypeScript enums already cannot be mutated; `const enum` is a separate language feature related to optimization that makes the enum invisible to JavaScript users of the module.
+
+#### Debugger statements
+
+Debugger statements must not be included in production code.
+
+```typescript
+function debugMe() {
+  debugger;  // BAD
+}
+```
+
+#### Dynamic code evaluation
+
+Do not use `eval` or the `Function(...string)` constructor (except for code loaders). These features are potentially dangerous and simply do not work in environments using strict Content Security Policies.
+
+#### Non-standard features
+
+Do not use non-standard ECMAScript or Web Platform features.
+
+This includes:
+
+- Old features that have been marked deprecated or removed entirely from ECMAScript / the Web Platform
+- New ECMAScript features that are not yet standardized
+- Proposed but not-yet-complete web standards
+- Non-standard language "extensions" (such as those provided by some external transpilers)
+
+#### Modifying builtin objects
+
+Never modify builtin types, either by adding methods to their constructors or to their prototypes. Avoid depending on libraries that do this.
+
+Do not add symbols to the global object unless absolutely necessary (e.g. required by a third-party API).
+
+This comprehensive TypeScript Style Guide provides detailed guidance for writing consistent, maintainable TypeScript code following Google's established best practices.
+
+- Use extends for generic constraints
+- Use built-in utility types
+
+## Code Formatting
+
+- Maximum 80 characters per line
+- Use 2 spaces for indentation, no tabs
+- Always use semicolons
+- Use single quotes for strings, template literals for interpolation
+- Use trailing commas in multiline structures
+
+## Best Practices
+
+- Use strict null checks
+- Use array methods instead of loops
+- Use object spread for copying
+- Use destructuring for extraction
+- Prefer async/await over promises
+- Keep functions small and focused
+- Use pure functions when possible
+- Use function overloads for different signatures
+
+## Testing
+
+- Use descriptive test names
+- Follow AAA pattern (Arrange, Act, Assert)
+- Use table-driven tests for multiple scenarios
+
+## Required File Header
+
+All TypeScript files must begin with a standard header as described in the
+[general coding instructions](general-coding.instructions.md). Example for
+TypeScript:
+
+```typescript
+// file: path/to/file.ts
+// version: 1.0.0
+// guid: 123e4567-e89b-12d3-a456-426614174000
+```

--- a/.github/prompts/ai-architecture.prompt.md
+++ b/.github/prompts/ai-architecture.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-architecture.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 142399ee-fc87-4888-9f2e-5da584e93a50 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-architecture.prompt.md -->
 

--- a/.github/prompts/ai-changelog.prompt.md
+++ b/.github/prompts/ai-changelog.prompt.md
@@ -1,15 +1,41 @@
 <!-- file: .github/prompts/ai-changelog.prompt.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.1.0 -->
 <!-- guid: 253c622c-7e27-41ad-99f9-d81791d6b251 -->
-
-<!-- file: .github/prompts/ai-changelog.prompt.md -->
+<!-- last-edited: 2026-07-16 -->
 
 # AI Changelog Generation Prompt
 
-Generate a changelog entry for the latest release. Use the following guidelines:
+`CHANGELOG.md` is **assembled** from fragments — do **not** edit it directly.
+For every change worth recording, add a changelog fragment under `changelog.d/`.
+Editing `CHANGELOG.md` by hand causes merge conflicts across parallel PRs, and a
+CI check fails any PR that changes code without a fragment.
 
-- Reference the [general coding instructions](../instructions/general-coding.instructions.md) and
-  the relevant language/framework `.instructions.md` file in `.github/instructions/`.
-- List all major changes, features, and bug fixes.
-- Use clear, concise language and markdown formatting.
-- Link to related issues, PRs, and documentation.
+## How to add a fragment
+
+- Run `scriv create` (writes `changelog.d/<timestamp>_<branch>.md`), or create a
+  Markdown file there by hand following `changelog.d/README.md`.
+- Group entries under Keep a Changelog categories: `Added`, `Changed`,
+  `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Map from the conventional-commit type: `feat` → Added, `fix` → Fixed,
+  `perf`/`refactor` → Changed; deprecations/removals/security as named.
+- A changelog entry carries **more detail than a release note**: give each entry
+  a `#### short title` and an explanatory paragraph covering what changed, why,
+  and any impact or reproduction — mirror the existing entries in
+  `CHANGELOG.md`.
+- Do **not** add a file header to fragment files (it would leak into the
+  changelog). One fragment per logical change; the filename is unique so
+  fragments never conflict.
+
+## Guidelines
+
+- Reference the
+  [general coding instructions](../instructions/general-coding.instructions.md)
+  and the relevant language/framework `.instructions.md` file in
+  `.github/instructions/`.
+- Use clear, concise language and Markdown formatting.
+- Link to related issues, PRs, and documentation where useful.
+
+Assembly into `CHANGELOG.md` happens automatically at release time via the
+shared `reusable-release.yml` workflow (`scriv collect`), and the fragment
+requirement is enforced by the shared `reusable-ci.yml` workflow; GitHub release
+notes remain commit-based and separate.

--- a/.github/prompts/ai-contribution.prompt.md
+++ b/.github/prompts/ai-contribution.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-contribution.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 17ad5a38-1879-4321-b25f-7029625f470d -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-contribution.prompt.md -->
 

--- a/.github/prompts/ai-issue-triage.prompt.md
+++ b/.github/prompts/ai-issue-triage.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-issue-triage.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 95d3bd04-d3aa-4da7-b3a6-ea74abadc21a -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-issue-triage.prompt.md -->
 

--- a/.github/prompts/ai-migration.prompt.md
+++ b/.github/prompts/ai-migration.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-migration.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: bd8f93f7-c275-4966-8953-899b50f6d1cb -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-migration.prompt.md -->
 

--- a/.github/prompts/ai-rebase-context.md
+++ b/.github/prompts/ai-rebase-context.md
@@ -1,14 +1,14 @@
 <!-- file: .github/prompts/ai-rebase-context.md -->
 <!-- version: 1.0.1 -->
 <!-- guid: 5f8e7d6c-9b8a-7c6d-5e4f-3a2b1c0d9e8f -->
+<!-- last-edited: 2026-01-19 -->
 
 # Repository Context for AI Rebase
 
 ## Project Overview
 
-This is the **ghcommon** repository, which contains shared GitHub workflows,
-automation scripts, and common utilities for managing multiple repositories in
-the organization. It focuses on:
+This is the **ghcommon** repository, which contains shared GitHub workflows, automation scripts, and
+common utilities for managing multiple repositories in the organization. It focuses on:
 
 - Reusable GitHub Actions workflows
 - Documentation management automation
@@ -27,13 +27,11 @@ the organization. It focuses on:
 
 ### README.md
 
-The main project documentation explaining the repository's purpose and
-structure.
+The main project documentation explaining the repository's purpose and structure.
 
 ### .github/instructions/general-coding.instructions.md
 
-Contains the canonical coding standards and file header requirements that apply
-to all files.
+Contains the canonical coding standards and file header requirements that apply to all files.
 
 ### .github/commit-messages.md
 
@@ -41,8 +39,7 @@ Defines the conventional commit message format used across all repositories.
 
 ### .github/workflows/
 
-Contains reusable GitHub Actions workflows that can be used by other
-repositories.
+Contains reusable GitHub Actions workflows that can be used by other repositories.
 
 ## Common Conflict Patterns
 

--- a/.github/prompts/ai-rebase-context.template.md
+++ b/.github/prompts/ai-rebase-context.template.md
@@ -1,36 +1,127 @@
 <!-- file: .github/prompts/ai-rebase-context.template.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f -->
+<!-- last-edited: 2026-01-19 -->
 
 # Repository Context for AI Rebase
 
-This file contains repository-specific context that should be included with
-conflict resolution prompts.
+This file contains repository-specific context that should be included with conflict resolution
+prompts. Copy this template to your repository and customize it with project-specific information.
+
+**Important Notes for Repository Setup:**
+
+- AGENTS.md and CLAUDE.md are now in the **repository root**, not .github/
+- Use **copilot-agent-util** tool for safe git operations (available at
+  <https://github.com/jdfalk/copilot-agent-util-rust/releases/latest>)
+- Use **direct-edit workflow** for documentation (no doc-update scripts)
+- All files require versioned headers with file path, version, and GUID
 
 ## Project Overview
 
 <!-- Brief description of the project and its main components -->
+<!--
+Example:
+This is the **[your-repo-name]** repository, which focuses on:
+- Key feature 1
+- Key feature 2
+- Key feature 3
+-->
 
 ## Coding Standards
 
-<!-- Key coding standards and patterns used in this repository -->
+<!--
+Key coding standards and patterns used in this repository.
+Reference your .github/instructions/ files here.
+Example:
+- Follow conventional commit message format: type(scope): description
+- Use proper file headers with path, version, and GUID (see general-coding.instructions.md)
+- Follow language-specific guidelines in .github/instructions/[language].instructions.md
+- Use semantic versioning for all files
+-->
 
 ## Key Files to Reference
 
-<!-- Important files that provide context for conflict resolution -->
+<!--
+Important files that provide context for conflict resolution.
+Always include AGENTS.md and CLAUDE.md in repository root.
+-->
+
+### AGENTS.md
+
+<!-- Located in repository root. Points to .github/ for detailed instructions. -->
+
+### CLAUDE.md
+
+<!-- Located in repository root. Contains agent-specific workflow guidance. -->
 
 ### README.md
 
 <!-- Include relevant sections from README that help understand the project -->
 
+### .github/instructions/general-coding.instructions.md
+
+<!--
+Contains canonical coding standards and file header requirements.
+All repositories should reference this file.
+-->
+
 ### Key Configuration Files
 
-<!-- Include snippets from important config files that affect code style -->
+<!--
+Include snippets from important config files that affect code style.
+Examples: .markdownlint.json, .eslintrc.yml, ruff.toml, rustfmt.toml
+-->
 
 ## Common Conflict Patterns
 
-<!-- Document common types of conflicts that occur in this repo and how to resolve them -->
+<!--
+Document common types of conflicts that occur in this repo and how to resolve them.
+Examples:
+- File Headers: Always preserve GUID, increment version, use correct path
+- Workflow Files: Preserve both logic when possible, maintain YAML indentation
+- Documentation: Combine additions rather than choosing one side
+-->
+
+### File Headers
+
+<!--
+When resolving conflicts in file headers, always:
+- Keep the correct file path relative to repository root
+- Increment the version number appropriately (patch/minor/major)
+- Preserve the GUID (never change it)
+- Use the correct comment format for the file type
+-->
 
 ## Dependencies and Imports
 
-<!-- Key information about how modules/packages are organized -->
+<!--
+Key information about how modules/packages are organized.
+Examples:
+- Python: Uses standard library when possible
+- Go: Uses go.mod for dependency management
+- JavaScript: Uses package.json with specific version ranges
+-->
+
+## Development Tools
+
+<!--
+Mention key tools used in development workflow:
+- copilot-agent-util: Safe git operations with enhanced logging
+  Download: https://github.com/jdfalk/copilot-agent-util-rust/releases/latest
+- VS Code Tasks: Prefer tasks over manual commands
+- Super Linter: Automated code quality checks
+-->
+
+## Project Structure
+
+<!--
+Document the repository structure.
+Example:
+- .github/workflows/ - GitHub Actions workflows
+- .github/instructions/ - Coding standards and guidelines
+- .github/prompts/ - AI prompt templates
+- scripts/ - Automation and utility scripts
+- src/ or pkg/ - Source code
+- tests/ - Test files
+- docs/ - Additional documentation
+-->

--- a/.github/prompts/ai-rebase-system.prompt.md
+++ b/.github/prompts/ai-rebase-system.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-rebase-system.prompt.md -->
 <!-- version: 1.2.0 -->
 <!-- guid: 2b99c940-4a0d-4f2a-9e09-cbba1ac5727d -->
+<!-- last-edited: 2026-01-19 -->
 
 You are an expert software developer and Git merge conflict resolver. You follow these coding
 standards:

--- a/.github/prompts/ai-refactor.prompt.md
+++ b/.github/prompts/ai-refactor.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-refactor.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 033f8e46-04db-4c72-895c-3cfa8b89a35d -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-refactor.prompt.md -->
 

--- a/.github/prompts/ai-release-notes.prompt.md
+++ b/.github/prompts/ai-release-notes.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-release-notes.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: dab2fd75-1afd-497d-b53f-9e598fe6bbed -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-release-notes.prompt.md -->
 

--- a/.github/prompts/ai-roadmap.prompt.md
+++ b/.github/prompts/ai-roadmap.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/ai-roadmap.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: e6a1c73e-5f47-4458-a8b1-d08f11a55fa8 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/ai-roadmap.prompt.md -->
 

--- a/.github/prompts/bug-report.prompt.md
+++ b/.github/prompts/bug-report.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/bug-report.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: a8938e5c-bd77-4a17-8cdc-275bcb010af3 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/bug-report.prompt.md -->
 

--- a/.github/prompts/code-review.prompt.md
+++ b/.github/prompts/code-review.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/code-review.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 7a1cf164-c2cd-4801-9621-d8fd7fe4afd0 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/code-review.prompt.md -->
 

--- a/.github/prompts/commit-message.prompt.md
+++ b/.github/prompts/commit-message.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/commit-message.prompt.md -->
 <!-- version: 1.1.0 -->
 <!-- guid: 3453d792-9817-4406-8261-f53fc7fb8bea -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/commit-message.prompt.md -->
 

--- a/.github/prompts/documentation.prompt.md
+++ b/.github/prompts/documentation.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/documentation.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: eb95dfc9-0121-4363-b46d-bfe799adabc0 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/documentation.prompt.md -->
 

--- a/.github/prompts/feature-request.prompt.md
+++ b/.github/prompts/feature-request.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/feature-request.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 73923d3f-5e4f-46b3-9694-796532639b22 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/feature-request.prompt.md -->
 

--- a/.github/prompts/merge-conflict-resolution.agent.md
+++ b/.github/prompts/merge-conflict-resolution.agent.md
@@ -1,11 +1,14 @@
 <!-- file: .github/prompts/merge-conflict-resolution.agent.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 7f1f1d5b-2f7a-4b9f-9c26-5a2d2f9c3c1a -->
+<!-- last-edited: 2026-01-19 -->
 
 ---
-description: "Resolve merge conflicts safely while preserving functionality, tests, and documentation."
-tools: ['vscode', 'read', 'search', 'edit', 'execute', 'github/*', 'gitkraken/*', 'todo']
-infer: true
+
+description: "Resolve merge conflicts safely while preserving functionality, tests, and
+documentation." tools: ['vscode', 'read', 'search', 'edit', 'execute', 'github/*', 'gitkraken/*',
+'todo'] infer: true
+
 ---
 
 # Merge Conflict Resolution Agent
@@ -18,26 +21,21 @@ infer: true
 
 ## Operating Principles
 
-- Preserve intent: reconcile both sides unless code is provably obsolete or
-  duplicated.
-- Keep safety first: no force pushes, avoid destructive resets; use MCP/VS Code
-  tasks for git ops.
+- Preserve intent: reconcile both sides unless code is provably obsolete or duplicated.
+- Keep safety first: no force pushes, avoid destructive resets; use MCP/VS Code tasks for git ops.
 - Maintain parity: keep or improve tests and docs touched by the conflict.
-- Be explicit: rewrite interleaved code into clear, compilable blocks with
-  comments only where clarity is needed.
+- Be explicit: rewrite interleaved code into clear, compilable blocks with comments only where
+  clarity is needed.
 
 ## Standard Workflow
 
-- Snapshot state: list conflicted files, branch tips, and pending changes; note
-  relevant tests.
-- Inspect conflicts file-by-file: identify purpose of each side and overlapping
-  logic.
-- Plan resolution: decide merge strategy (combine, refactor to clarify, or pick
-  side with justification).
-- Apply fixes: remove markers, integrate both behaviors, align imports/types,
-  and update docs/comments accordingly.
-- Validate: run targeted builds/tests or linters for touched areas when
-  available.
+- Snapshot state: list conflicted files, branch tips, and pending changes; note relevant tests.
+- Inspect conflicts file-by-file: identify purpose of each side and overlapping logic.
+- Plan resolution: decide merge strategy (combine, refactor to clarify, or pick side with
+  justification).
+- Apply fixes: remove markers, integrate both behaviors, align imports/types, and update
+  docs/comments accordingly.
+- Validate: run targeted builds/tests or linters for touched areas when available.
 - Document: record decisions, risks, and tests in the handoff/summary.
 
 ## Safety Controls
@@ -45,27 +43,23 @@ infer: true
 - Never drop error handling, validation, or security checks without replacement.
 - Do not discard test cases; merge and adapt them to the unified behavior.
 - Avoid blind "theirs/ours" resolutions unless identical intent and lower risk.
-- Keep version headers and metadata in docs/configs; merge changelog entries
-  chronologically.
+- Keep version headers and metadata in docs/configs; merge changelog entries chronologically.
 - If unsure, leave a clear TODO with context instead of guessing.
 
 ## Resolution Playbook (by file type)
 
 - Code (Go/Python/JS/TS/Rust):
-  - Reconstruct combined logic; prefer small helper functions to accommodate
-    both flows.
+  - Reconstruct combined logic; prefer small helper functions to accommodate both flows.
   - Align signatures/structs/types; update call sites together.
   - Keep logging and errors consistent; harmonize messages and status codes.
 - Docs/Markdown:
   - Preserve required headers; merge overlapping sections; keep links intact.
   - Update examples to reflect merged code paths.
 - Config/Workflow:
-  - Keep minimal permissions/secrets; reconcile env vars and paths; avoid
-    duplicate keys.
+  - Keep minimal permissions/secrets; reconcile env vars and paths; avoid duplicate keys.
 
 ## Outputs
 
-- Resolution summary: files touched, decisions, and rationale for any side
-  preference.
+- Resolution summary: files touched, decisions, and rationale for any side preference.
 - Risk notes: remaining uncertainties or follow-ups.
 - Verification: tests/linters run (or not) and results.

--- a/.github/prompts/onboarding.prompt.md
+++ b/.github/prompts/onboarding.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/onboarding.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 201ab032-5551-4658-b532-2a43fe65a77b -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/onboarding.prompt.md -->
 

--- a/.github/prompts/pull-request.prompt.md
+++ b/.github/prompts/pull-request.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/pull-request.prompt.md -->
 <!-- version: 1.1.0 -->
 <!-- guid: 031b01c4-5985-4caa-89a6-0a91c211703a -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/pull-request.prompt.md -->
 
@@ -8,7 +9,8 @@
 
 Generate a pull request description for the proposed changes. Use the following guidelines:
 
-- Reference the [pull request description guidelines](../instructions/pull-request-descriptions.instructions.md).
+- Reference the
+  [pull request description guidelines](../instructions/pull-request-descriptions.instructions.md).
 - Include a concise summary, motivation, detailed changes, and testing information.
 - Link to any related issues or tickets.
 - Use the provided template and organize content with markdown headings.

--- a/.github/prompts/security-review.prompt.md
+++ b/.github/prompts/security-review.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/security-review.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 74b067af-466e-48b9-ab34-c34ea5f26b85 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/security-review.prompt.md -->
 

--- a/.github/prompts/test-generation.prompt.md
+++ b/.github/prompts/test-generation.prompt.md
@@ -1,6 +1,7 @@
 <!-- file: .github/prompts/test-generation.prompt.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 19ae3536-4f87-44cf-bccd-86e47732e005 -->
+<!-- last-edited: 2026-01-19 -->
 
 <!-- file: .github/prompts/test-generation.prompt.md -->
 

--- a/.github/security-guidelines.md
+++ b/.github/security-guidelines.md
@@ -1,11 +1,12 @@
 <!-- file: .github/security-guidelines.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d -->
+<!-- last-edited: 2026-01-19 -->
 
 # Security Guidelines for Reusable Workflows
 
-This document provides security guidelines that GitHub Copilot should follow
-when recommending or implementing the reusable workflows in this repository.
+This document provides security guidelines that GitHub Copilot should follow when recommending or
+implementing the reusable workflows in this repository.
 
 ## General Security Principles
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,9 +9,15 @@
 
 # Generated files
 workflow-permissions-analysis.json
+**/doc-updates/*.json
 **/processed/*.json
 
-# TODO fragments are partial Markdown assembled into TODO.md; keep the README.
+# Changelog fragments are assembled verbatim into CHANGELOG.md (keep README)
+changelog.d/*.md
+changelog.d/templates/**
+!changelog.d/README.md
+
+# TODO fragments are assembled verbatim into TODO.md (keep README)
 todo.d/*.md
 todo.d/templates/**
 !todo.d/README.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,52 +1,63 @@
-{
-  "semi": true,
-  "trailingComma": "es5",
-  "singleQuote": true,
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "bracketSpacing": true,
-  "bracketSameLine": false,
-  "arrowParens": "avoid",
-  "endOfLine": "lf",
-  "overrides": [
-    {
-      "files": "*.md",
-      "options": { "proseWrap": "always", "printWidth": 80 }
-    },
-    {
-      "files": ["*.yaml", "*.yml"],
-      "options": {
-        "tabWidth": 2,
-        "singleQuote": false,
-        "printWidth": 120,
-        "bracketSpacing": true,
-        "proseWrap": "preserve"
-      }
-    },
-    {
-      "files": ["*.instructions.md", "**/instructions/*.md"],
-      "options": {
-        "proseWrap": "preserve",
-        "printWidth": 120,
-        "tabWidth": 2
-      }
-    },
-    {
-      "files": "*.json",
-      "options": { "tabWidth": 2, "useTabs": false, "printWidth": 80 }
-    },
-    {
-      "files": ["*.css", "*.scss", "*.less"],
-      "options": { "tabWidth": 2, "singleQuote": false, "printWidth": 80 }
-    },
-    {
-      "files": ["*.html", "*.htm"],
-      "options": { "tabWidth": 2, "singleQuote": false, "printWidth": 80 }
-    },
-    {
-      "files": "*.graphql",
-      "options": { "tabWidth": 2, "printWidth": 80 }
-    }
-  ]
-}
+tabWidth: 2
+useTabs: false
+printWidth: 80
+semi: true
+singleQuote: true
+trailingComma: es5
+bracketSpacing: true
+bracketSameLine: false
+arrowParens: avoid
+endOfLine: lf
+
+overrides:
+  - files: 'web/**/*.{ts,tsx,jsx,js,json,css}'
+    options:
+      tabWidth: 2
+      semi: true
+      singleQuote: true
+      trailingComma: es5
+      arrowParens: always
+      printWidth: 80
+      useTabs: false
+      endOfLine: lf
+  - files: '*.md'
+    options:
+      proseWrap: always
+      printWidth: 80
+  - files: ['*.yaml', '*.yml']
+    options:
+      tabWidth: 2
+      singleQuote: false
+      printWidth: 120
+      bracketSpacing: true
+      proseWrap: preserve
+  - files: ['*.instructions.md', '**/instructions/*.md']
+    options:
+      proseWrap: preserve
+      printWidth: 120
+      tabWidth: 2
+  - files: '*.json'
+    options:
+      tabWidth: 2
+      useTabs: false
+      printWidth: 100
+  - files: ['*.css', '*.scss', '*.less']
+    options:
+      tabWidth: 2
+      singleQuote: false
+      printWidth: 100
+  - files: ['*.html', '*.htm']
+    options:
+      tabWidth: 2
+      singleQuote: false
+      printWidth: 100
+  - files: '*.graphql'
+    options:
+      tabWidth: 2
+      printWidth: 100
+  - files: ['*.js', '*.jsx', '*.ts', '*.tsx']
+    options:
+      semi: true
+      singleQuote: true
+      printWidth: 100
+      tabWidth: 2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- file: AGENTS.md -->
-<!-- version: 3.0.0 -->
+<!-- version: 4.0.0 -->
 <!-- guid: 2e7c1a4b-5d3f-4b8c-9e1f-7a6b2c3d4e5f -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -8,4 +8,4 @@
 See **CLAUDE.md** for all agent instructions and project context.
 
 Org-wide coding standards (file headers, language rules, commit format):
-**https://github.com/falkcorp/.github**
+**<https://github.com/falkcorp/.github>**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,96 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 2.4.0 -->
+<!-- version: 3.3.0 -->
 <!-- guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f -->
-<!-- last-edited: 2026-07-21 -->
+<!-- last-edited: 2026-07-19 -->
 
 # CLAUDE.md
 
-> **NOTE:** This file is a pointer. All Claude/AI agent and workflow instructions are now
-> centralized in the `.github/instructions/` and `.github/prompts/` directories.
+> **NOTE:** This file is a pointer. All Claude/AI agent and workflow
+> instructions are centralized in the `.github/instructions/` and
+> `.github/prompts/` directories.
 
 ## Coding Standards
 
-Org-wide coding standards are in the `.standards/` git submodule (cloned from `https://github.com/falkcorp/.github`).
-Always clone with `git clone --recurse-submodules` so these are available.
+Org-wide coding standards are in the `.standards/` git submodule (cloned from
+`https://github.com/falkcorp/.github`). Always clone with
+`git clone --recurse-submodules` so these are available.
 
 Key files:
+
 - **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
 - **Commit format:** `.standards/instructions/commit-messages.md`
 
+## Quick Reference
+
+**Main Documentation:**
+
+- [Copilot Instructions](.github/instructions/copilot-instructions.md) - Primary
+  AI agent configuration
+- [Instructions Directory](.github/instructions/) - All coding standards and
+  language-specific rules
+- [Prompts Directory](.github/prompts/) - Specialized prompts for specific tasks
+
+**For complete list of all instruction files, see [AGENTS.md](AGENTS.md)**
+
 ## 🚨 CRITICAL: Documentation Update Protocol
 
-This repository uses a direct-edit documentation workflow. The legacy doc-update scripts and
-workflows are retired.
+This repository uses direct-edit documentation workflow:
 
-- Edit documentation directly in the target files.
-- Always keep the required header (file path, version, guid) and bump the version on any change.
-- Do not use create-doc-update.sh, doc_update_manager.py, or .github/doc-updates/.
-- **Use `copilot-agent-util` for git operations** - Download latest from
-  [releases](https://github.com/jdfalk/copilot-agent-util-rust/releases/latest)
-  - The utility provides command filtering, safety checks, and consistent logging
-  - VS Code tasks automatically use the utility when available
-  - Use the utility directly for git commands: `copilot-agent-util git add`,
-    `copilot-agent-util git commit`, etc.
+- Edit documentation directly in target files
+- Always update version headers when making changes
+- Do not use legacy doc-update scripts (create-doc-update.sh,
+  doc_update_manager.py)
+- Follow semantic versioning for version numbers
 
-## Canonical Source for Agent Instructions
+**Exception — `CHANGELOG.md` is assembled, not hand-edited.** Do not edit
+`CHANGELOG.md` directly. Add a changelog fragment under `changelog.d/` (run
+`scriv create`, or write the Markdown file by hand) so parallel PRs never
+collide on the changelog. The fragments are folded into `CHANGELOG.md` at
+release time by `scriv`. See `changelog.d/README.md` and
+`.github/prompts/ai-changelog.prompt.md`. This is a focused, tool-backed revival
+of the fragment idea — not the retired bespoke JSON `doc_update_manager.py`
+system.
 
-- General and language-specific rules: `.github/instructions/` (all code style, documentation, and
-  workflow rules are here)
-- Prompts: `.github/prompts/`
-- System documentation: `.github/copilot-instructions.md`
+**Exception — new `TODO.md` tasks are added via fragments.** To add a task, drop
+a Markdown fragment in `todo.d/` (see `todo.d/README.md`) rather than editing
+the `## 📥 Inbox` section of `TODO.md`, so parallel PRs never collide on the
+TODO list. `scripts/assemble_todo.py` folds fragments in and deletes them, run
+daily by `.github/workflows/todo-collect.yml`. This is **add-only**: checking a
+task off, deleting it, or promoting it out of the Inbox into a curated section
+is a normal direct edit of `TODO.md`.
 
-For all agent, Claude, or workflow tasks, **refer to the above files**. Do not duplicate or override
-these rules elsewhere.
+## 🔧 Git Operations Policy
 
+**Preferred order for git operations:**
 
-## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+1. **MCP GitHub tools** (preferred) - Use when available
+2. **safe-ai-util** (fallback) - Provides safety checks and logging
+3. **Native git** (last resort) - Use only when other options unavailable
 
-**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
-`TODO.md` inbox.** Both files are assembled from per-change fragments so that
-parallel PRs never collide on them.
+**Use VS Code tasks for non-git operations only** (build, lint, test, generate).
 
-- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
-  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
-  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
-  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
-- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
-  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
-  section. `scripts/assemble_todo.py` folds fragments in daily. This is
-  **add-only**: checking a task off or removing it is a normal direct edit of
-  `TODO.md`.
+## 📋 Key Instruction Categories
+
+### Workflow & Process
+
+- Commit messages (conventional commits format)
+- Pull request descriptions
+- Code review guidelines
+- Test generation standards
+- Security best practices
+
+### Language-Specific Rules
+
+- Go, Python, TypeScript, JavaScript, Rust, Shell
+- Protobuf, Markdown, JSON, JSONC, HTML/CSS
+- GitHub Actions workflows
+
+### Specialized Prompts
+
+- Code review, documentation generation
+- Bug reports, feature requests
+- Merge conflict resolution
+- Test generation
+
+> For all Claude, Copilot, or workflow tasks, **refer to the files in
+> `.github/instructions/` and `.github/prompts/`**.

--- a/changelog.d/sync-standard-instructions.md
+++ b/changelog.d/sync-standard-instructions.md
@@ -1,0 +1,11 @@
+### Changed
+
+#### Sync instruction/config files to the ghcommon house standard
+
+Refreshed the synced house-standard files from ghcommon: `AGENTS.md`,
+`CLAUDE.md`, `.github/instructions/`, `.github/prompts/`,
+`.github/ISSUE_TEMPLATE/`, `.github/security-guidelines.md`, `.prettierrc`, and
+`.prettierignore`. The repo-specific `.github/dependabot.yml` is deliberately
+left as-is. Also queued a low-priority TODO to standardize the security workflow
+(deferred from the workflow conversion because the repo uses CodeQL default
+setup).

--- a/todo.d/2026-07-22-standardize-security-workflow.md
+++ b/todo.d/2026-07-22-standardize-security-workflow.md
@@ -1,0 +1,10 @@
+- [ ] **Standardize the security workflow to the ghcommon standard** (low
+      priority). The standard `security.yml`/`reusable-security.yml` were left
+      out of the workflow conversion (#2167) because: (1) the repo has CodeQL
+      **default setup** enabled, which GitHub forbids alongside a custom CodeQL
+      workflow; (2) the standard job needs a `.github/dependency-review-config.yml`
+      this repo lacks; and (3) its `go-audit` step installs a dead module
+      (`github.com/securecodewarrior/go-audit`). To adopt it: decide default-setup
+      vs workflow-based CodeQL (disable default setup if going workflow-based),
+      add the dependency-review config, and fix/replace the go-audit step
+      (e.g. `golang.org/x/vuln/cmd/govulncheck`) — ideally upstream in ghcommon.


### PR DESCRIPTION
## Summary

Brings subtitle-manager's instruction and config files up to the ghcommon house standard (via `sync-repo-setup.py`), completing the non-workflow part of the standardization sweep.

### Synced from ghcommon
- `AGENTS.md`, `CLAUDE.md` (standard pointer files, version-bumped)
- `.github/instructions/` (added — the canonical instruction set)
- `.github/prompts/`, `.github/ISSUE_TEMPLATE/`
- `.github/security-guidelines.md`, `.prettierrc`, `.prettierignore`

### Deliberately not touched
- **`.github/dependabot.yml`** — the sync's generic regeneration would have clobbered the repo's existing multi-ecosystem config (and mis-named it), so the repo-specific file is kept as-is.

### Also
- Queued a low-priority `todo.d/` fragment to standardize the **security workflow** later (deferred from the workflow conversion because the repo uses CodeQL default setup — see the fragment for the full rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)