### PR TITLE
fix(transcriber): self-hosted Whisper ASR client — make 'start our own' actually transcribe (W2)

### DIFF
--- a/changelog.d/w2-whisper-asr-client.md
+++ b/changelog.d/w2-whisper-asr-client.md
@@ -1,0 +1,13 @@
+### Fixed
+
+#### Real self-hosted Whisper transcription (ASR webservice client)
+
+Added `transcriber.ASRTranscribe`, a client that speaks the native `/asr`
+protocol of the self-hosted `onerahmet/openai-whisper-asr-webservice` image
+(multipart `audio_file` upload, SRT/VTT/JSON output), and rewired the container
+transcription path to use it. Previously the container path was a stub that
+pointed the OpenAI SDK at the container with a dummy key (wrong protocol), had a
+base-URL restore bug, and discarded the result — so "start our own Whisper"
+never produced a subtitle. Both the container and external-API paths now write
+the transcript sidecar (`<media>.<lang>.srt`). See
+`docs/WHISPER_PIPELINE_DECISIONS.md` (W2).

--- a/docs/WHISPER_PIPELINE_DECISIONS.md
+++ b/docs/WHISPER_PIPELINE_DECISIONS.md
@@ -101,3 +101,44 @@ the `dualsub [input] [target-lang]` CLI command (`cmd/dualsub.go`).
   (google/gpt/grpc); no double-subs-specific backend.**
   Why: reuse the existing, configured translator.
   Revise: pin a backend for double-subs if quality/consistency demands it.
+
+---
+
+## W2 — Self-hosted Whisper transcription client
+
+Implemented `ASRTranscribe` (`pkg/transcriber/asr.go`) and rewired the container
+transcription path (`pkg/transcriber/whisper_container.go`).
+
+- **D2.1 Speak the ASR webservice's native `/asr` protocol, not the OpenAI API.**
+  Why: the self-hosted image (`onerahmet/openai-whisper-asr-webservice`) exposes
+  `POST /asr` with a multipart `audio_file`, not `/audio/transcriptions`. The old
+  stub pointed the OpenAI SDK at the container with a `"dummy-key-for-container"`
+  and discarded the result. `ASRTranscribe` posts the file and returns SRT.
+  Revise: to support a different self-hosted server, add another client function
+  and select on config.
+
+- **D2.2 The container path now WRITES the subtitle (`<media>.<lang>.srt`).**
+  Why: both the container and external-API paths previously transcribed and threw
+  the bytes away, so no subtitle was ever produced. `writeTranscript` writes a
+  sidecar using the same validated path builder as the scanner.
+  Revise: to return bytes instead of writing, or to choose a different output
+  location/format, change `writeTranscript` / the task functions.
+
+- **D2.3 `ENABLE_WHISPER` auto-orchestration stays opt-in (commented in compose).**
+  Why: auto-starting a Whisper container needs the docker socket and (ideally) a
+  GPU; enabling it by default would surprise users. The mechanism works when set.
+  Revise: uncomment `ENABLE_WHISPER=1` in `docker-compose.yml`/`docker-stack.yml`
+  to auto-start the container.
+
+- **D2.4 Kept the OpenAI-compatible external path (`WhisperTranscribe`) as the
+  user-provided-server option; the two container designs are NOT yet unified.**
+  Why: W2 fixed the primary (ASR webservice) path; the second design
+  (`pkg/transcriber/docker.go`, `openai/whisper` CLI) is untouched to keep the
+  change focused.
+  Revise: remove or gate `docker.go` once the ASR path is confirmed in
+  production, per the design doc's "reconcile the two container designs".
+
+- **D2.5 Default ASR HTTP timeout is 30 minutes.**
+  Why: transcribing a full movie can take a long time on CPU.
+  Revise: pass a custom `*http.Client` to `ASRTranscribe`, or make it
+  configurable.

