### PR TITLE
feat(subsync): subtitle drift verification — detect speed-up/slow-down (W3+W4)

### DIFF
--- a/changelog.d/w4-drift-verify.md
+++ b/changelog.d/w4-drift-verify.md
@@ -1,0 +1,13 @@
+### Added
+
+#### Subtitle drift verification (`verify`)
+
+Added the `pkg/subsync` package and the `verify [media] [subtitle] [lang]`
+command, which check whether a subtitle stays aligned with the audio across a
+media file's runtime — detecting both a constant offset and linear speed-up /
+slow-down drift (e.g. a 23.976↔25 fps mismatch), including a likely framerate
+cause. It samples audio windows, transcribes each with Whisper, measures the
+local offset per window, and fits `offset = slope·t + intercept`. This also
+wires up the previously-unused `audio.ExtractTrackWithDuration`. The drift
+classifier is a pure, fully-tested function; the audio/Whisper measurement is
+injectable. See `docs/WHISPER_PIPELINE_DECISIONS.md` (W3+W4).

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,86 @@
+// file: cmd/verify.go
+// version: 1.0.0
+// guid: 203bb659-7f2f-4b3c-8d86-10b58591ec59
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+	"github.com/jdfalk/subtitle-manager/pkg/subsync"
+	"github.com/jdfalk/subtitle-manager/pkg/video"
+)
+
+var (
+	verifyAnchors int
+	verifyTrack   int
+)
+
+// verifyCmd checks whether a subtitle stays aligned with a media file's audio
+// across its runtime, detecting a constant offset and linear speed-up/slow-down
+// drift by transcribing several audio windows with Whisper.
+var verifyCmd = &cobra.Command{
+	Use:   "verify [media] [subtitle] [lang]",
+	Short: "Verify a subtitle's audio alignment (offset + speed drift) using Whisper",
+	Long: `Sample several audio windows across the media, transcribe each with Whisper,
+and compare the spoken timing to the subtitle. Reports whether the subtitle is in
+sync, has a constant offset, or drifts (sped up / slowed down) — including a
+likely framerate cause (e.g. 23.976 vs 25 fps).
+
+Requires a configured Whisper endpoint (openai_api_key, base URL overridable for a
+self-hosted server) and ffmpeg on PATH.`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger("verify")
+		media, subPath, lang := args[0], args[1], args[2]
+		if err := security.ValidateLanguageCode(lang); err != nil {
+			return err
+		}
+
+		info, err := video.AnalyzeVideo(media)
+		if err != nil {
+			return fmt.Errorf("probe media: %w", err)
+		}
+		if info.Duration <= 0 {
+			return fmt.Errorf("could not determine media duration")
+		}
+
+		measure, err := subsync.NewWhisperMeasurer(media, subPath, lang, viper.GetString("openai_api_key"), verifyTrack, nil)
+		if err != nil {
+			return err
+		}
+
+		rep, err := subsync.Verify(context.Background(), subsync.VerifyOptions{
+			MediaDuration: info.Duration,
+			Anchors:       verifyAnchors,
+		}, measure)
+		if err != nil {
+			return err
+		}
+
+		logger.Infof("verified %d/%d anchors", rep.Used, len(rep.Anchors))
+		fmt.Printf("In sync:        %v\n", rep.InSync)
+		fmt.Printf("Constant offset:%v (%.0f ms)\n", rep.ConstantOffset, rep.InterceptMs)
+		fmt.Printf("Rate drift:     %v (%.2f ms/s)\n", rep.RateDrift, rep.SlopeMsPerSec)
+		if rep.LikelyCause != "" {
+			fmt.Printf("Likely cause:   %s\n", rep.LikelyCause)
+		}
+		fmt.Printf("Fit RMSE:       %.0f ms (max residual %.0f ms)\n", rep.RMSEMs, rep.MaxResidualMs)
+		if !rep.InSync {
+			return fmt.Errorf("subtitle is not in sync")
+		}
+		return nil
+	},
+}
+
+func init() {
+	verifyCmd.Flags().IntVar(&verifyAnchors, "anchors", 10, "number of audio windows to sample")
+	verifyCmd.Flags().IntVar(&verifyTrack, "audio-track", 0, "audio track index to transcribe")
+	rootCmd.AddCommand(verifyCmd)
+}

