### PR TITLE
feat(postprocess): subtitle post-processing pipeline + Bazarr parity inventory

### DIFF
--- a/changelog.d/feat-postprocess-pipeline.md
+++ b/changelog.d/feat-postprocess-pipeline.md
@@ -1,0 +1,12 @@
+### Added
+
+#### Subtitle post-processing pipeline (Bazarr parity)
+
+Added `pkg/postprocess`, wired into the download path (`scanner.ProcessFile`), so
+downloaded subtitles can be post-processed like Bazarr does — all opt-in via
+config: `postprocess.utf8_encoding` (detect charset and convert to UTF-8),
+`postprocess.chmod` (set file permissions), `postprocess.auto_sync` (sync the
+subtitle to the media after download), and `postprocess.custom_script` (run a
+shell command with `SM_SUBTITLE_PATH`/`SM_MEDIA_PATH`/`SM_LANG`). With no config
+the pipeline is a no-op. Also added `docs/BAZARR_PARITY_STATUS.md`, a grounded
+backend feature-parity inventory and plan.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,0 +1,94 @@
+<!-- file: docs/BAZARR_PARITY_STATUS.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
+<!-- last-edited: 2026-07-23 -->
+
+# Bazarr Backend Parity — Status & Gap Inventory
+
+Grounded audit of subtitle-manager's backend against
+[`BAZARR_FEATURE_LIST_COMPLETE.md`](BAZARR_FEATURE_LIST_COMPLETE.md), verified by
+reading the code (2026-07-23). Status legend: **✅ Built**, **🟡 Partial**,
+**🔴 Missing**. "Partial" means the plumbing exists but the behaviour is not
+wired into the live path.
+
+## The load-bearing caveat: the provider layer
+
+**~52 of ~55 registered subtitle providers are non-functional stubs** — each
+GETs a fictional `https://api.<name>.com/subtitles/<file>/<lang>` endpoint
+(`pkg/providers/*/*.go`). Only **opensubtitles** is a real integration;
+`generic` and `whisper` are configurable HTTP pass-throughs. Bazarr's provider
+breadth comes from Python's `subliminal`; porting dozens of real scrapers to Go
+is a large, separate effort. **Until that is done, automatic search/download
+works only through opensubtitles**, regardless of how good the surrounding
+engine is. This is the single biggest parity gap and is tracked separately.
+
+## Matrix
+
+### Sonarr / Radarr
+| Capability | Status | Notes |
+| --- | --- | --- |
+| REST library sync (episodes/movies, host/port/ssl/base/key) | ✅ | `pkg/sonarr/client.go`, `pkg/radarr/client.go` |
+| Scheduled sync wired into webserver | 🟡 | `StartContinuousSync` unused; monitor loop doesn't re-pull |
+| Minimum-score threshold applied to *arr downloads | 🟡 | global scorer exists, not applied at download |
+| Monitored-only mode | 🔴 | `monitored` field not even decoded |
+| Excluded tags / series types | 🔴 | not decoded/filtered |
+| Path mappings (arr↔local) applied | 🔴 | import-only stub; never applied |
+| Webhook on import → search | 🟡 | only `Download` event; hardcoded `en`; no profile/score |
+
+### Search / download / upgrade engine
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Provider registry breadth | 🔴 | ~52 stubs; 1 real (opensubtitles) |
+| Automatic "wanted" search loop (scheduled) | 🟡 | monitor skeleton exists; no score gate |
+| Manual search (ranked candidates) | 🟡 | `/api/search`; only opensubtitles implements `Searcher` |
+| Score-gated accept/reject (min-score) | 🟡 | `pkg/scoring` not wired into auto-download |
+| Score-based upgrade | 🔴 | upgrade decided by file size, not score |
+| Adaptive searching | 🟡 | fixed retry→blacklist; in-memory provider backoff |
+| Parallel provider fetch (core path) | 🟡 | `multi.go` is serial with backoff sleeps |
+| Use embedded tracks as a source | 🟡 | ffmpeg extract exists but not a download source; `embedded` provider is a stub |
+| Ignore PGS/image subtitles | 🔴 | not filtered |
+| Desired-languages via profiles | ✅ | `FetchWithProfile` iterates by priority |
+
+### Post-processing / languages / profiles
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Language profiles (multi-lang, priority, cutoff) | ✅ | `pkg/profiles` + REST/CLI |
+| Forced / HI honored at download & naming | 🟡 | flags stored, not honored |
+| Default profile auto-assigned to new *arr items | 🟡 | single global default; no auto-assign |
+| Mass-edit (bulk profile assign) | 🔴 | single-item only |
+| Single-language filename option | 🔴 | always `video.<lang>.srt` |
+| **UTF-8 re-encoding** | ✅ **(this PR)** | `pkg/postprocess.EncodeUTF8` wired into `ProcessFile` |
+| **chmod on written subtitles** | ✅ **(this PR)** | `postprocess.chmod` |
+| **Auto-sync after download** | ✅ **(this PR)** | `postprocess.auto_sync` |
+| **Custom post-download script** | ✅ **(this PR)** | `postprocess.custom_script` |
+| Format conversion on download (ASS/VTT) | 🟡 | astisub writer real but gRPC path stubbed; download emits `.srt` only |
+| Anti-captcha wired to providers | 🟡 | solver exists, never called |
+| History retention/depth | 🟡 | records written; no pruning |
+| Blacklist (per-subtitle) | 🟡 | not persisted; item-level only |
+
+### Infrastructure / settings
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Auth (form/API-key/OAuth) | ✅ | (Basic-auth challenge not offered) |
+| Bind addr/port + base_url | ✅ | |
+| DB backends (sqlite/pebble/postgres) | ✅ | auth uses a side sqlite `auth.db` |
+| Metrics/health/logging | ✅ | |
+| Config persistence + settings API | ✅ | `/api/config` + viper WriteConfig |
+| Scheduler with persisted per-task intervals | 🟡 | CLI-flag driven; not config/UI per-job |
+| Outbound proxy (HTTP/Socks) for providers | 🔴 | none |
+| Notifications (Apprise / many channels) | 🟡 | 3 fixed channels; no Apprise |
+| Plex incoming webhook | 🔴 | only Sonarr/Radarr/custom |
+| External-Whisper model/timeout config | 🟡 | selectable only for the local container |
+
+## Implementation plan (backend)
+
+Ordered by value × tractability. Items marked **done** are landing now.
+
+1. **Post-processing pipeline** — UTF-8, chmod, auto-sync, custom script. **done (this PR).**
+2. Score-gated auto-download + score-based upgrade (wire `pkg/scoring` into `ProcessFile`).
+3. Sonarr/Radarr: decode+apply `monitored`, `tags`, `seriesType`; apply path mappings.
+4. Real `embedded` source (ffmpeg extract) preferred before providers.
+5. Profile mass-edit; honor Forced/HI + cutoff-score; single-language filename option.
+6. Infra: outbound proxy; Plex webhook; external-Whisper model/timeout; Apprise notifications.
+7. Blacklist persistence; history retention.
+8. **(Large, separate track)** replace the ~52 stub providers with real integrations.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/vektra/mockery/v2 v2.53.5
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.40.0
 	google.golang.org/api v0.265.0
