### PR TITLE
feat(subtitles): double-subs (bilingual, Esperanto-tagged) generation (W5)

### DIFF
--- a/changelog.d/w5-double-subs.md
+++ b/changelog.d/w5-double-subs.md
@@ -1,0 +1,12 @@
+### Added
+
+#### Double-subs (bilingual) generation (`dualsub`)
+
+Added `subtitles.GenerateDualSubtitles` and the `dualsub [input] [target-lang]`
+command, which produce a bilingual subtitle: each cue keeps its original line(s)
+and gains the translation stacked beneath (default target Mandarin `zh`). The
+output is written with a sentinel language suffix (default Esperanto `eo`, e.g.
+`video.eo.srt`) so media players treat it as a distinct, unused-language track
+rather than overwriting a real subtitle. Output is stacked-SRT; styled ASS
+positioning is a documented future option. See
+`docs/WHISPER_PIPELINE_DECISIONS.md` (W5).

--- a/cmd/dualsub.go
+++ b/cmd/dualsub.go
@@ -1,0 +1,72 @@
+// file: cmd/dualsub.go
+// version: 1.0.0
+// guid: 7b9d1e2a-4c86-4f30-9b57-1e8a2d6c3f45
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+)
+
+var (
+	dualSubOutput   string
+	dualSubSentinel string
+)
+
+// dualSubCmd generates a bilingual ("double subs") subtitle: the original text
+// with a translation stacked beneath each cue, tagged with a sentinel language
+// code (Esperanto "eo" by default) so players do not treat it as a real track.
+var dualSubCmd = &cobra.Command{
+	Use:   "dualsub [input] [target-lang]",
+	Short: "Generate bilingual double-subs (original + translation) tagged as a sentinel language",
+	Long: `Generate a bilingual "double subs" subtitle from an existing subtitle file:
+each cue keeps its original line(s) and gains the translation stacked beneath.
+
+The output is written with a sentinel language suffix (default "eo", Esperanto)
+so Plex/Jellyfin/Emby treat it as a distinct, unused-language track rather than
+overwriting a real subtitle. target-lang defaults to zh (Mandarin).`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("dualsub")
+		in := args[0]
+		targetLang := "zh"
+		if len(args) == 2 {
+			targetLang = args[1]
+		}
+		if err := security.ValidateLanguageCode(targetLang); err != nil {
+			return fmt.Errorf("invalid target language: %w", err)
+		}
+		if err := security.ValidateLanguageCode(dualSubSentinel); err != nil {
+			return fmt.Errorf("invalid sentinel language: %w", err)
+		}
+
+		out := dualSubOutput
+		if out == "" {
+			base := strings.TrimSuffix(in, filepath.Ext(in))
+			out = base + "." + dualSubSentinel + ".srt"
+		}
+
+		service := viper.GetString("translate_service")
+		gKey := viper.GetString("google_api_key")
+		gptKey := viper.GetString("openai_api_key")
+		grpcAddr := viper.GetString("grpc_addr")
+
+		logger.Infof("generating double-subs %s -> %s (target=%s, tag=%s)", in, out, targetLang, dualSubSentinel)
+		return subtitles.GenerateDualSubtitles(in, out, targetLang, service, gKey, gptKey, grpcAddr)
+	},
+}
+
+func init() {
+	dualSubCmd.Flags().StringVarP(&dualSubOutput, "output", "o", "", "output path (default: <input>.<sentinel>.srt)")
+	dualSubCmd.Flags().StringVar(&dualSubSentinel, "sentinel", "eo", "sentinel language code used to tag the double-subs output")
+	rootCmd.AddCommand(dualSubCmd)
+}

--- a/docs/WHISPER_PIPELINE_DECISIONS.md
+++ b/docs/WHISPER_PIPELINE_DECISIONS.md
@@ -57,3 +57,47 @@ Implemented as `scanner.ProcessLibrary` (`pkg/scanner/library.go`) + the
 - **D1.6 Default worker count in the CLI is 4 when `scan_workers` is unset.**
   Why: a sensible parallelism default; `ProcessLibrary` itself clamps `<1` to 1.
   Revise: change the default in `cmd/librarysearch.go` or set `scan_workers`.