--- a/docs/WHISPER_PIPELINE_DECISIONS.md
+++ b/docs/WHISPER_PIPELINE_DECISIONS.md
@@ -142,3 +142,52 @@ transcription path (`pkg/transcriber/whisper_container.go`).
   Why: transcribing a full movie can take a long time on CPU.
   Revise: pass a custom `*http.Client` to `ASRTranscribe`, or make it
   configurable.
+
+---
+
+## W3 + W4 — Windowed extraction & subtitle drift verification
+
+Implemented as the `pkg/subsync` package (`analyze.go`, `verify.go`,
+`measurer.go`) + the `verify [media] [subtitle] [lang]` CLI command
+(`cmd/verify.go`). W3 (wiring the orphaned `audio.ExtractTrackWithDuration`) is
+folded in — the measurer is its first real caller.
+
+- **D4.1 Drift model is a linear fit `offset = slope·t + intercept`.**
+  Why: captures both a constant offset (intercept) and speed-up/slow-down
+  (slope) — a plain median shift, like `pkg/syncer`, cannot see drift.
+  Revise: for non-linear drift (variable framerate, edits) switch to piecewise
+  fitting or per-segment offsets.
+
+- **D4.2 The classifier (`Analyze`) is a pure function; audio/Whisper are
+  injected (`AnchorMeasurer`).**
+  Why: keeps the math fully unit-testable without ffmpeg or Whisper, and lets the
+  measurer target a user-provided or self-hosted server.
+  Revise: n/a — this is a testability boundary; extend via new measurers.
+
+- **D4.3 Anchor↔subtitle matching is by nearest start-time within
+  `maxMatchMs` (3 s), offset = median of matched diffs.**
+  Why: simple and robust for small/moderate offsets; median rejects outliers.
+  KNOWN LIMITATION: an offset larger than ~half the inter-cue gap can match the
+  wrong neighbouring cue; large drift is still caught at earlier anchors where the
+  accumulated offset is smaller.
+  Revise: match by TEXT similarity (compare transcribed text to subtitle text)
+  instead of time — far more robust but needs fuzzy text matching.
+
+- **D4.4 Rate-drift threshold is 5 ms/s; in-sync tolerance is 150 ms;
+  min-confidence 0.5; 10 anchors × 45 s windows, skipping 2 min intro/credits.**
+  Why: defaults that flag real framerate drift (≈40 ms/s for 25↔23.976) while
+  ignoring jitter, and avoid non-dialogue intros/credits.
+  Revise: all are `VerifyOptions` fields / CLI flags.
+
+- **D4.5 `verify` reports and (by exit code) fails when out of sync, but does NOT
+  auto-correct.**
+  Why: verification and correction are separate concerns; correcting via
+  rescale-then-shift (`t' = (1+slope)·t + intercept`) is a follow-up that would
+  replace `pkg/syncer`'s single-median shift.
+  Revise: add a `--fix` flag that applies the fitted transform to the subtitle.
+
+- **D4.6 Transcription for measurement reuses `WhisperTranscribe`
+  (OpenAI-compatible); a self-hosted server is used by pointing its base URL, or
+  by injecting a `TranscribeFunc` backed by `ASRTranscribe` (W2).**
+  Why: one transcription path; the measurer is backend-agnostic via injection.
+  Revise: default the measurer to the container ASR client when configured.