@@ -139,7 +140,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
 	golang.org/x/mod v0.37.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/pkg/postprocess/postprocess.go
+++ b/pkg/postprocess/postprocess.go
@@ -1,0 +1,125 @@
+// file: pkg/postprocess/postprocess.go
+// version: 1.0.0
+// guid: e05a04c4-5ff1-4ed0-8c91-3b114e2a3d94
+
+// Package postprocess implements the Bazarr-style post-processing pipeline that
+// runs on a subtitle after it is downloaded/written: UTF-8 re-encoding,
+// permission (chmod) enforcement, automatic sync against the media, and an
+// optional custom user script. Every step is opt-in via config, so with no
+// configuration the pipeline is a no-op and the download path is unchanged.
+//
+// Config keys (viper):
+//
+//	postprocess.utf8_encoding  bool    convert downloaded subtitles to UTF-8
+//	postprocess.chmod          string  octal mode applied to the file, e.g. "0644"
+//	postprocess.auto_sync      bool    sync the subtitle to the media after download
+//	postprocess.custom_script  string  shell command run after download
+package postprocess
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/asticode/go-astisub"
+	"github.com/spf13/viper"
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/transform"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/syncer"
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// EncodeUTF8 converts subtitle bytes to UTF-8. If the data is already valid
+// UTF-8 it is returned unchanged (minus any BOM). Otherwise the charset is
+// detected (e.g. Windows-1252, ISO-8859-1) and transcoded. On detection/decode
+// failure the original bytes are returned so a download is never lost.
+func EncodeUTF8(data []byte) []byte {
+	if utf8.Valid(data) {
+		return bytes.TrimPrefix(data, utf8BOM)
+	}
+	enc, _, _ := charset.DetermineEncoding(data, "")
+	out, _, err := transform.Bytes(enc.NewDecoder(), data)
+	if err != nil {
+		return data
+	}
+	return bytes.TrimPrefix(out, utf8BOM)
+}
+
+// EncodeUTF8IfEnabled applies EncodeUTF8 only when postprocess.utf8_encoding is
+// set. Called on the downloaded bytes before they are written.
+func EncodeUTF8IfEnabled(data []byte) []byte {
+	if !viper.GetBool("postprocess.utf8_encoding") {
+		return data
+	}
+	return EncodeUTF8(data)
+}
+
+// AfterDownload runs the post-write steps (chmod, auto-sync, custom script) on a
+// subtitle that has just been written for the given media file. Each step is
+// gated by config and errors are logged, not returned, so post-processing never
+// fails a completed download.
+func AfterDownload(ctx context.Context, subtitlePath, mediaPath, lang string) {
+	logger := logging.GetLogger("postprocess")
+
+	if mode := viper.GetString("postprocess.chmod"); mode != "" {
+		if m, err := strconv.ParseUint(mode, 8, 32); err == nil {
+			if err := os.Chmod(subtitlePath, os.FileMode(m)); err != nil {
+				logger.Warnf("chmod %s: %v", subtitlePath, err)
+			}
+		} else {
+			logger.Warnf("invalid postprocess.chmod %q: %v", mode, err)
+		}
+	}
+
+	if viper.GetBool("postprocess.auto_sync") && mediaPath != "" {
+		if err := autoSync(mediaPath, subtitlePath); err != nil {
+			logger.Warnf("auto-sync %s: %v", subtitlePath, err)
+		}
+	}
+
+	if script := viper.GetString("postprocess.custom_script"); script != "" {
+		if err := runScript(ctx, script, subtitlePath, mediaPath, lang); err != nil {
+			logger.Warnf("custom script: %v", err)
+		}
+	}
+}
+
+// autoSync synchronizes subtitlePath to mediaPath (using embedded subtitles as
+// the reference) and overwrites the file with the aligned result.
+func autoSync(mediaPath, subtitlePath string) error {
+	items, err := syncer.Sync(mediaPath, subtitlePath, syncer.Options{UseEmbedded: true})
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(subtitlePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sub := astisub.Subtitles{Items: items}
+	return sub.WriteToSRT(f)
+}
+
+// runScript executes the configured shell command, passing the subtitle, media
+// and language via environment variables (SM_SUBTITLE_PATH / SM_MEDIA_PATH /
+// SM_LANG) so paths are never interpolated into the command string.
+func runScript(ctx context.Context, script, subtitlePath, mediaPath, lang string) error {
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"SM_SUBTITLE_PATH="+subtitlePath,
+		"SM_MEDIA_PATH="+mediaPath,
+		"SM_LANG="+lang,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, bytes.TrimSpace(out))
+	}
+	return nil
+}

