### PR TITLE
feat(embedded): extract real embedded subtitle tracks via ffmpeg

### DIFF
--- a/changelog.d/feat-embedded-provider.md
+++ b/changelog.d/feat-embedded-provider.md
@@ -1,0 +1,12 @@
+### Added
+
+#### Real embedded-subtitle provider (extract tracks from the container)
+
+The `embedded` provider now extracts subtitle tracks already muxed into the
+media file via `ffmpeg`, matching Bazarr's "use embedded subtitles" feature,
+instead of the previous stub that hit a fake HTTP endpoint. It probes streams
+with `ffprobe` (`pkg/video.SubtitleStreams`), skips image-based tracks
+(PGS/VobSub/DVD) that cannot be converted to text, selects the track whose
+language matches the request (tolerating ISO 639-1 vs 639-2, e.g. `en` vs
+`eng`), and returns it as SRT. When the language is unconstrained and exactly
+one text track exists, that track is used.

--- a/pkg/providers/embedded/embedded.go
+++ b/pkg/providers/embedded/embedded.go
@@ -1,48 +1,95 @@
 // file: pkg/providers/embedded/embedded.go
+// version: 2.0.0
+// guid: 7c1a9e34-2b58-4d06-9f13-8a6e2c4b7d90
+
+// Package embedded provides a subtitle "provider" that extracts subtitle tracks
+// already embedded in the media container (via ffmpeg), rather than downloading
+// from an external service. It is a genuinely functional source: Bazarr's "use
+// embedded subtitles" feature.
 package embedded
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"path/filepath"
-	"time"
+	"strings"
+
+	"github.com/asticode/go-astisub"
+	"golang.org/x/text/language"
+
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+	"github.com/jdfalk/subtitle-manager/pkg/video"
 )
 
-// Client implements the providers.Provider interface for Embedded.
-// It performs a simple HTTP GET to download subtitles.
-type Client struct {
-	// APIURL is the base URL of the Embedded API.
-	APIURL string
-	// HTTPClient is used to make requests.
-	HTTPClient *http.Client
-}
+// Client implements the providers.Provider interface by extracting an embedded
+// subtitle track that matches the requested language.
+type Client struct{}
 
-// New returns a Client configured with reasonable defaults.
-func New() *Client {
-	return &Client{
-		APIURL:     "https://api.embedded.com",
-		HTTPClient: &http.Client{Timeout: 15 * time.Second},
-	}
-}
+// New returns a Client.
+func New() *Client { return &Client{} }
 
-// Fetch downloads the subtitle for mediaPath in lang.
-// It returns the subtitle bytes or an error.
+// Fetch extracts the embedded subtitle track of mediaPath whose language matches
+// lang and returns it as SRT bytes. Image-based tracks (PGS/VobSub/DVD) are
+// skipped because they cannot be converted to text. It returns an error when no
+// matching text track is present.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	name := filepath.Base(mediaPath)
-	url := fmt.Sprintf("%s/subtitles/%s/%s", c.APIURL, name, lang)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	streams, err := video.SubtitleStreams(mediaPath)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.HTTPClient.Do(req)
+
+	ordinal := -1
+	for _, s := range streams {
+		if s.ImageBased() {
+			continue
+		}
+		if languageMatches(s.Language, lang) {
+			ordinal = s.Ordinal
+			break
+		}
+	}
+	// If nothing matched by language but there is exactly one text track and the
+	// caller did not constrain the language, use it.
+	if ordinal < 0 && lang == "" {
+		var textOnly []video.SubtitleStream
+		for _, s := range streams {
+			if !s.ImageBased() {
+				textOnly = append(textOnly, s)
+			}
+		}
+		if len(textOnly) == 1 {
+			ordinal = textOnly[0].Ordinal
+		}
+	}
+	if ordinal < 0 {
+		return nil, fmt.Errorf("no embedded %q subtitle track in %s", lang, mediaPath)
+	}
+
+	items, err := subtitles.ExtractTrack(mediaPath, ordinal)
 	if err != nil {
+		return nil, fmt.Errorf("extract embedded track %d: %w", ordinal, err)
+	}
+	buf := &bytes.Buffer{}
+	if err := (&astisub.Subtitles{Items: items}).WriteToSRT(buf); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	return buf.Bytes(), nil
+}
+
+// languageMatches reports whether a stream language tag matches the requested
+// language, tolerating ISO 639-1 vs 639-2 differences (e.g. "en" vs "eng").
+func languageMatches(streamLang, want string) bool {
+	streamLang = strings.TrimSpace(streamLang)
+	want = strings.TrimSpace(want)
+	if streamLang == "" || want == "" {
+		return false
 	}
-	return io.ReadAll(resp.Body)
+	a, err1 := language.Parse(streamLang)
+	b, err2 := language.Parse(want)
+	if err1 == nil && err2 == nil {
+		ba, _ := a.Base()
+		bb, _ := b.Base()
+		return ba == bb
+	}
+	return strings.EqualFold(streamLang, want)
 }

--- a/pkg/providers/embedded/embedded_test.go
+++ b/pkg/providers/embedded/embedded_test.go
@@ -1,32 +1,63 @@
+// file: pkg/providers/embedded/embedded_test.go
+// version: 2.0.0
+// guid: bc3bc260-6f2f-4daf-bba0-ed75a93d271d
+
 package embedded
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestClientFetch verifies that the client downloads subtitles using the expected URL.
-func TestClientFetch(t *testing.T) {
-	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		fmt.Fprint(w, "data")
-	}))
-	defer srv.Close()
+func TestLanguageMatches(t *testing.T) {
+	cases := []struct {
+		stream, want string
+		match        bool
+	}{
+		{"eng", "en", true},
+		{"en", "eng", true},
+		{"eng", "eng", true},
+		{"fre", "en", false},
+		{"", "en", false},
+		{"en", "", false},
+		{"spa", "es", true},
+	}
+	for _, c := range cases {
+		if got := languageMatches(c.stream, c.want); got != c.match {
+			t.Errorf("languageMatches(%q,%q)=%v want %v", c.stream, c.want, got, c.match)
+		}
+	}
+}
 