--- a/pkg/subsync/analyze.go
+++ b/pkg/subsync/analyze.go
@@ -1,0 +1,153 @@
+// file: pkg/subsync/analyze.go
+// version: 1.0.0
+// guid: 4a285ebc-78ec-4122-a588-f91307b65522
+
+// Package subsync verifies that a subtitle stays aligned with a media file's
+// audio across its runtime — detecting both a constant offset and linear
+// "speed up / slow down" drift (e.g. a 23.976↔25 fps mismatch) — rather than
+// only correcting a single global offset like pkg/syncer does.
+package subsync
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// Anchor is a measured local timing error between a subtitle and the audio at a
+// point in the media. OffsetMs is (subtitle − audio) in milliseconds: positive
+// means the subtitle cue is later than the spoken words. Confidence is 0..1.
+type Anchor struct {
+	At         time.Duration
+	OffsetMs   float64
+	Confidence float64
+}
+
+// DriftReport summarizes subtitle-vs-audio alignment across anchors.
+type DriftReport struct {
+	Anchors []Anchor // all measured anchors (including low-confidence)
+	Used    int      // anchors that passed the confidence filter
+
+	// SlopeMsPerSec is drift: ms of added offset per second of runtime.
+	SlopeMsPerSec float64
+	// InterceptMs is the fitted constant offset at t=0.
+	InterceptMs float64
+	// MaxResidualMs / RMSEMs describe how well a linear model fits (fit quality).
+	MaxResidualMs float64
+	RMSEMs        float64
+
+	InSync         bool   // within tolerance at every usable anchor
+	ConstantOffset bool   // significant offset, ~zero slope (a plain shift fixes it)
+	RateDrift      bool   // significant slope (speed up / slow down)
+	LikelyCause    string // human-readable cause when RateDrift is set
+}
+
+// Analyze fits offset = slope·t + intercept over the anchors (t in seconds,
+// offset in ms) and classifies the result.
+//
+//   - maxResidualMs: per-anchor tolerance; InSync requires every usable anchor's
+//     absolute offset to be within this.
+//   - minConfidence: anchors below this are ignored (noisy transcription, music,
+//     silence).
+//   - driftSlopeThresholdMs: |slope| at or above this (ms per second) is treated
+//     as rate drift rather than a constant offset.
+//
+// It is a pure function so the classification is unit-testable without audio or
+// Whisper.
+func Analyze(anchors []Anchor, maxResidualMs, minConfidence, driftSlopeThresholdMs float64) DriftReport {
+	rep := DriftReport{Anchors: anchors}
+
+	var ts, offs []float64
+	var maxAbsOffset float64
+	for _, a := range anchors {
+		if a.Confidence < minConfidence {
+			continue
+		}
+		ts = append(ts, a.At.Seconds())
+		offs = append(offs, a.OffsetMs)
+		if math.Abs(a.OffsetMs) > maxAbsOffset {
+			maxAbsOffset = math.Abs(a.OffsetMs)
+		}
+	}
+	rep.Used = len(ts)
+	if rep.Used == 0 {
+		return rep
+	}
+	if rep.Used == 1 {
+		rep.InterceptMs = offs[0]
+		rep.InSync = math.Abs(offs[0]) <= maxResidualMs
+		rep.ConstantOffset = !rep.InSync
+		return rep
+	}
+
+	n := float64(len(ts))
+	var sx, sy, sxx, sxy float64
+	for i := range ts {
+		sx += ts[i]
+		sy += offs[i]
+		sxx += ts[i] * ts[i]
+		sxy += ts[i] * offs[i]
+	}
+	denom := n*sxx - sx*sx
+	if denom == 0 {
+		// All anchors at the same timestamp: cannot fit a slope; treat the mean
+		// offset as a constant offset.
+		rep.InterceptMs = sy / n
+		rep.InSync = maxAbsOffset <= maxResidualMs
+		rep.ConstantOffset = !rep.InSync
+		return rep
+	}
+
+	slope := (n*sxy - sx*sy) / denom
+	intercept := (sy - slope*sx) / n
+	rep.SlopeMsPerSec = slope
+	rep.InterceptMs = intercept
+
+	var sumSq float64
+	for i := range ts {
+		r := offs[i] - (slope*ts[i] + intercept)
+		if a := math.Abs(r); a > rep.MaxResidualMs {
+			rep.MaxResidualMs = a
+		}
+		sumSq += r * r
+	}
+	rep.RMSEMs = math.Sqrt(sumSq / n)
+
+	rep.InSync = maxAbsOffset <= maxResidualMs
+	rep.RateDrift = math.Abs(slope) >= driftSlopeThresholdMs
+	rep.ConstantOffset = !rep.RateDrift && math.Abs(intercept) > maxResidualMs
+	if rep.RateDrift {
+		rep.LikelyCause = likelyCause(slope)
+	}
+	return rep
+}
+
+// likelyCause names a probable framerate mismatch for a given drift slope
+// (ms per second), or returns a generic description. A rate factor r means the
+// offset grows by (r−1)·1000 ms per second.
+func likelyCause(slopeMsPerSec float64) string {
+	r := 1 + slopeMsPerSec/1000
+	cands := []struct {
+		ratio float64
+		name  string
+	}{
+		{25.0 / 24.0, "framerate 24→25 (PAL speed-up)"},
+		{24.0 / 25.0, "framerate 25→24"},
+		{25.0 / 23.976, "framerate 23.976→25"},
+		{23.976 / 25.0, "framerate 25→23.976"},
+		{30.0 / 29.97, "framerate 29.97→30"},
+		{29.97 / 30.0, "framerate 30→29.97"},
+	}
+	best := ""
+	bestDiff := 0.005 // ratio tolerance
+	for _, c := range cands {
+		if d := math.Abs(r - c.ratio); d < bestDiff {
+			bestDiff = d
+			best = c.name
+		}
+	}
+	if best == "" {
+		return fmt.Sprintf("linear drift ~%.1f ms/s (rate %.4f)", slopeMsPerSec, r)
+	}
+	return best
+}

