### PR TITLE
feat(arr): Sonarr/Radarr monitored-only, tag/series-type exclusion, path mappings

### DIFF
--- a/changelog.d/feat-arr-filters.md
+++ b/changelog.d/feat-arr-filters.md
@@ -1,0 +1,11 @@
+### Added
+
+#### Sonarr/Radarr filtering: monitored-only, tags, series-types, path mappings
+
+Added `pkg/arr` filtering applied when syncing the Sonarr/Radarr library, for
+Bazarr parity: `integrations.{sonarr,radarr}.monitored_only` (ingest only
+monitored items), `.excluded_series_types` (Sonarr, e.g. `anime`/`daily`),
+`.excluded_tags` (tag IDs), and `.path_mappings` (rewrite a path prefix when
+*arr and subtitle-manager see files under different roots). Filters are applied
+in the client's `Episodes`/`Movies` decode and auto-populated from config in
+`Sync`. The zero config is backwards compatible (no filtering).

--- a/pkg/arr/filter.go
+++ b/pkg/arr/filter.go
@@ -1,0 +1,95 @@
+// file: pkg/arr/filter.go
+// version: 1.0.0
+// guid: 94ab65c2-d217-4214-9857-eb91161a7dff
+
+// Package arr holds shared filtering used by the Sonarr and Radarr clients to
+// reach Bazarr parity: monitored-only mode, excluded series-types and tags, and
+// path mappings (when *arr and subtitle-manager see files under different
+// roots).
+package arr
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// Filters describes which Sonarr/Radarr items to ingest and how to remap their
+// paths. The zero value applies no filtering (backwards compatible).
+type Filters struct {
+	// MonitoredOnly drops items that are not monitored.
+	MonitoredOnly bool
+	// ExcludedSeriesTypes drops Sonarr series whose type matches (e.g. "anime",
+	// "daily", "standard"). Case-insensitive. Ignored by Radarr.
+	ExcludedSeriesTypes []string
+	// ExcludedTagIDs drops items carrying any of these Sonarr/Radarr tag IDs.
+	ExcludedTagIDs []int
+	// PathMappings rewrites a leading path prefix {from → to} so subtitle-manager
+	// can find files that *arr reports under a different root.
+	PathMappings [][2]string
+}
+
+// IsZero reports whether no filtering/mapping is configured.
+func (f Filters) IsZero() bool {
+	return !f.MonitoredOnly && len(f.ExcludedSeriesTypes) == 0 &&
+		len(f.ExcludedTagIDs) == 0 && len(f.PathMappings) == 0
+}
+
+// TypeExcluded reports whether seriesType is in the excluded set.
+func (f Filters) TypeExcluded(seriesType string) bool {
+	for _, t := range f.ExcludedSeriesTypes {
+		if strings.EqualFold(strings.TrimSpace(t), strings.TrimSpace(seriesType)) {
+			return true
+		}
+	}
+	return false
+}
+
+// TagsExcluded reports whether any of tags is in the excluded set.
+func (f Filters) TagsExcluded(tags []int) bool {
+	if len(f.ExcludedTagIDs) == 0 {
+		return false
+	}
+	set := make(map[int]struct{}, len(f.ExcludedTagIDs))
+	for _, id := range f.ExcludedTagIDs {
+		set[id] = struct{}{}
+	}
+	for _, id := range tags {
+		if _, ok := set[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// MapPath applies the first matching path prefix mapping to p, or returns p
+// unchanged. The longest "from" prefix wins so nested mappings are stable.
+func (f Filters) MapPath(p string) string {
+	best := -1
+	var bestTo string
+	for _, m := range f.PathMappings {
+		from, to := m[0], m[1]
+		if from != "" && strings.HasPrefix(p, from) && len(from) > best {
+			best = len(from)
+			bestTo = to + strings.TrimPrefix(p, from)
+		}
+	}
+	if best >= 0 {
+		return bestTo
+	}
+	return p
+}
+
+// FiltersFromViper reads filters from config under the given prefix, e.g.
+// "integrations.sonarr" or "integrations.radarr".
+func FiltersFromViper(prefix string) Filters {
+	f := Filters{
+		MonitoredOnly:       viper.GetBool(prefix + ".monitored_only"),
+		ExcludedSeriesTypes: viper.GetStringSlice(prefix + ".excluded_series_types"),
+		ExcludedTagIDs:      viper.GetIntSlice(prefix + ".excluded_tags"),
+	}
+	for from, to := range viper.GetStringMapString(prefix + ".path_mappings") {
+		f.PathMappings = append(f.PathMappings, [2]string{from, to})
+	}
+	return f
+}

--- a/pkg/arr/filter_test.go
+++ b/pkg/arr/filter_test.go
@@ -1,0 +1,55 @@
+// file: pkg/arr/filter_test.go
+// version: 1.0.0
+// guid: d11afe66-6490-452f-be08-c52826b24f04
+
+package arr
+
+import "testing"
+
+func TestTypeExcluded(t *testing.T) {
+	f := Filters{ExcludedSeriesTypes: []string{"anime", "daily"}}
+	if !f.TypeExcluded("Anime") {
+		t.Fatal("expected Anime excluded (case-insensitive)")
+	}
+	if f.TypeExcluded("standard") {
+		t.Fatal("standard should not be excluded")
+	}
+}
+
+func TestTagsExcluded(t *testing.T) {
+	f := Filters{ExcludedTagIDs: []int{5, 8}}
+	if !f.TagsExcluded([]int{1, 8}) {
+		t.Fatal("expected excluded via tag 8")
+	}
+	if f.TagsExcluded([]int{1, 2}) {
+		t.Fatal("no excluded tag present")
+	}
+	if (Filters{}).TagsExcluded([]int{1}) {
+		t.Fatal("empty exclusion set should never exclude")
+	}
+}
+
+func TestMapPathLongestPrefix(t *testing.T) {
+	f := Filters{PathMappings: [][2]string{
+		{"/tv", "/media/tv"},
+		{"/tv/anime", "/media/anime"},
+	}}
+	if got := f.MapPath("/tv/anime/Show/ep.mkv"); got != "/media/anime/Show/ep.mkv" {
+		t.Fatalf("longest-prefix mapping failed: %s", got)
+	}
+	if got := f.MapPath("/tv/Show/ep.mkv"); got != "/media/tv/Show/ep.mkv" {
+		t.Fatalf("prefix mapping failed: %s", got)
+	}
+	if got := f.MapPath("/movies/x.mkv"); got != "/movies/x.mkv" {
+		t.Fatalf("unmapped path should pass through: %s", got)
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	if !(Filters{}).IsZero() {
+		t.Fatal("empty filters should be zero")
+	}
+	if (Filters{MonitoredOnly: true}).IsZero() {
+		t.Fatal("MonitoredOnly set should not be zero")
+	}
+}

--- a/pkg/radarr/client.go
+++ b/pkg/radarr/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 )
@@ -16,6 +17,9 @@ import (
 type Client struct {
 	BaseURL string
 	APIKey  string
+	// Filters restricts which movies are ingested and remaps paths; Sync
+	// populates it from config when left zero.
+	Filters arr.Filters
 	client  *http.Client
 }
 
@@ -30,6 +34,8 @@ func NewClient(baseURL, apiKey string) *Client {
 
 type movie struct {
 	Title     string `json:"title"`
+	Monitored bool   `json:"monitored"`
+	Tags      []int  `json:"tags"`
 	MovieFile struct {
 		Path string `json:"path"`
 	} `json:"movieFile"`
@@ -59,7 +65,13 @@ func (c *Client) Movies(ctx context.Context) ([]database.MediaItem, error) {
 		if mv.MovieFile.Path == "" {
 			continue
 		}
-		items = append(items, database.MediaItem{Path: mv.MovieFile.Path, Title: mv.Title})
+		if c.Filters.MonitoredOnly && !mv.Monitored {
+			continue
+		}
+		if c.Filters.TagsExcluded(mv.Tags) {
+			continue
+		}
+		items = append(items, database.MediaItem{Path: c.Filters.MapPath(mv.MovieFile.Path), Title: mv.Title})
 	}
 	return items, nil
 }
@@ -67,6 +79,9 @@ func (c *Client) Movies(ctx context.Context) ([]database.MediaItem, error) {
 // Sync fetches the movie library and stores new items in store.
 func Sync(ctx context.Context, c *Client, store database.SubtitleStore) error {
 	logger := logging.GetLogger("radarr")
+	if c.Filters.IsZero() {
+		c.Filters = arr.FiltersFromViper("integrations.radarr")
+	}
 	movies, err := c.Movies(ctx)
 	if err != nil {
 		return err

--- a/pkg/sonarr/client.go
+++ b/pkg/sonarr/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 )
@@ -16,6 +17,10 @@ import (
 type Client struct {
 	BaseURL string
 	APIKey  string
+	// Filters, when set, restrict which items are ingested (monitored-only,
+	// excluded series-types/tags) and remap paths. Sync populates it from config
+	// when left zero.
+	Filters arr.Filters
 	client  *http.Client
 }
 
@@ -29,8 +34,12 @@ func NewClient(baseURL, apiKey string) *Client {
 }
 
 type episode struct {
-	Series struct {
-		Title string `json:"title"`
+	Monitored bool `json:"monitored"`
+	Series    struct {
+		Title      string `json:"title"`
+		Monitored  bool   `json:"monitored"`
+		SeriesType string `json:"seriesType"`
+		Tags       []int  `json:"tags"`
 	} `json:"series"`
 	EpisodeFile struct {
 		Path string `json:"path"`
@@ -63,7 +72,14 @@ func (c *Client) Episodes(ctx context.Context) ([]database.MediaItem, error) {
 		if ep.EpisodeFile.Path == "" {
 			continue
 		}
-		items = append(items, database.MediaItem{Path: ep.EpisodeFile.Path, Title: ep.Series.Title, Season: ep.SeasonNumber, Episode: ep.EpisodeNumber})
+		if c.Filters.MonitoredOnly && (!ep.Monitored || !ep.Series.Monitored) {
+			continue
+		}
+		if c.Filters.TypeExcluded(ep.Series.SeriesType) || c.Filters.TagsExcluded(ep.Series.Tags) {
+			continue
+		}
+		path := c.Filters.MapPath(ep.EpisodeFile.Path)
+		items = append(items, database.MediaItem{Path: path, Title: ep.Series.Title, Season: ep.SeasonNumber, Episode: ep.EpisodeNumber})
 	}
 	return items, nil
 }
@@ -71,6 +87,9 @@ func (c *Client) Episodes(ctx context.Context) ([]database.MediaItem, error) {
 // Sync fetches episodes and stores new items in store.
 func Sync(ctx context.Context, c *Client, store database.SubtitleStore) error {
 	logger := logging.GetLogger("sonarr")
+	if c.Filters.IsZero() {
+		c.Filters = arr.FiltersFromViper("integrations.sonarr")
+	}
 	eps, err := c.Episodes(ctx)
 	if err != nil {
 		return err

--- a/pkg/sonarr/filter_test.go
+++ b/pkg/sonarr/filter_test.go
@@ -1,0 +1,59 @@
+// file: pkg/sonarr/filter_test.go
+// version: 1.0.0
+// guid: 3d9c8a71-4e26-4b2f-8a05-7c1e9d3b6f22
+
+package sonarr
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
+)
+
+// TestEpisodesFiltering verifies monitored-only, series-type and tag exclusion,
+// and path mapping are applied when ingesting Sonarr episodes.
+func TestEpisodesFiltering(t *testing.T) {
+	const body = `[
+	  {"monitored":true,"series":{"title":"Keep","monitored":true,"seriesType":"standard","tags":[1]},"episodeFile":{"path":"/tv/Keep/e1.mkv"},"seasonNumber":1,"episodeNumber":1},
+	  {"monitored":false,"series":{"title":"Unmon","monitored":true,"seriesType":"standard","tags":[]},"episodeFile":{"path":"/tv/Unmon/e1.mkv"},"seasonNumber":1,"episodeNumber":1},
+	  {"monitored":true,"series":{"title":"Anime","monitored":true,"seriesType":"anime","tags":[]},"episodeFile":{"path":"/tv/Anime/e1.mkv"},"seasonNumber":1,"episodeNumber":1},
+	  {"monitored":true,"series":{"title":"Tagged","monitored":true,"seriesType":"standard","tags":[9]},"episodeFile":{"path":"/tv/Tagged/e1.mkv"},"seasonNumber":1,"episodeNumber":1}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "k" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		BaseURL: srv.URL,
+		APIKey:  "k",
+		client:  srv.Client(),
+		Filters: arr.Filters{
+			MonitoredOnly:       true,
+			ExcludedSeriesTypes: []string{"anime"},
+			ExcludedTagIDs:      []int{9},
+			PathMappings:        [][2]string{{"/tv", "/media/tv"}},
+		},
+	}
+
+	items, err := c.Episodes(context.Background())
+	if err != nil {
+		t.Fatalf("episodes: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after filtering, got %d: %+v", len(items), items)
+	}
+	if items[0].Title != "Keep" {
+		t.Fatalf("expected Keep, got %q", items[0].Title)
+	}
+	if items[0].Path != "/media/tv/Keep/e1.mkv" {
+		t.Fatalf("expected mapped path, got %q", items[0].Path)
+	}
+}


### PR DESCRIPTION
## Summary

Bazarr parity for Sonarr/Radarr filtering — the audit found these fully **missing** (the clients didn't even decode `monitored`/`tags`/`seriesType`).

New `pkg/arr` (pure, tested helpers) wired into both clients:
- `integrations.{sonarr,radarr}.monitored_only` — ingest only monitored items
- `.excluded_series_types` (Sonarr) — drop e.g. `anime`/`daily`
- `.excluded_tags` — drop items carrying any listed tag ID
- `.path_mappings` — rewrite a leading path prefix (arr↔local root differences), longest-prefix wins

Applied during the `Episodes`/`Movies` decode; `Sync` auto-populates filters from config when unset. **Backwards compatible** — empty config filters nothing.

## Verification
`go build ./...`, `gofmt`, and `go test ./pkg/arr/ ./pkg/sonarr/ ./pkg/radarr/` pass (helper tests + an httptest-driven Sonarr filtering test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)