### PR TITLE
fix(webserver): serve SPA shell for client routes (unbreak web UI navigation)

### DIFF
--- a/changelog.d/fix-spa-routing.md
+++ b/changelog.d/fix-spa-routing.md
@@ -1,0 +1,10 @@
+### Fixed
+
+#### Web UI deep links / navigation (SPA routing)
+
+Fixed the web server so client routes (`/library`, `/tools/verify`,
+`/settings/...`, etc.) load the correct page. The SPA fallback rewrote unknown
+paths to `/index.html`, which `http.FileServer` then 301-redirects to `./` —
+bouncing every deep link and in-app navigation back to the dashboard, so no page
+but the dashboard ever rendered. The fallback now writes `index.html`'s bytes
+directly with a 200.

--- a/pkg/webserver/spa.go
+++ b/pkg/webserver/spa.go
@@ -12,17 +12,28 @@ import (
 // for the React application.
 func spaFileServer(fsys fs.FS) http.Handler {
 	fsHandler := http.FileServer(http.FS(fsys))
-	// Detect if index.html is present so we don't break during tests.
-	_, err := fs.Stat(fsys, "index.html")
+	// Read index.html up front so unknown paths can be served the SPA shell
+	// directly. (Detecting its presence also avoids breaking tests that embed no
+	// frontend.)
+	indexData, err := fs.ReadFile(fsys, "index.html")
 	hasIndex := err == nil
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if hasIndex {
 			path := strings.TrimPrefix(r.URL.Path, "/")
 			if path != "" {
-				if _, err := fs.Stat(fsys, path); err != nil && errors.Is(err, fs.ErrNotExist) {
-					r = r.Clone(r.Context())
-					r.URL.Path = "/index.html"
+				if _, statErr := fs.Stat(fsys, path); statErr != nil && errors.Is(statErr, fs.ErrNotExist) {
+					// Unknown path → serve the SPA shell so client-side routing
+					// (e.g. /library, /tools/verify) works on hard navigation.
+					// We write index.html's bytes directly rather than rewriting
+					// r.URL.Path to "/index.html": http.FileServer 301-redirects
+					// requests for ".../index.html" to "./", which would bounce
+					// every deep link back to the app root.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					w.Header().Set("Cache-Control", "no-cache")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(indexData)
+					return
 				}
 			}
 		}

--- a/pkg/webserver/spa_test.go
+++ b/pkg/webserver/spa_test.go
@@ -1,0 +1,53 @@
+// file: pkg/webserver/spa_test.go
+// version: 1.0.0
+// guid: 98a47e42-ba7f-4823-962f-09688de989bd
+
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// TestSpaFileServerServesShellForClientRoutes verifies unknown paths (client
+// routes like /library, /tools/verify) get index.html with a 200 — not a
+// redirect. Regression test: the previous implementation rewrote unknown paths
+// to /index.html, which http.FileServer 301-redirects to "./", bouncing every
+// deep link back to the app root so no page but the dashboard ever rendered.
+func TestSpaFileServerServesShellForClientRoutes(t *testing.T) {
+	const shell = "<!doctype html><title>app</title>"
+	fsys := fstest.MapFS{
+		"index.html":    {Data: []byte(shell)},
+		"assets/app.js": {Data: []byte("console.log(1)")},
+	}
+	h := spaFileServer(fsys)
+
+	for _, route := range []string{"/library", "/tools/verify", "/settings/auth"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, route, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d (Location=%q)", route, rec.Code, rec.Header().Get("Location"))
+		}
+		if !strings.Contains(rec.Body.String(), "<title>app</title>") {
+			t.Fatalf("%s: expected SPA shell, got %q", route, rec.Body.String())
+		}
+	}
+}
+
+// TestSpaFileServerServesRealAssets verifies real files are still served
+// normally (not replaced by the shell).
+func TestSpaFileServerServesRealAssets(t *testing.T) {
+	fsys := fstest.MapFS{
+		"index.html":    {Data: []byte("<!doctype html>")},
+		"assets/app.js": {Data: []byte("console.log(1)")},
+	}
+	h := spaFileServer(fsys)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/app.js", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "console.log(1)") {
+		t.Fatalf("asset not served: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

**Critical web UI fix.** Every page in the web UI rendered the **dashboard** — no other route (Media Library, Settings, System, tools) would load, whether via a deep link or in-app navigation.

Root cause: `spaFileServer` rewrote unknown paths to `/index.html`, but `http.FileServer` **301-redirects any request for `.../index.html` to `./`** (canonicalization). So `/library` → rewrite `/index.html` → `301 ./` → back to `/` (dashboard). Chrome also caches the 301 permanently, compounding it.

Fix: serve `index.html`'s bytes **directly** with a `200` for unknown paths, instead of rewriting the URL. Real assets still go through the file server.

Verified live: after the fix, `/system`, `/library`, `/tools/verify` etc. all render their correct pages. Regression tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)