### PR TITLE
feat(webserver): library-paths + rescan/resync endpoints (Media Library was empty)

### DIFF
--- a/changelog.d/feat-library-paths-api.md
+++ b/changelog.d/feat-library-paths-api.md
@@ -1,0 +1,9 @@
+### Added
+
+#### Library paths API for the Media Library
+
+Added the `/api/library/paths` (GET/POST/DELETE) plus `/api/library/rescan` and
+`/api/library/resync` endpoints. The Media Library UI called these but no backend
+route existed, so the library always appeared empty and "Add Library Path"
+silently failed. Configured root paths are now persisted (a JSON file beside the
+database) and adding or rescanning a path scans it into the media library.

--- a/pkg/webserver/librarypaths.go
+++ b/pkg/webserver/librarypaths.go
@@ -1,0 +1,169 @@
+// file: pkg/webserver/librarypaths.go
+// version: 1.0.0
+// guid: 17206a5a-f1bc-4f44-acfa-aa3d7f72f59c
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/metadata"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+)
+
+// libraryPathsMu guards the on-disk library-paths list.
+var libraryPathsMu sync.Mutex
+
+// libraryPathsFile returns the JSON file used to persist the configured library
+// root paths. It lives alongside the database so it survives restarts.
+func libraryPathsFile() string {
+	dbPath := viper.GetString("db_path")
+	dir := dbPath
+	if fi, err := os.Stat(dbPath); err == nil && !fi.IsDir() {
+		dir = filepath.Dir(dbPath)
+	}
+	if dir == "" {
+		dir = "."
+	}
+	return filepath.Join(dir, "library-paths.json")
+}
+
+func readLibraryPaths() []string {
+	data, err := os.ReadFile(libraryPathsFile())
+	if err != nil {
+		return []string{}
+	}
+	var paths []string
+	if err := json.Unmarshal(data, &paths); err != nil || paths == nil {
+		return []string{}
+	}
+	return paths
+}
+
+func writeLibraryPaths(paths []string) error {
+	data, err := json.MarshalIndent(paths, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(libraryPathsFile()), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(libraryPathsFile(), data, 0o644)
+}
+
+// scanPathAsync scans dir into the media library in the background so newly
+// added / rescanned paths populate MediaItems without blocking the request.
+func scanPathAsync(dir string) {
+	go func() {
+		logger := logging.GetLogger("library-paths")
+		store, err := database.OpenStoreWithConfig()
+		if err != nil {
+			logger.Warnf("scan %s: open store: %v", dir, err)
+			return
+		}
+		defer store.Close()
+		if err := metadata.ScanLibraryProgress(context.Background(), dir, store, nil); err != nil {
+			logger.Warnf("scan %s: %v", dir, err)
+		}
+	}()
+}
+
+// libraryPathsHandler manages the configured library root paths that the Media
+// Library UI browses. The previous UI called /api/library/paths but no backend
+// route existed, so the library always appeared empty and "Add Library Path"
+// silently failed. GET returns {"paths": [...]}, POST {"path": "..."} adds and
+// scans it, DELETE {"path": "..."} removes it.
+func libraryPathsHandler() http.Handler {
+	type body struct {
+		Path string `json:"path"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			libraryPathsMu.Lock()
+			paths := readLibraryPaths()
+			libraryPathsMu.Unlock()
+			writeJSON(w, map[string]any{"paths": paths})
+
+		case http.MethodPost:
+			var q body
+			if err := json.NewDecoder(r.Body).Decode(&q); err != nil || q.Path == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			clean, err := security.ValidateAndSanitizePath(q.Path)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			libraryPathsMu.Lock()
+			paths := readLibraryPaths()
+			if !slices.Contains(paths, clean) {
+				paths = append(paths, clean)
+				sort.Strings(paths)
+				if err := writeLibraryPaths(paths); err != nil {
+					libraryPathsMu.Unlock()
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+			libraryPathsMu.Unlock()
+			scanPathAsync(clean)
+			writeJSON(w, map[string]any{"paths": paths})
+
+		case http.MethodDelete:
+			var q body
+			if err := json.NewDecoder(r.Body).Decode(&q); err != nil || q.Path == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			libraryPathsMu.Lock()
+			paths := readLibraryPaths()
+			paths = slices.DeleteFunc(paths, func(p string) bool { return p == q.Path })
+			err := writeLibraryPaths(paths)
+			libraryPathsMu.Unlock()
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			writeJSON(w, map[string]any{"paths": paths})
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+// libraryRescanHandler rescans every configured library path from disk.
+func libraryRescanHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		libraryPathsMu.Lock()
+		paths := readLibraryPaths()
+		libraryPathsMu.Unlock()
+		for _, p := range paths {
+			scanPathAsync(p)
+		}
+		writeJSON(w, map[string]any{"status": "started", "paths": len(paths)})
+	})
+}
+
+// writeJSON writes v as a JSON response.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/pkg/webserver/librarypaths_test.go
+++ b/pkg/webserver/librarypaths_test.go
@@ -1,0 +1,76 @@
+// file: pkg/webserver/librarypaths_test.go
+// version: 1.0.0
+// guid: 1b2c62c8-236d-4c33-bdb5-23d18ff8bcdd
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestLibraryPathsHandler verifies GET/POST/DELETE of configured library paths,
+// which the Media Library UI needs (previously the route was missing, so the
+// library was always empty and "Add Library Path" failed).
+func TestLibraryPathsHandler(t *testing.T) {
+	dir := t.TempDir()
+	viper.Set("db_path", dir)
+	defer viper.Reset()
+
+	h := libraryPathsHandler()
+
+	get := func() []string {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/library/paths", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET expected 200, got %d", rec.Code)
+		}
+		var out struct {
+			Paths []string `json:"paths"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("bad json: %v (%s)", err, rec.Body.String())
+		}
+		return out.Paths
+	}
+
+	if p := get(); len(p) != 0 {
+		t.Fatalf("expected no paths initially, got %v", p)
+	}
+
+	// POST a valid path (the temp dir is allowed by ValidateAndSanitizePath).
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/library/paths", strings.NewReader(`{"path":"`+dir+`"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if p := get(); len(p) != 1 || p[0] != dir {
+		t.Fatalf("expected [%s], got %v", dir, p)
+	}
+
+	// DELETE it.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/api/library/paths", strings.NewReader(`{"path":"`+dir+`"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE expected 200, got %d", rec.Code)
+	}
+	if p := get(); len(p) != 0 {
+		t.Fatalf("expected empty after delete, got %v", p)
+	}
+}
+
+// TestLibraryPathsBadRequest verifies invalid input is rejected.
+func TestLibraryPathsBadRequest(t *testing.T) {
+	viper.Set("db_path", t.TempDir())
+	defer viper.Reset()
+	rec := httptest.NewRecorder()
+	libraryPathsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/library/paths", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty path, got %d", rec.Code)
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -209,6 +209,11 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/library/tags", authMiddleware(db, "basic", libraryTagsHandler(db)))
 	mux.Handle(prefix+"/api/library/scan", authMiddleware(db, "basic", libraryScanHandler(db)))
 	mux.Handle(prefix+"/api/library/scan/status", authMiddleware(db, "basic", libraryScanStatusHandler()))