+
+---
+
+## W5 — Double-subs (bilingual) generator
+
+Implemented as `subtitles.GenerateDualSubtitles` (`pkg/subtitles/dualsub.go`) +
+the `dualsub [input] [target-lang]` CLI command (`cmd/dualsub.go`).
+
+- **D5.1 Append the translation as a stacked line; keep the original.**
+  Why: the whole point of double-subs is showing both languages. This is the
+  opposite of `TranslateFileToSRT`, which replaces the cue text.
+  Revise: to change ordering (translation on top), swap the append for a prepend.
+
+- **D5.2 Output is stacked-SRT, not styled ASS.**
+  Why: SRT works everywhere and needs no styling engine; the multi-format ASS
+  writer (`pkg/media/server.go`) is currently stubbed. Original renders above,
+  translation below, within one cue.
+  Revise: implement an ASS output path (top/bottom `\an8`/`\an2` styles) once the
+  format writer is finished, and add a `--format ass` flag.
+
+- **D5.3 Translate the whole cue as one unit (all lines joined), not just the
+  first line.**
+  Why: the single-language translator only translates `Lines[0].Items[0]`, which
+  drops multi-line dialogue; `itemText` joins all lines for an accurate
+  translation.
+  Revise: if per-line alignment matters, translate line-by-line instead.
+
+- **D5.4 Default target language is `zh` (Mandarin); default sentinel tag is `eo`
+  (Esperanto).**
+  Why: matches the stated intent — Mandarin double-subs tagged with an
+  unused-language code so players don't confuse them with real tracks.
+  Revise: `--sentinel` and the `target-lang` arg both override; change the
+  defaults in `cmd/dualsub.go`.
+
+- **D5.5 Output is a sidecar file (`<input>.eo.srt`), not a muxed track.**
+  Why: the project only writes sidecar subtitles; there is no container-muxing
+  step. The "player won't confuse it" benefit comes from the filename suffix.
+  Revise: add an ffmpeg mux-back step (`-metadata:s:s language=epo`) if an
+  embedded track is wanted.
+
+- **D5.6 Translation backend is whatever `translate_service` selects
+  (google/gpt/grpc); no double-subs-specific backend.**
+  Why: reuse the existing, configured translator.
+  Revise: pin a backend for double-subs if quality/consistency demands it.