-	c := New()
-	c.APIURL = srv.URL
-	b, err := c.Fetch(context.Background(), "/path/movie.mkv", "en")
+// TestFetchExtractsEmbedded muxes an SRT track into an MKV with ffmpeg and
+// verifies Fetch extracts it. Skips when ffmpeg is unavailable.
+func TestFetchExtractsEmbedded(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available")
+	}
+	dir := t.TempDir()
+	srt := filepath.Join(dir, "in.srt")
+	const content = "1\n00:00:00,500 --> 00:00:01,500\nHello embedded\n"
+	if err := os.WriteFile(srt, []byte(content), 0o644); err != nil {
+		t.Fatalf("write srt: %v", err)
+	}
+	mkv := filepath.Join(dir, "movie.mkv")
+	// 1s black video + the SRT muxed as a subtitle track tagged eng.
+	mux := exec.Command("ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=black:s=64x64:d=1",
+		"-i", srt, "-c:v", "mpeg4", "-c:s", "srt", "-metadata:s:s:0", "language=eng", mkv)
+	if out, err := mux.CombinedOutput(); err != nil {
+		t.Skipf("ffmpeg mux unavailable in this environment: %v: %s", err, out)
+	}
+
+	data, err := New().Fetch(context.Background(), mkv, "en")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
-	if string(b) != "data" {
-		t.Fatalf("unexpected body: %s", b)
-	}
-	if gotURL != "/subtitles/movie.mkv/en" {
-		t.Fatalf("unexpected url: %s", gotURL)
+	if !strings.Contains(string(data), "Hello embedded") {
+		t.Fatalf("extracted subtitle missing content: %q", data)
 	}
 }

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -1,5 +1,5 @@
 // file: pkg/video/video.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 // Package video provides video analysis and processing utilities using ffmpeg and ffprobe.
@@ -203,4 +203,65 @@ func GetSubtitleTracks(videoPath string) ([]map[string]string, error) {
 	}
 
 	return tracks, nil
+}
+
+// SubtitleStream describes one embedded subtitle track of a media file.
+type SubtitleStream struct {
+	// Ordinal is the 0-based index among subtitle streams, suitable for
+	// ffmpeg's "0:s:N" stream selector.
+	Ordinal int
+	// Codec is the ffmpeg codec name, e.g. "subrip", "ass", "hdmv_pgs_subtitle".
+	Codec string
+	// Language is the ISO language tag on the stream (may be empty).
+	Language string
+	// Title is the stream title tag (may be empty).
+	Title string
+}
+
+// ImageBased reports whether the subtitle codec is a bitmap/image format
+// (PGS/VobSub/DVD) that cannot be losslessly converted to text.
+func (s SubtitleStream) ImageBased() bool {
+	switch s.Codec {
+	case "hdmv_pgs_subtitle", "pgssub", "dvd_subtitle", "dvdsub", "xsub":
+		return true
+	default:
+		return false
+	}
+}
+
+// SubtitleStreams lists the embedded subtitle tracks of a media file, including
+// their language tag and codec, using ffprobe.
+func SubtitleStreams(mediaPath string) ([]SubtitleStream, error) {
+	cmd := exec.CommandContext(context.Background(), ffprobePath,
+		"-v", "quiet",
+		"-select_streams", "s",
+		"-print_format", "json",
+		"-show_streams",
+		mediaPath)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe subtitle streams: %w", err)
+	}
+	var res struct {
+		Streams []struct {
+			CodecName string `json:"codec_name"`
+			Tags      struct {
+				Language string `json:"language"`
+				Title    string `json:"title"`
+			} `json:"tags"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		return nil, fmt.Errorf("parse ffprobe subtitle streams: %w", err)
+	}
+	streams := make([]SubtitleStream, 0, len(res.Streams))
+	for i, s := range res.Streams {
+		streams = append(streams, SubtitleStream{
+			Ordinal:  i,
+			Codec:    s.CodecName,
+			Language: s.Tags.Language,
+			Title:    s.Tags.Title,
+		})
+	}
+	return streams, nil
 }


### PR DESCRIPTION
## Summary

Turns the `embedded` provider from a stub (it previously hit a fake `api.embedded.com` HTTP endpoint) into a genuinely functional source that extracts subtitle tracks already muxed into the media container — Bazarr's "use embedded subtitles" feature. This is item #4 in `docs/BAZARR_PARITY_STATUS.md`.

## Changes

- **pkg/video**: new `SubtitleStream{Ordinal,Codec,Language,Title}`, `ImageBased()`, and `SubtitleStreams()` (runs `ffprobe -select_streams s -show_streams`).
- **pkg/providers/embedded**: `Fetch()` now probes the container, skips image-based tracks (PGS/VobSub/DVD) that can't become text, language-matches the requested subtitle (ISO 639-1 vs 639-2 tolerant via `x/text/language`), extracts via `subtitles.ExtractTrack`, and returns SRT. Falls back to the sole text track when the language is unconstrained.
- **tests**: replaced the obsolete HTTP-stub test with a `languageMatches` table test plus an ffmpeg-gated mux→extract round-trip test (skips cleanly where ffmpeg is unavailable).

## Testing

- `go build ./...` — clean
- `go test ./pkg/providers/embedded/ ./pkg/video/` — pass (round-trip test genuinely runs; not skipped locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)