+	// Library root paths for the Media Library UI (previously missing, leaving the
+	// library empty and "Add Library Path" broken).
+	mux.Handle(prefix+"/api/library/paths", authMiddleware(db, "basic", libraryPathsHandler()))
+	mux.Handle(prefix+"/api/library/rescan", authMiddleware(db, "basic", libraryRescanHandler()))
+	mux.Handle(prefix+"/api/library/resync", authMiddleware(db, "basic", libraryRescanHandler()))
 	// Whisper pipeline endpoints (library-search bridge, double-subs, drift verify)
 	mux.Handle(prefix+"/api/library/search", authMiddleware(db, "basic", librarySearchHandler()))
 	mux.Handle(prefix+"/api/library/search/status", authMiddleware(db, "basic", librarySearchStatusHandler()))


### PR DESCRIPTION
## Summary

The Media Library UI calls `/api/library/paths` (GET/POST/DELETE), `/api/library/rescan`, and `/api/library/resync` — but **none existed on the backend**, so the library always appeared empty and "Add Library Path" silently failed (the fetch got the SPA `index.html`, not JSON).

Implements them (GET/POST/DELETE library root paths persisted to a JSON file beside the DB; rescan/resync scan the configured paths). Tests included.

> Pairs with #2179 (SPA routing fix) — together they make the Media Library reachable and populatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)