--- a/pkg/subsync/analyze_test.go
+++ b/pkg/subsync/analyze_test.go
@@ -1,0 +1,87 @@
+// file: pkg/subsync/analyze_test.go
+// version: 1.0.0
+// guid: 6edb8fe6-6267-4627-b640-b12ba5a1ef86
+
+package subsync
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// anchorsFrom builds anchors at evenly spaced timestamps whose offset follows
+// offset(t) = slopeMsPerSec*t + interceptMs, all at full confidence.
+func anchorsFrom(n int, spacing time.Duration, slopeMsPerSec, interceptMs float64) []Anchor {
+	as := make([]Anchor, n)
+	for i := 0; i < n; i++ {
+		at := time.Duration(i) * spacing
+		as[i] = Anchor{At: at, OffsetMs: slopeMsPerSec*at.Seconds() + interceptMs, Confidence: 1}
+	}
+	return as
+}
+
+func TestAnalyzeInSync(t *testing.T) {
+	rep := Analyze(anchorsFrom(8, 5*time.Minute, 0, 20), 150, 0.5, 5)
+	if !rep.InSync {
+		t.Fatalf("expected in sync, got %+v", rep)
+	}
+	if rep.RateDrift || rep.ConstantOffset {
+		t.Fatalf("expected no drift/offset flags, got %+v", rep)
+	}
+}
+
+func TestAnalyzeConstantOffset(t *testing.T) {
+	rep := Analyze(anchorsFrom(8, 5*time.Minute, 0, 900), 150, 0.5, 5)
+	if rep.InSync {
+		t.Fatalf("900ms offset should not be in sync")
+	}
+	if !rep.ConstantOffset || rep.RateDrift {
+		t.Fatalf("expected constant offset, got %+v", rep)
+	}
+	if math.Abs(rep.InterceptMs-900) > 1 {
+		t.Fatalf("intercept ~900 expected, got %.1f", rep.InterceptMs)
+	}
+	if math.Abs(rep.SlopeMsPerSec) > 0.01 {
+		t.Fatalf("slope ~0 expected, got %.4f", rep.SlopeMsPerSec)
+	}
+}
+
+func TestAnalyzeRateDriftFramerate(t *testing.T) {
+	// Subtitle timed for 25 fps played at 23.976 → rate 23.976/25, slope = (r-1)*1000.
+	r := 23.976 / 25.0
+	slope := (r - 1) * 1000 // ≈ -40.96 ms/s
+	rep := Analyze(anchorsFrom(10, 6*time.Minute, slope, 0), 150, 0.5, 5)
+	if !rep.RateDrift {
+		t.Fatalf("expected rate drift for slope %.2f, got %+v", slope, rep)
+	}
+	if rep.InSync {
+		t.Fatalf("rate-drifting subtitle should not be in sync")
+	}
+	if math.Abs(rep.SlopeMsPerSec-slope) > 0.5 {
+		t.Fatalf("slope %.2f expected, got %.2f", slope, rep.SlopeMsPerSec)
+	}
+	if rep.LikelyCause == "" || rep.LikelyCause[:9] != "framerate" {
+		t.Fatalf("expected a framerate cause, got %q", rep.LikelyCause)
+	}
+}
+
+func TestAnalyzeConfidenceFilter(t *testing.T) {
+	as := anchorsFrom(4, 5*time.Minute, 0, 10)
+	// Add a wildly wrong, low-confidence anchor that must be ignored.
+	as = append(as, Anchor{At: 30 * time.Minute, OffsetMs: 9000, Confidence: 0.1})
+	rep := Analyze(as, 150, 0.5, 5)
+	if rep.Used != 4 {
+		t.Fatalf("low-confidence anchor should be filtered; used=%d", rep.Used)
+	}
+	if !rep.InSync {
+		t.Fatalf("expected in sync after filtering noise, got %+v", rep)
+	}
+}
+
+func TestAnalyzeEmpty(t *testing.T) {
+	rep := Analyze(nil, 150, 0.5, 5)
+	if rep.Used != 0 || rep.InSync {
+		t.Fatalf("empty anchors should yield Used=0 and not in-sync, got %+v", rep)
+	}
+}

