### PR TITLE
feat(scanner): library-search bridge — turn Sonarr/Radarr pulls into subtitle downloads (W1)

### DIFF
--- a/changelog.d/w1-library-search-bridge.md
+++ b/changelog.d/w1-library-search-bridge.md
@@ -1,0 +1,13 @@
+### Added
+
+#### Library → subtitle-search bridge (`library-search`)
+
+Added `scanner.ProcessLibrary` and the `library-search [lang]` command, which
+download subtitles for every item in the persisted media library — the rows
+populated by `scanlib` and by the Sonarr/Radarr sync. Previously nothing read
+the library to fetch subtitles (search only walked filesystem directories), so a
+Sonarr/Radarr pull never actually triggered a subtitle search. The sweep reuses
+`ProcessFile` per item (same validation, upgrade, history, and events as the
+directory scanner), is best-effort (one item's failure doesn't abort the run),
+and skips items whose file is missing on disk. See
+`docs/WHISPER_PIPELINE_DECISIONS.md` (W1) for the decisions behind this.

--- a/cmd/librarysearch.go
+++ b/cmd/librarysearch.go
@@ -1,0 +1,65 @@
+// file: cmd/librarysearch.go
+// version: 1.0.0
+// guid: 0e522c71-dd7d-4e80-af62-1fe449641282
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/scanner"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+)
+
+var librarySearchUpgrade bool
+
+// librarySearchCmd downloads subtitles for every item already recorded in the
+// media library (populated by `scanlib` or the Sonarr/Radarr sync), rather than
+// walking a directory. This is the bridge that turns a Sonarr/Radarr pull into
+// actual subtitle downloads.
+var librarySearchCmd = &cobra.Command{
+	Use:   "library-search [lang]",
+	Short: "Download subtitles for every item in the persisted media library",
+	Long: `Iterate the media library stored in the database (as populated by the
+scanlib command or the Sonarr/Radarr sync) and download subtitles for each item
+using all configured providers. Items whose file is missing on disk are skipped.
+
+This differs from 'scan', which walks a filesystem directory: library-search
+operates on the authoritative file paths pulled from Sonarr/Radarr.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("library-search")
+		lang := args[0]
+		if err := security.ValidateLanguageCode(lang); err != nil {
+			return err
+		}
+
+		dbPath := viper.GetString("db_path")
+		if dbPath == "" {
+			return fmt.Errorf("library-search requires a configured database (set db_path)")
+		}
+		store, err := database.OpenStore(dbPath, viper.GetString("db_backend"))
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+
+		workers := viper.GetInt("scan_workers")
+		if workers < 1 {
+			workers = 4
+		}
+		logger.Infof("searching subtitles for library items (lang=%s, workers=%d)", lang, workers)
+		return scanner.ProcessLibrary(context.Background(), lang, "", nil, librarySearchUpgrade, workers, store)
+	},
+}
+
+func init() {
+	librarySearchCmd.Flags().BoolVarP(&librarySearchUpgrade, "upgrade", "u", false, "replace existing subtitles when a better one is found")
+	rootCmd.AddCommand(librarySearchCmd)
+}

--- a/docs/WHISPER_PIPELINE_DECISIONS.md
+++ b/docs/WHISPER_PIPELINE_DECISIONS.md
@@ -1,0 +1,59 @@
+<!-- file: docs/WHISPER_PIPELINE_DECISIONS.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3e1b072f-e045-4b9d-8920-e957f3f06cd2 -->
+<!-- last-edited: 2026-07-23 -->
+
+# Whisper Pipeline — Decisions Log
+
+Running record of decisions made while implementing the Whisper-centric pipeline
+described in [`WHISPER_PIPELINE_DESIGN.md`](WHISPER_PIPELINE_DESIGN.md). Each
+entry is a decision the reviewer may want to **revise later**. Format:
+**Decision → Why → How to revise.**
+
+Work items are W1–W6 from the design doc. This log is appended to by each
+work-item PR.
+
+---
+
+## W1 — Library → subtitle-search bridge
+
+Implemented as `scanner.ProcessLibrary` (`pkg/scanner/library.go`) + the
+`library-search [lang]` CLI command (`cmd/librarysearch.go`).
+
+- **D1.1 Reuse `ProcessFile` per item rather than a new download path.**
+  Why: keeps language validation, output-path construction, existing-subtitle
+  skipping, upgrade logic, download-history recording, and failure events
+  identical to the directory scanner — one code path to maintain.
+  Revise: if library items should be searched differently from filesystem files
+  (e.g. richer provider queries from stored Title/Season/Episode), change the
+  body of `ProcessLibrary` to call a metadata-aware fetch instead of `ProcessFile`.
+
+- **D1.2 Best-effort sweep: a single item's fetch failure is logged, not fatal.**
+  Why: a missing subtitle for one title should not abort the whole library run.
+  Revise: to make failures fatal, return the error from the pool goroutine in
+  `ProcessLibrary` instead of logging and returning nil.
+
+- **D1.3 Skip items whose file is missing on disk (not an error).**
+  Why: the persisted library can lag the filesystem (deleted/moved media).
+  Revise: to surface stale entries, add a "prune missing" pass or log at a higher
+  level / emit an event.
+
+- **D1.4 Provider selection: use all configured providers (`FetchFromAll` via
+  `nil` provider), keyed on file path + language only.**
+  Why: matches current `scan` behaviour; no new configuration needed.
+  Revise: switch to `FetchWithProfile`/`FetchWithProfileTagged` (needs the
+  `*sql.DB` handle) to honour per-item language profiles and tags; or thread the
+  stored Title/Season/Episode into provider search queries for better matches.
+
+- **D1.5 Auto-trigger after Sonarr/Radarr sync is DEFERRED; the bridge is exposed
+  as a CLI command for now.**
+  Why: wiring a post-sync search into `pkg/sonarr/scheduler.go` /
+  `pkg/radarr/scheduler.go` requires threading language + provider config through
+  the schedulers; kept out of the first PR to stay focused. The CLI command is
+  cron-able in the meantime.
+  Revise: add an opt-in `sonarr.search_after_sync` / `radarr.search_after_sync`
+  config and call `ProcessLibrary` at the end of the scheduler's job function.
+
+- **D1.6 Default worker count in the CLI is 4 when `scan_workers` is unset.**
+  Why: a sensible parallelism default; `ProcessLibrary` itself clamps `<1` to 1.
+  Revise: change the default in `cmd/librarysearch.go` or set `scan_workers`.

--- a/pkg/scanner/library.go
+++ b/pkg/scanner/library.go
@@ -1,0 +1,72 @@
+// file: pkg/scanner/library.go
+// version: 1.0.0
+// guid: acade7fb-427e-4e78-b36f-894bf25b622c
+
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sourcegraph/conc/pool"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/providers"
+)
+
+// ProcessLibrary downloads subtitles for every media item recorded in the
+// store's library. The library is populated by scanlib (filesystem scan) and by
+// the Sonarr/Radarr sync, both of which persist database.MediaItem rows keyed by
+// the local media file path. This function is the bridge that lets a
+// Sonarr/Radarr pull actually drive subtitle search: previously nothing read the
+// persisted library to fetch subtitles.
+//
+// Behaviour and design decisions (see docs/WHISPER_PIPELINE_DECISIONS.md, W1):
+//   - It reuses ProcessFile per item, so language validation, output-path
+//     construction, existing-subtitle skipping, upgrade logic, download history,
+//     and failure events are identical to the directory scanner.
+//   - It is best-effort: a single item's fetch failure is logged and does not
+//     abort the sweep (unlike the pool-error propagation used elsewhere), because
+//     a missing subtitle for one title should not stop the rest of the library.
+//   - Items whose file no longer exists on disk, or that are not video files, are
+//     skipped rather than treated as errors (the library can lag the filesystem).
+//
+// When p is nil, ProcessFile falls back to providers.FetchFromAll across all
+// configured providers.
+func ProcessLibrary(ctx context.Context, lang, providerName string, p providers.Provider, upgrade bool, workers int, store database.SubtitleStore) error {
+	logger := logging.GetLogger("scanner")
+	if store == nil {
+		return fmt.Errorf("library search requires a database store")
+	}
+	items, err := store.ListMediaItems()
+	if err != nil {
+		return fmt.Errorf("list media items: %w", err)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	logger.Infof("library search over %d media items (lang=%s)", len(items), lang)
+
+	work := pool.New().WithErrors().WithMaxGoroutines(workers)
+	for i := range items {
+		item := items[i]
+		if item.Path == "" || !isVideoFile(item.Path) {
+			continue
+		}
+		if _, err := os.Stat(item.Path); err != nil {
+			logger.Debugf("skip missing library file %s", item.Path)
+			continue
+		}
+		work.Go(func() error {
+			logger.Debugf("library search %s", item.Path)
+			if err := ProcessFile(ctx, item.Path, lang, providerName, p, upgrade, store); err != nil {
+				// Best-effort: log and continue so one failure does not abort the sweep.
+				logger.Warnf("library search %s: %v", item.Path, err)
+			}
+			return nil
+		})
+	}
+	return work.Wait()
+}

--- a/pkg/scanner/library_test.go
+++ b/pkg/scanner/library_test.go
@@ -1,0 +1,107 @@
+// file: pkg/scanner/library_test.go
+// version: 1.0.0
+// guid: 39c3dc5d-d0bf-489d-8c43-0b33d257c01c
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+)
+
+// TestProcessLibrary verifies the library-search bridge fetches subtitles for
+// media items recorded in the store and skips items whose file is missing.
+func TestProcessLibrary(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	// A real library item pointing at an existing file, plus a stale item whose
+	// file no longer exists (should be skipped, not error).
+	if err := store.InsertMediaItem(&database.MediaItem{Path: vid, Title: "Movie"}); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+	if err := store.InsertMediaItem(&database.MediaItem{Path: filepath.Join(dir, "gone.mkv"), Title: "Gone"}); err != nil {
+		t.Fatalf("insert stale item: %v", err)
+	}
+
+	m := providersmocks.NewMockProvider(t)
+	// Fetch must be called exactly once — only for the existing file.
+	m.On("Fetch", mock.Anything, vid, "en").Return([]byte("sub"), nil).Once()
+
+	if err := ProcessLibrary(context.Background(), "en", "test", m, false, 2, store); err != nil {
+		t.Fatalf("process library: %v", err)
+	}
+	m.AssertExpectations(t)
+
+	data, err := os.ReadFile(filepath.Join(dir, "movie.en.srt"))
+	if err != nil {
+		t.Fatalf("read subtitle: %v", err)
+	}
+	if string(data) != "sub" {
+		t.Fatalf("unexpected subtitle %q", data)
+	}
+}
+
+// TestProcessLibraryNilStore verifies a nil store is a clear error, not a panic.
+func TestProcessLibraryNilStore(t *testing.T) {
+	if err := ProcessLibrary(context.Background(), "en", "test", nil, false, 1, nil); err == nil {
+		t.Fatal("expected error for nil store")
+	}
+}
+
+// TestProcessLibraryBestEffort verifies one item's fetch failure does not abort
+// the sweep: a second, healthy item still gets its subtitle.
+func TestProcessLibraryBestEffort(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.mkv")
+	bad := filepath.Join(dir, "bad.mkv")
+	for _, p := range []string{good, bad} {
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatalf("create %s: %v", p, err)
+		}
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	for _, p := range []string{bad, good} {
+		if err := store.InsertMediaItem(&database.MediaItem{Path: p}); err != nil {
+			t.Fatalf("insert %s: %v", p, err)
+		}
+	}
+
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, bad, "en").Return([]byte(nil), context.DeadlineExceeded)
+	m.On("Fetch", mock.Anything, good, "en").Return([]byte("ok"), nil)
+
+	if err := ProcessLibrary(context.Background(), "en", "test", m, false, 1, store); err != nil {
+		t.Fatalf("process library returned error despite best-effort: %v", err)
+	}
+
+	if data, err := os.ReadFile(filepath.Join(dir, "good.en.srt")); err != nil || string(data) != "ok" {
+		t.Fatalf("healthy item not processed after a failure: data=%q err=%v", data, err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **W1** from `docs/WHISPER_PIPELINE_DESIGN.md`: the missing bridge between the persisted media library and subtitle search.

The Sonarr/Radarr REST sync already writes `MediaItem` rows (authoritative local file paths), but **no code read them to fetch subtitles** — search only walked filesystem directories. This adds:

- `scanner.ProcessLibrary(ctx, lang, providerName, p, upgrade, workers, store)` — iterates `store.ListMediaItems()` and downloads a subtitle per item, reusing `ProcessFile` (identical validation/upgrade/history/events to the directory scanner).
- `library-search [lang]` CLI command.
- Tests: happy path, nil-store error, missing-file skip, and best-effort (one failure doesn't abort the sweep).

## Decisions (see `docs/WHISPER_PIPELINE_DECISIONS.md` W1)
- Reuse `ProcessFile` per item; best-effort sweep; skip missing files; use all providers (`FetchFromAll`); **auto-trigger after *arr sync is deferred** (exposed as a cron-able CLI for now).

## Verification
`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/scanner/` all pass.

Docs + decisions log included. 🤖 Generated with [Claude Code](https://claude.com/claude-code)