--- a/pkg/postprocess/postprocess_test.go
+++ b/pkg/postprocess/postprocess_test.go
@@ -1,0 +1,82 @@
+// file: pkg/postprocess/postprocess_test.go
+// version: 1.0.0
+// guid: e8717c91-78e9-4330-bdda-91b8e9cd31fa
+
+package postprocess
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestEncodeUTF8 verifies valid UTF-8 passes through (BOM stripped) and a
+// Windows-1252/Latin-1 byte is transcoded to UTF-8.
+func TestEncodeUTF8(t *testing.T) {
+	// Valid UTF-8 with a BOM.
+	in := append([]byte{0xEF, 0xBB, 0xBF}, []byte("héllo")...)
+	got := EncodeUTF8(in)
+	if string(got) != "héllo" {
+		t.Fatalf("expected BOM stripped UTF-8, got %q", got)
+	}
+
+	// "café" with é as a single Latin-1 byte 0xE9 (invalid UTF-8).
+	latin1 := []byte{'c', 'a', 'f', 0xE9}
+	out := EncodeUTF8(latin1)
+	if !strings.Contains(string(out), "café") {
+		t.Fatalf("expected transcoded café, got %q (% x)", out, out)
+	}
+}
+
+// TestEncodeUTF8IfEnabledGating verifies the toggle.
+func TestEncodeUTF8IfEnabledGating(t *testing.T) {
+	defer viper.Reset()
+	latin1 := []byte{'c', 'a', 'f', 0xE9}
+
+	viper.Set("postprocess.utf8_encoding", false)
+	if got := EncodeUTF8IfEnabled(latin1); string(got) != string(latin1) {
+		t.Fatalf("disabled should pass through unchanged")
+	}
+	viper.Set("postprocess.utf8_encoding", true)
+	if got := EncodeUTF8IfEnabled(latin1); !strings.Contains(string(got), "café") {
+		t.Fatalf("enabled should transcode, got %q", got)
+	}
+}
+
+// TestAfterDownloadChmodAndScript verifies chmod and the custom script run with
+// the documented environment variables.
+func TestAfterDownloadChmodAndScript(t *testing.T) {
+	defer viper.Reset()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "movie.en.srt")
+	if err := os.WriteFile(sub, []byte("1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	marker := filepath.Join(dir, "ran.txt")
+
+	viper.Set("postprocess.chmod", "0640")
+	// Script records the env vars it received.
+	viper.Set("postprocess.custom_script", "printf '%s|%s|%s' \"$SM_SUBTITLE_PATH\" \"$SM_MEDIA_PATH\" \"$SM_LANG\" > "+marker)
+
+	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en")
+
+	fi, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o640 {
+		t.Fatalf("expected mode 0640, got %o", fi.Mode().Perm())
+	}
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("script did not run (no marker): %v", err)
+	}
+	want := sub + "|" + filepath.Join(dir, "movie.mkv") + "|en"
+	if string(data) != want {
+		t.Fatalf("script env mismatch: got %q want %q", data, want)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jdfalk/subtitle-manager/pkg/events"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	"github.com/jdfalk/subtitle-manager/pkg/metadata"
+	"github.com/jdfalk/subtitle-manager/pkg/postprocess"
 	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/security"
 )
@@ -140,6 +141,8 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 			wasUpgrade = true
 		}
 	}