--- a/pkg/subsync/measurer.go
+++ b/pkg/subsync/measurer.go
@@ -1,0 +1,116 @@
+// file: pkg/subsync/measurer.go
+// version: 1.0.0
+// guid: 42201e57-1e84-4b64-ba44-6ac2c8a1e15d
+
+package subsync
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/asticode/go-astisub"
+
+	"github.com/jdfalk/subtitle-manager/pkg/audio"
+	"github.com/jdfalk/subtitle-manager/pkg/transcriber"
+)
+
+// TranscribeFunc transcribes an audio file to SRT bytes for the given language.
+// Injecting it lets the measurer target either a user-provided OpenAI-compatible
+// server or a self-hosted ASR webservice, and makes the glue testable.
+type TranscribeFunc func(ctx context.Context, audioPath, lang string) ([]byte, error)
+
+// maxMatchMs is how close (in ms) a transcribed cue's start must be to a
+// subtitle cue's start for the two to be considered the same line. Beyond this
+// the match is treated as spurious. It bounds how large an offset a single
+// anchor can measure; larger drift is still caught at earlier anchors where the
+// accumulated offset is smaller. See docs/WHISPER_PIPELINE_DECISIONS.md (W4).
+const maxMatchMs = 3000.0
+
+// measureWindow computes the local offset between subtitle cues and transcribed
+// ("spoken") cues for a window that starts at `at` in the media. Spoken cue
+// timestamps are relative to the window, so `at` is added to place them on the
+// media timeline. For each spoken cue it finds the nearest subtitle cue by start
+// time (within maxMatchMs) and records subStart−spokenStart; the anchor offset is
+// the median of those diffs and confidence is the fraction of spoken cues matched.
+//
+// Pure function: unit-testable without ffmpeg or Whisper.
+func measureWindow(subCues, spoken []*astisub.Item, at time.Duration) Anchor {
+	if len(spoken) == 0 {
+		return Anchor{At: at, Confidence: 0}
+	}
+	var diffs []float64
+	matched := 0
+	for _, sp := range spoken {
+		abs := at + sp.StartAt
+		bestDiff := math.MaxFloat64
+		var bestSigned float64
+		for _, sc := range subCues {
+			d := float64(sc.StartAt-abs) / float64(time.Millisecond)
+			if math.Abs(d) < bestDiff {
+				bestDiff = math.Abs(d)
+				bestSigned = d
+			}
+		}
+		if bestDiff <= maxMatchMs {
+			diffs = append(diffs, bestSigned)
+			matched++
+		}
+	}
+	if len(diffs) == 0 {
+		return Anchor{At: at, Confidence: 0}
+	}
+	return Anchor{At: at, OffsetMs: median(diffs), Confidence: float64(matched) / float64(len(spoken))}
+}
+
+// median returns the median of xs (xs is copied, not mutated).
+func median(xs []float64) float64 {
+	c := append([]float64(nil), xs...)
+	sort.Float64s(c)
+	n := len(c)
+	if n == 0 {
+		return 0
+	}
+	if n%2 == 1 {
+		return c[n/2]
+	}
+	return (c[n/2-1] + c[n/2]) / 2
+}
+
+// NewWhisperMeasurer builds an AnchorMeasurer that, per window, extracts the
+// audio with ffmpeg, transcribes it, and measures the offset against the
+// subtitle cues loaded from subtitlePath. If transcribe is nil, it defaults to
+// transcriber.WhisperTranscribe with whisperKey (OpenAI-compatible; point its
+// base URL at a self-hosted server for local Whisper).
+func NewWhisperMeasurer(mediaPath, subtitlePath, lang, whisperKey string, audioTrack int, transcribe TranscribeFunc) (AnchorMeasurer, error) {
+	sub, err := astisub.OpenFile(subtitlePath)
+	if err != nil {
+		return nil, fmt.Errorf("open subtitle: %w", err)
+	}
+	if transcribe == nil {
+		transcribe = func(_ context.Context, audioPath, l string) ([]byte, error) {
+			return transcriber.WhisperTranscribe(audioPath, l, whisperKey)
+		}
+	}
+	return func(ctx context.Context, at, window time.Duration) (Anchor, error) {
+		wav, err := audio.ExtractTrackWithDuration(mediaPath, audioTrack, at, window)
+		if err != nil {
+			return Anchor{}, fmt.Errorf("extract audio window: %w", err)
+		}
+		defer os.Remove(wav)
+
+		data, err := transcribe(ctx, wav, lang)
+		if err != nil {
+			return Anchor{}, fmt.Errorf("transcribe window: %w", err)
+		}
+		spoken, err := astisub.ReadFromSRT(bytes.NewReader(data))
+		if err != nil {
+			return Anchor{}, fmt.Errorf("parse transcription: %w", err)
+		}
+		return measureWindow(sub.Items, spoken.Items, at), nil
+	}, nil
+}