--- a/pkg/subtitles/dualsub.go
+++ b/pkg/subtitles/dualsub.go
@@ -1,0 +1,91 @@
+// file: pkg/subtitles/dualsub.go
+// version: 1.0.0
+// guid: 64b56784-2864-4efa-bea4-60caa16c1ffa
+
+package subtitles
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/asticode/go-astisub"
+
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+	"github.com/jdfalk/subtitle-manager/pkg/translator"
+)
+
+// GenerateDualSubtitles reads the subtitle file at inPath, translates each cue's
+// text to targetLang, and writes a bilingual ("double subs") SRT to outPath.
+//
+// Unlike TranslateFileToSRT — which REPLACES each cue's text with its translation
+// — this PRESERVES the original line(s) and APPENDS the translation as an
+// additional stacked line, so each cue shows the original above and the
+// translation below. Translations are cached in-memory so identical source lines
+// are only translated once per file.
+//
+// The output is intended to be tagged with a sentinel language code (Esperanto,
+// "eo", by convention) so media players/servers do not treat it as a real
+// single-language track. See docs/WHISPER_PIPELINE_DECISIONS.md (W5). This
+// produces stacked-SRT double subs; styled ASS positioning is a future option
+// (it depends on the currently-stubbed multi-format writer).
+func GenerateDualSubtitles(inPath, outPath, targetLang, service, googleKey, gptKey, grpcAddr string) error {
+	validatedInPath, err := security.ValidateAndSanitizePath(inPath)
+	if err != nil {
+		return fmt.Errorf("invalid input path: %w", err)
+	}
+	validatedOutPath, err := security.ValidateAndSanitizePath(outPath)
+	if err != nil {
+		return fmt.Errorf("invalid output path: %w", err)
+	}
+
+	sub, err := astisub.OpenFile(validatedInPath)
+	if err != nil {
+		return err
+	}
+
+	cache := make(map[string]string, len(sub.Items))
+	for _, item := range sub.Items {
+		orig := itemText(item)
+		if orig == "" {
+			continue
+		}
+		t, ok := cache[orig]
+		if !ok {
+			t, err = translator.Translate(service, orig, targetLang, googleKey, gptKey, grpcAddr)
+			if err != nil {
+				return fmt.Errorf("translate %q: %w", orig, err)
+			}
+			cache[orig] = t
+		}
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		// Preserve the original line(s); append the translation as a new stacked
+		// line so SRT renders original-over-translation.
+		item.Lines = append(item.Lines, astisub.Line{Items: []astisub.LineItem{{Text: t}}})
+	}
+
+	buf := &bytes.Buffer{}
+	if err := sub.WriteToSRT(buf); err != nil {
+		return err
+	}
+	return os.WriteFile(validatedOutPath, buf.Bytes(), 0644)
+}
+
+// itemText concatenates every line's text in a subtitle item into a single
+// string, joining lines with a space so the whole cue is translated as one unit
+// (rather than only the first line, as the single-language translator does).
+func itemText(item *astisub.Item) string {
+	var b strings.Builder
+	for i, line := range item.Lines {
+		for _, li := range line.Items {
+			b.WriteString(li.Text)
+		}
+		if i < len(item.Lines)-1 {
+			b.WriteString(" ")
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/pkg/subtitles/dualsub_test.go
+++ b/pkg/subtitles/dualsub_test.go
@@ -1,0 +1,79 @@
+// file: pkg/subtitles/dualsub_test.go
+// version: 1.0.0
+// guid: 0d6f4a1c-9e52-4b7a-8c31-5f2d7e9a1b04
+
+package subtitles
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/translator"
+)
+
+// TestGenerateDualSubtitles verifies the bilingual output keeps the original
+// text and appends the translation as a second stacked line per cue.
+func TestGenerateDualSubtitles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qs := r.URL.Query()["q"]
+		if len(qs) == 0 {
+			qs = []string{""}
+		}
+		parts := make([]string, len(qs))
+		for i := range qs {
+			parts[i] = `{"translatedText":"你好"}`
+		}
+		fmt.Fprintf(w, `{"data":{"translations":[%s]}}`, strings.Join(parts, ","))
+	}))
+	defer srv.Close()
+	translator.SetGoogleAPIURL(srv.URL)
+	defer translator.SetGoogleAPIURL("https://translation.googleapis.com/language/translate/v2")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	src := filepath.Join(wd, "../../testdata/simple.srt")
+	inData, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "in.srt")
+	if err := os.WriteFile(inPath, inData, 0644); err != nil {
+		t.Fatalf("write in: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	t.Cleanup(viper.Reset)
+
+	// Esperanto sentinel tag, exactly as the pipeline intends.
+	out := filepath.Join(dir, "in.eo.srt")
+	if err := GenerateDualSubtitles(inPath, out, "zh", "google", "k", "", ""); err != nil {
+		t.Fatalf("dual: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read out: %v", err)
+	}
+	got := string(data)
+	// Original preserved.
+	if !strings.Contains(got, "Hello world") {
+		t.Fatalf("original text missing from dual subs:\n%s", got)
+	}
+	// Translation appended.
+	if !strings.Contains(got, "你好") {
+		t.Fatalf("translation missing from dual subs:\n%s", got)
+	}
+	// Original must appear before the translation within the first cue.
+	if idxOrig, idxT := strings.Index(got, "Hello world"), strings.Index(got, "你好"); idxOrig > idxT {
+		t.Fatalf("translation should be stacked below original; got original@%d translation@%d", idxOrig, idxT)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **W5**: bilingual "double subs". `subtitles.GenerateDualSubtitles` keeps each cue's original line(s) and **appends** the translation as a stacked line (vs the existing translator, which *replaces* the text), writing a sentinel-tagged sidecar (`video.eo.srt` by default) so Plex/Jellyfin/Emby treat it as a distinct, unused-language track.

- `dualsub [input] [target-lang]` CLI (default target `zh` Mandarin, `--sentinel eo`, `--output`).
- Whole-cue translation (joins multi-line dialogue), in-memory dedupe cache.
- Test asserts original is preserved, translation is appended, and ordering (original above translation).

## Decisions (`docs/WHISPER_PIPELINE_DECISIONS.md` W5)
Stacked-SRT (ASS styling deferred — the format writer is stubbed); sidecar not muxed; defaults `zh`/`eo`; reuse configured translate backend.

## Verification
`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/subtitles/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)