--- a/pkg/transcriber/asr.go
+++ b/pkg/transcriber/asr.go
@@ -1,0 +1,117 @@
+// file: pkg/transcriber/asr.go
+// version: 1.0.0
+// guid: c35500d2-dcef-4ad9-884d-9d91de10459a
+
+package transcriber
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ASROptions configures a call to a self-hosted whisper-asr-webservice /asr
+// endpoint (the onerahmet/openai-whisper-asr-webservice image).
+type ASROptions struct {
+	// Task is "transcribe" (default) or "translate" (translate-to-English).
+	Task string
+	// Language is the spoken-language ISO code; empty means auto-detect.
+	Language string
+	// Output is the subtitle format: "srt" (default), "vtt", "txt", "tsv", "json".
+	Output string
+	// WordTimestamps requests per-word timings (json output only).
+	WordTimestamps bool
+}
+
+// asrHTTPClient is the default client for ASR calls. Transcription of a full
+// media file can take many minutes, so the timeout is generous.
+var asrHTTPClient = &http.Client{Timeout: 30 * time.Minute}
+
+// ASRTranscribe posts filePath to a self-hosted whisper-asr-webservice instance
+// at baseURL (for example http://localhost:9000) and returns the subtitle bytes
+// in the requested output format.
+//
+// This speaks the webservice's NATIVE protocol — a multipart POST to /asr with
+// the media in the `audio_file` field — not the OpenAI /audio/transcriptions
+// API. It is the client the self-hosted ("start our own") Whisper path needs;
+// the previous container code incorrectly pointed the OpenAI SDK at the
+// container with a dummy key. If httpClient is nil, a long-timeout default is
+// used.
+func ASRTranscribe(ctx context.Context, httpClient *http.Client, baseURL, filePath string, opts ASROptions) ([]byte, error) {
+	if opts.Task == "" {
+		opts.Task = "transcribe"
+	}
+	if opts.Output == "" {
+		opts.Output = "srt"
+	}
+	if httpClient == nil {
+		httpClient = asrHTTPClient
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open media: %w", err)
+	}
+	defer f.Close()
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	fw, err := mw.CreateFormFile("audio_file", filepath.Base(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("build multipart: %w", err)
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return nil, fmt.Errorf("copy media: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/asr")
+	if err != nil {
+		return nil, fmt.Errorf("invalid whisper base URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("task", opts.Task)
+	q.Set("output", opts.Output)
+	q.Set("encode", "true")
+	if opts.Language != "" {
+		q.Set("language", opts.Language)
+	}
+	if opts.WordTimestamps {
+		q.Set("word_timestamps", "true")
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("asr request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read asr response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("whisper asr webservice returned %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("whisper asr webservice returned an empty subtitle")
+	}
+	return data, nil
+}

--- a/pkg/transcriber/asr_test.go
+++ b/pkg/transcriber/asr_test.go
@@ -1,0 +1,92 @@
+// file: pkg/transcriber/asr_test.go
+// version: 1.0.0
+// guid: 9a7483a9-a895-401e-951d-2f0abea7746c
+
+package transcriber
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleSRT = "1\n00:00:01,000 --> 00:00:02,000\nHello\n"
+
+// TestASRTranscribe verifies the client speaks the whisper-asr-webservice
+// native /asr protocol: multipart audio_file + query params, SRT body back.
+func TestASRTranscribe(t *testing.T) {
+	dir := t.TempDir()
+	media := filepath.Join(dir, "clip.wav")
+	if err := os.WriteFile(media, []byte("AUDIODATA"), 0644); err != nil {
+		t.Fatalf("write media: %v", err)
+	}
+
+	var sawFile bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/asr" {
+			http.Error(w, "bad route", http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("task") != "transcribe" || q.Get("output") != "srt" || q.Get("language") != "en" {
+			http.Error(w, "bad query: "+r.URL.RawQuery, http.StatusBadRequest)
+			return
+		}
+		f, hdr, err := r.FormFile("audio_file")
+		if err != nil {
+			http.Error(w, "no audio_file: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer f.Close()
+		if hdr.Filename != "clip.wav" {
+			http.Error(w, "bad filename", http.StatusBadRequest)
+			return
+		}
+		if b, _ := io.ReadAll(f); string(b) != "AUDIODATA" {
+			http.Error(w, "bad audio content", http.StatusBadRequest)
+			return
+		}
+		sawFile = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleSRT))
+	}))
+	defer srv.Close()
+
+	out, err := ASRTranscribe(context.Background(), srv.Client(), srv.URL, media, ASROptions{Language: "en"})
+	if err != nil {
+		t.Fatalf("asr: %v", err)
+	}
+	if !sawFile {
+		t.Fatal("server did not receive audio_file")
+	}
+	if string(out) != sampleSRT {
+		t.Fatalf("unexpected subtitle: %q", out)
+	}
+}
+
+// TestASRTranscribeErrorStatus verifies a non-200 is surfaced as an error.
+func TestASRTranscribeErrorStatus(t *testing.T) {
+	dir := t.TempDir()
+	media := filepath.Join(dir, "clip.wav")
+	_ = os.WriteFile(media, []byte("x"), 0644)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "model not loaded", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	if _, err := ASRTranscribe(context.Background(), srv.Client(), srv.URL, media, ASROptions{}); err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+// TestASRTranscribeMissingFile verifies a clear error when the media is absent.
+func TestASRTranscribeMissingFile(t *testing.T) {
+	if _, err := ASRTranscribe(context.Background(), nil, "http://127.0.0.1:0", "/no/such/file.wav", ASROptions{}); err == nil {
+		t.Fatal("expected error for missing media file")
+	}
+}

--- a/pkg/transcriber/whisper_container.go
+++ b/pkg/transcriber/whisper_container.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
 
+	"github.com/jdfalk/subtitle-manager/pkg/security"
 	"github.com/jdfalk/subtitle-manager/pkg/tasks"
 )
 
@@ -275,30 +277,36 @@ func (w *WhisperContainer) TranscribeFile(ctx context.Context, filePath, languag
 	return task, nil
 }
 
-// transcribeWithContainer performs transcription using the local container.
+// Transcribe transcribes filePath against the running self-hosted Whisper
+// container and returns the subtitle bytes (SRT). It speaks the ASR
+// webservice's native protocol via ASRTranscribe against the mapped container
+// port; it does NOT use the OpenAI API.
+func (w *WhisperContainer) Transcribe(ctx context.Context, filePath, language string) ([]byte, error) {
+	baseURL := fmt.Sprintf("http://localhost:%s", w.config.Port)
+	return ASRTranscribe(ctx, nil, baseURL, filePath, ASROptions{Language: language, Output: "srt"})
+}
+
+// transcribeWithContainer performs transcription using the local container and
+// writes the resulting SRT next to the media file (<media>.<lang>.srt).
 func (w *WhisperContainer) transcribeWithContainer(ctx context.Context, taskID, filePath, language string) error {
 	tasks.Update(taskID, 20) // Container available
 
-	// For now, delegate to external API until container API is fully implemented
-	// This is where you'd implement the container-specific transcription logic
-	baseURL := fmt.Sprintf("http://localhost:%s/v1", w.config.Port)
-	oldBaseURL := baseURL
-	SetBaseURL(baseURL)
-	defer SetBaseURL(oldBaseURL)
-
-	tasks.Update(taskID, 50) // Starting API call
-
-	// Use existing transcriber function
-	_, err := WhisperTranscribe(filePath, language, "dummy-key-for-container")
+	data, err := w.Transcribe(ctx, filePath, language)
 	if err != nil {
 		return fmt.Errorf("container transcription failed: %w", err)
+	}
+
+	tasks.Update(taskID, 80) // Transcription complete, writing output
+	if err := writeTranscript(filePath, language, data); err != nil {
+		return err
 	}
 
 	tasks.Update(taskID, 100) // Completed
 	return nil
 }
 
-// transcribeWithExternalAPI performs transcription using external OpenAI API.
+// transcribeWithExternalAPI performs transcription using an external
+// OpenAI-compatible API and writes the resulting SRT next to the media file.
 func (w *WhisperContainer) transcribeWithExternalAPI(ctx context.Context, taskID, filePath, language string) error {
 	tasks.Update(taskID, 20) // Falling back to external API
 
@@ -309,12 +317,31 @@ func (w *WhisperContainer) transcribeWithExternalAPI(ctx context.Context, taskID
 
 	tasks.Update(taskID, 50) // Starting API call
 
-	_, err := WhisperTranscribe(filePath, language, apiKey)
+	data, err := WhisperTranscribe(filePath, language, apiKey)
 	if err != nil {
 		return fmt.Errorf("external API transcription failed: %w", err)
 	}
 
+	tasks.Update(taskID, 80) // Transcription complete, writing output
+	if err := writeTranscript(filePath, language, data); err != nil {
+		return err
+	}
+
 	tasks.Update(taskID, 100) // Completed
+	return nil
+}
+
+// writeTranscript writes subtitle bytes to a sidecar file next to the media,
+// named <media-base>.<lang>.srt, using the same validated-path construction as
+// the scanner so the output is safe and consistent with downloaded subtitles.
+func writeTranscript(mediaPath, language string, data []byte) error {
+	out, err := security.ValidateSubtitleOutputPath(mediaPath, language)
+	if err != nil {
+		return fmt.Errorf("invalid transcript output path: %w", err)
+	}
+	if err := os.WriteFile(out, data, 0644); err != nil {
+		return fmt.Errorf("write transcript: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implements **W2**: a real client for the self-hosted Whisper server, fixing the biggest gap.

The container lifecycle (`whisper start/stop/status`) was built, but `transcribeWithContainer` was a **stub**: it pointed the OpenAI SDK at the container with `"dummy-key-for-container"` (the ASR webservice doesn't speak the OpenAI protocol), had a base-URL restore bug, and **discarded the transcription result** — so self-hosted Whisper never produced a subtitle.

- `transcriber.ASRTranscribe(ctx, client, baseURL, filePath, opts)` — multipart `POST /asr` (native protocol), returns SRT/VTT/JSON. Fully httptest-tested.
- `WhisperContainer.Transcribe` uses it against the mapped container port.
- Both container **and** external-API paths now **write** the transcript sidecar (`<media>.<lang>.srt`) via `writeTranscript` (same validated path builder as the scanner).

## Decisions (`docs/WHISPER_PIPELINE_DECISIONS.md` W2)
Native `/asr` protocol; container path now writes output; `ENABLE_WHISPER` stays opt-in; the second `openai/whisper` CLI container design is left for a later reconcile; 30-min default timeout.

## Verification
`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/transcriber/` all pass. (End-to-end against a live container needs a running Whisper server — noted in the decisions log.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)