--- a/pkg/subsync/verify.go
+++ b/pkg/subsync/verify.go
@@ -1,0 +1,103 @@
+// file: pkg/subsync/verify.go
+// version: 1.0.0
+// guid: 6ab465c3-300f-48b8-a82c-416c9c14018e
+
+package subsync
+
+import (
+	"context"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+)
+
+// AnchorMeasurer measures the local subtitle-vs-audio offset at position `at`
+// using a window of length `window`. Real implementations extract the audio
+// window, transcribe it with Whisper, and compare to the subtitle cues in that
+// range (see NewWhisperMeasurer). It is an injected dependency so Verify's
+// orchestration is testable without ffmpeg or Whisper.
+type AnchorMeasurer func(ctx context.Context, at, window time.Duration) (Anchor, error)
+
+// VerifyOptions configures a drift-verification pass. Zero fields fall back to
+// sensible defaults.
+type VerifyOptions struct {
+	MediaDuration time.Duration // required
+	Anchors       int           // sample windows (default 10)
+	Window        time.Duration // window length (default 45s)
+	SkipStart     time.Duration // skip intro (default 2m)
+	SkipEnd       time.Duration // skip credits (default 2m)
+	MaxResidualMs float64       // per-anchor tolerance (default 150)
+	MinConfidence float64       // ignore weaker anchors (default 0.5)
+	DriftSlopeMs  float64       // rate-drift threshold, ms/s (default 5)
+}
+
+func (o *VerifyOptions) withDefaults() {
+	if o.Anchors <= 0 {
+		o.Anchors = 10
+	}
+	if o.Window <= 0 {
+		o.Window = 45 * time.Second
+	}
+	if o.SkipStart <= 0 {
+		o.SkipStart = 2 * time.Minute
+	}
+	if o.SkipEnd <= 0 {
+		o.SkipEnd = 2 * time.Minute
+	}
+	if o.MaxResidualMs <= 0 {
+		o.MaxResidualMs = 150
+	}
+	if o.MinConfidence <= 0 {
+		o.MinConfidence = 0.5
+	}
+	if o.DriftSlopeMs <= 0 {
+		o.DriftSlopeMs = 5
+	}
+}
+
+// sampleTimes returns Anchors evenly spread across the usable span of the media,
+// skipping the configured intro/credits margins. If the margins leave no usable
+// span (very short media), it falls back to the whole runtime.
+func sampleTimes(o VerifyOptions) []time.Duration {
+	start, end := o.SkipStart, o.MediaDuration-o.SkipEnd
+	if end <= start {
+		start, end = 0, o.MediaDuration
+	}
+	span := end - start
+	if span <= 0 {
+		return nil
+	}
+	step := span / time.Duration(o.Anchors)
+	times := make([]time.Duration, 0, o.Anchors)
+	for i := 0; i < o.Anchors; i++ {
+		at := start + step*time.Duration(i) + step/2
+		// Keep the window inside the media.
+		if at+o.Window > o.MediaDuration {
+			at = o.MediaDuration - o.Window
+		}
+		if at < 0 {
+			at = 0
+		}
+		times = append(times, at)
+	}
+	return times
+}
+
+// Verify samples anchors across the media, measures each via measure, and
+// analyzes the result. Per-anchor measurement errors are logged and skipped so
+// one bad window does not fail the whole verification.
+func Verify(ctx context.Context, opts VerifyOptions, measure AnchorMeasurer) (DriftReport, error) {
+	opts.withDefaults()
+	logger := logging.GetLogger("subsync")
+
+	var anchors []Anchor
+	for _, at := range sampleTimes(opts) {
+		a, err := measure(ctx, at, opts.Window)
+		if err != nil {
+			logger.Debugf("anchor at %s failed: %v", at, err)
+			continue
+		}
+		anchors = append(anchors, a)
+	}
+	return Analyze(anchors, opts.MaxResidualMs, opts.MinConfidence, opts.DriftSlopeMs), nil
+}