+	// Post-processing: optionally re-encode to UTF-8 before writing.
+	data = postprocess.EncodeUTF8IfEnabled(data)
 	if err := os.WriteFile(validatedOutputPath, data, 0644); err != nil {
 		logger.Warnf("write %s: %v", validatedOutputPath, err)
 
@@ -185,6 +188,8 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 	if store != nil {
 		_ = store.InsertDownload(&database.DownloadRecord{File: validatedOutputPath, VideoFile: path, Provider: providerName, Language: lang})
 	}
+	// Post-processing: chmod, auto-sync, custom script (all opt-in via config).
+	postprocess.AfterDownload(ctx, validatedOutputPath, path, lang)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

First of several PRs toward **Bazarr backend feature parity**. Adds the **post-processing pipeline** that runs after a subtitle is downloaded — the biggest self-contained gap (the download path previously wrote raw bytes at `0644` and stopped).

`pkg/postprocess`, wired into `scanner.ProcessFile`, all **opt-in via config**:
- `postprocess.utf8_encoding` — detect charset (Windows-1252/Latin-1/…) and convert to UTF-8 (BOM stripped)
- `postprocess.chmod` — set permissions on the written subtitle
- `postprocess.auto_sync` — sync the subtitle to the media (via `pkg/syncer`) after download
- `postprocess.custom_script` — run a shell command with `SM_SUBTITLE_PATH`/`SM_MEDIA_PATH`/`SM_LANG` (paths passed via env, never interpolated)

With no config set it's a no-op, so existing behavior is unchanged.

## Also
- **`docs/BAZARR_PARITY_STATUS.md`** — a grounded backend parity matrix (Built/Partial/Missing with notes) and an ordered implementation plan, including the load-bearing caveat that **~52 of ~55 providers are non-functional stubs** (only opensubtitles is real).

## Verification
`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/postprocess/ ./pkg/scanner/` all pass (tests cover UTF-8 transcode, gating, chmod, and the custom-script env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)