--- a/pkg/subsync/verify_test.go
+++ b/pkg/subsync/verify_test.go
@@ -1,0 +1,111 @@
+// file: pkg/subsync/verify_test.go
+// version: 1.0.0
+// guid: c0acb0d8-9f74-4748-99ec-36b3e0f1990a
+
+package subsync
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/asticode/go-astisub"
+)
+
+func items(starts ...time.Duration) []*astisub.Item {
+	out := make([]*astisub.Item, len(starts))
+	for i, s := range starts {
+		out[i] = &astisub.Item{StartAt: s}
+	}
+	return out
+}
+
+func TestMeasureWindowInSync(t *testing.T) {
+	at := 10 * time.Minute
+	// spoken cues relative to window start; subtitle cues on absolute timeline.
+	spoken := items(0, 5*time.Second, 12*time.Second)
+	sub := items(at+0, at+5*time.Second, at+12*time.Second)
+	a := measureWindow(sub, spoken, at)
+	if math.Abs(a.OffsetMs) > 1 {
+		t.Fatalf("expected ~0 offset, got %.1f", a.OffsetMs)
+	}
+	if a.Confidence != 1 {
+		t.Fatalf("expected confidence 1, got %.2f", a.Confidence)
+	}
+}
+
+func TestMeasureWindowConstantOffset(t *testing.T) {
+	at := 20 * time.Minute
+	spoken := items(0, 4*time.Second, 9*time.Second)
+	// subtitle cues are 600ms later than the spoken words.
+	off := 600 * time.Millisecond
+	sub := items(at+off, at+4*time.Second+off, at+9*time.Second+off)
+	a := measureWindow(sub, spoken, at)
+	if math.Abs(a.OffsetMs-600) > 1 {
+		t.Fatalf("expected ~600ms offset, got %.1f", a.OffsetMs)
+	}
+	if a.Confidence != 1 {
+		t.Fatalf("expected confidence 1, got %.2f", a.Confidence)
+	}
+}
+
+func TestMeasureWindowNoSpoken(t *testing.T) {
+	a := measureWindow(items(1*time.Second), nil, 5*time.Minute)
+	if a.Confidence != 0 {
+		t.Fatalf("expected confidence 0 for silent window, got %.2f", a.Confidence)
+	}
+}
+
+func TestMeasureWindowUnmatchedIsLowConfidence(t *testing.T) {
+	at := 0 * time.Second
+	spoken := items(1 * time.Second)
+	// nearest subtitle cue is 10s away — beyond maxMatchMs, so no match.
+	sub := items(11 * time.Second)
+	a := measureWindow(sub, spoken, at)
+	if a.Confidence != 0 {
+		t.Fatalf("expected confidence 0 when nothing matches, got %.2f", a.Confidence)
+	}
+}
+
+// TestVerifyOrchestration drives Verify with a fake measurer that reports a
+// framerate-style drift, and checks the report reflects it.
+func TestVerifyOrchestration(t *testing.T) {
+	opts := VerifyOptions{MediaDuration: 100 * time.Minute}
+	r := 23.976 / 25.0
+	slope := (r - 1) * 1000 // ms/s
+	fake := func(_ context.Context, at, _ time.Duration) (Anchor, error) {
+		return Anchor{At: at, OffsetMs: slope * at.Seconds(), Confidence: 1}, nil
+	}
+	rep, err := Verify(context.Background(), opts, fake)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if rep.Used == 0 {
+		t.Fatal("expected anchors to be measured")
+	}
+	if !rep.RateDrift {
+		t.Fatalf("expected rate drift, got %+v", rep)
+	}
+}
+
+// TestVerifySkipsErroredAnchors ensures a measurer error on some anchors doesn't
+// fail the whole pass.
+func TestVerifySkipsErroredAnchors(t *testing.T) {
+	opts := VerifyOptions{MediaDuration: 60 * time.Minute, Anchors: 6}
+	calls := 0
+	fake := func(_ context.Context, at, _ time.Duration) (Anchor, error) {
+		calls++
+		if calls%2 == 0 {
+			return Anchor{}, context.DeadlineExceeded
+		}
+		return Anchor{At: at, OffsetMs: 10, Confidence: 1}, nil
+	}
+	rep, err := Verify(context.Background(), opts, fake)
+	if err != nil {
+		t.Fatalf("verify should not fail on per-anchor errors: %v", err)
+	}
+	if rep.Used == 0 {
+		t.Fatal("expected some anchors to survive")
+	}
+}


### PR DESCRIPTION
## Summary

Implements **W3+W4**: verify a subtitle stays aligned with the audio at several timestamps, detecting the "did it speed up or slow down?" case — not just a constant offset.

- **`pkg/subsync.Analyze`** — pure function: fits `offset = slope·t + intercept` over measured anchors, classifies **in-sync / constant-offset / rate-drift**, and names a likely framerate cause (e.g. `framerate 25→23.976`). Fully unit-tested (in-sync, constant offset, fps drift, confidence filtering).
- **`Verify`** — orchestration that samples N windows across the runtime (skipping intro/credits) and calls an injected `AnchorMeasurer`. Tested with a fake measurer.
- **`NewWhisperMeasurer`** — extracts each audio window (wires the previously-orphaned `audio.ExtractTrackWithDuration`), transcribes it, and measures the offset vs the subtitle. The `measureWindow` matching logic is a pure, tested function.
- **`verify [media] [subtitle] [lang]`** CLI — reports offset/drift/cause and exits non-zero when out of sync.

## Decisions (`docs/WHISPER_PIPELINE_DECISIONS.md` W3+W4)
Linear drift model; pure classifier with injected audio/Whisper; nearest-time matching within 3 s (text-similarity matching noted as a future improvement); defaults (5 ms/s drift threshold, 150 ms tolerance, 10×45 s windows); verify reports but doesn't auto-correct (`--fix` is a follow-up).

## Verification
`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/subsync/` all pass. (End-to-end needs ffmpeg + a Whisper endpoint — the algorithm and orchestration are tested without them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)