### PR TITLE
feat(scoring): score-gated auto-download and score-based upgrades

### DIFF
--- a/changelog.d/feat-scored-download.md
+++ b/changelog.d/feat-scored-download.md
@@ -1,0 +1,23 @@
+### Added
+
+#### Score-gated auto-download and score-based upgrades
+
+The subtitle scanner now uses the quality-scoring engine (`pkg/scoring`) to pick
+which subtitle to download, matching Bazarr's scoring behaviour. When
+`scoring.enabled` is set and the provider supports it (OpenSubtitles today), the
+scanner searches for candidates, scores each against the media, and downloads
+the highest-scoring candidate **that clears `scoring.min_score`** — downloading
+nothing when no candidate is good enough, instead of grabbing the first result.
+Upgrades now compare the new candidate's score against the score persisted for
+the previously downloaded subtitle (`DownloadRecord.MatchScore`) rather than
+merely comparing file sizes. The feature is off by default; existing behaviour
+is unchanged when `scoring.enabled` is false.
+
+### Fixed
+
+#### `fetch-scored` now downloads the selected candidate
+
+The `fetch-scored` command scored candidates but then downloaded the *first*
+search result regardless of the winner, making the scoring decorative. It now
+downloads the specific selected candidate via the provider's new
+`FetchByResult`.

--- a/cmd/fetch_scored.go
+++ b/cmd/fetch_scored.go
@@ -130,10 +130,9 @@ This command evaluates subtitles based on:
 			return fmt.Errorf("failed to find corresponding search result")
 		}
 
-		// Download the selected subtitle using the client's Fetch method
-		// Note: The client's Fetch method will automatically use the first search result
-		// In practice, we would enhance this to download the specific selected subtitle
-		data, err := client.Fetch(ctx, media, lang)
+		// Download the specific selected candidate (not merely the first search
+		// result), so the scoring actually determines what gets written.
+		data, err := client.FetchByResult(ctx, *selectedResult)
 		if err != nil {
 			return fmt.Errorf("download failed: %w", err)
 		}

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,5 +1,5 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
 <!-- last-edited: 2026-07-23 -->
 
@@ -84,10 +84,15 @@ engine is. This is the single biggest parity gap and is tracked separately.
 
 Ordered by value × tractability. Items marked **done** are landing now.
 
-1. **Post-processing pipeline** — UTF-8, chmod, auto-sync, custom script. **done (this PR).**
-2. Score-gated auto-download + score-based upgrade (wire `pkg/scoring` into `ProcessFile`).
-3. Sonarr/Radarr: decode+apply `monitored`, `tags`, `seriesType`; apply path mappings.
-4. Real `embedded` source (ffmpeg extract) preferred before providers.
+1. **Post-processing pipeline** — UTF-8, chmod, auto-sync, custom script. **done.**
+2. **Score-gated auto-download + score-based upgrade** — `pkg/scoring` is wired
+   into `ProcessFile` for the OpenSubtitles provider via an optional
+   `scoredProvider` capability: search → score → select best above
+   `scoring.min_score` → download that specific candidate; upgrades compare the
+   new candidate's score against the persisted `DownloadRecord.MatchScore`.
+   Gated behind `scoring.enabled` (off by default). **done.**
+3. Sonarr/Radarr: decode+apply `monitored`, `tags`, `seriesType`; apply path mappings. **done.**
+4. Real `embedded` source (ffmpeg extract) preferred before providers. **done.**
 5. Profile mass-edit; honor Forced/HI + cutoff-score; single-language filename option.
 6. Infra: outbound proxy; Plex webhook; external-Whisper model/timeout; Apprise notifications.
 7. Blacklist persistence; history retention.

--- a/pkg/providers/opensubtitles/opensubtitles.go
+++ b/pkg/providers/opensubtitles/opensubtitles.go
@@ -1,4 +1,8 @@
 // file: pkg/providers/opensubtitles/opensubtitles.go
+// version: 1.1.0
+// guid: 5af27051-d855-4321-9990-c4a59eaabbd5
+// last-edited: 2026-07-23
+
 package opensubtitles
 
 import (
@@ -368,8 +372,34 @@ func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, err
 	if len(urls) == 0 {
 		return nil, fmt.Errorf("no subtitles found")
 	}
+	return c.download(ctx, urls[0])
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urls[0], nil)
+// downloadURLForResult builds the download URL for a specific search result,
+// mirroring the construction used by Search. It returns "" when the result
+// carries no subtitle identifier.
+func (c *Client) downloadURLForResult(result SearchResult) string {
+	if result.Attributes.SubtitleID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/download?file_id=%s", c.APIURL, result.Attributes.SubtitleID)
+}
+
+// FetchByResult downloads the subtitle for a specific search result rather than
+// the first match. This is what lets a caller score candidates and then
+// download the selected best one.
+func (c *Client) FetchByResult(ctx context.Context, result SearchResult) ([]byte, error) {
+	url := c.downloadURLForResult(result)
+	if url == "" {
+		return nil, fmt.Errorf("search result has no downloadable subtitle id")
+	}
+	return c.download(ctx, url)
+}
+
+// download performs an authenticated GET of a subtitle download URL and returns
+// its bytes.
+func (c *Client) download(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/opensubtitles/opensubtitles_test.go
+++ b/pkg/providers/opensubtitles/opensubtitles_test.go
@@ -92,6 +92,30 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+// TestFetchByResult downloads a specific candidate rather than the first match.
+func TestFetchByResult(t *testing.T) {
+	srv := httptest.NewServer(mockHandler{})
+	defer srv.Close()
+	c := New("")
+	c.APIURL = srv.URL
+	c.HTTPClient = srv.Client()
+
+	var result SearchResult
+	result.Attributes.SubtitleID = "42"
+	data, err := c.FetchByResult(context.Background(), result)
+	if err != nil {
+		t.Fatalf("fetch by result error: %v", err)
+	}
+	if string(data) != "sub data" {
+		t.Fatalf("unexpected data: %s", data)
+	}
+
+	// A result with no subtitle id cannot be downloaded.
+	if _, err := c.FetchByResult(context.Background(), SearchResult{}); err == nil {
+		t.Fatal("expected error for result with no subtitle id")
+	}
+}
+
 // TestNewUsesConfig verifies that viper settings override defaults.
 func TestNewUsesConfig(t *testing.T) {
 	viper.Set("opensubtitles.api_url", "http://api")

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/scanner.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
 package scanner
 
@@ -112,10 +112,32 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 		}
 	}
 	var data []byte
-	if p != nil {
-		data, err = p.Fetch(ctx, path, lang)
-	} else {
-		data, providerName, err = providers.FetchFromAll(ctx, path, lang, "")
+	// matchScore holds the normalized (0-1) quality score when the scored path
+	// produced the subtitle; it stays nil on the plain byte path.
+	var matchScore *float64
+	scoredHandled := false
+	if sp, ok := p.(scoredProvider); ok && scoringEnabled() {
+		res, ferr := fetchBestScored(ctx, sp, path, lang)
+		if ferr != nil {
+			err = ferr
+		} else if res == nil {
+			// No candidate cleared the minimum score: nothing to download.
+			logger.Infof("no subtitle candidate for %s cleared minimum score", path)
+			return nil
+		} else {
+			data = res.data
+			norm := float64(res.total) / 100.0
+			matchScore = &norm
+			scoredHandled = true
+			logger.Infof("selected scored subtitle for %s (score %d, release %q)", path, res.total, res.release)
+		}
+	}
+	if !scoredHandled && err == nil {
+		if p != nil {
+			data, err = p.Fetch(ctx, path, lang)
+		} else {
+			data, providerName, err = providers.FetchFromAll(ctx, path, lang, "")
+		}
 	}
 	if err != nil {
 		logger.Warnf("fetch %s: %v", path, err)
@@ -133,8 +155,16 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 	}
 	var wasUpgrade bool
 	if upgrade {
-		if oldData, err := os.ReadFile(validatedOutputPath); err == nil {
-			if len(data) <= len(oldData) {
+		if oldData, rerr := os.ReadFile(validatedOutputPath); rerr == nil {
+			if matchScore != nil {
+				// Score-based upgrade: only replace the existing subtitle when
+				// the new candidate scores strictly higher than what we already
+				// downloaded for this video/language.
+				if prior := priorMatchScore(store, path, lang); prior != nil && *matchScore <= *prior {
+					logger.Debugf("existing subtitle %s scores >= new candidate (%.2f)", validatedOutputPath, *prior)
+					return nil
+				}
+			} else if len(data) <= len(oldData) {
 				logger.Debugf("existing subtitle %s is higher quality", validatedOutputPath)
 				return nil
 			}
@@ -164,6 +194,13 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 		fileSize = stat.Size()
 	}
 
+	// Report the real score when the scored path produced this subtitle,
+	// otherwise fall back to the neutral default.
+	eventScore := 1.0
+	if matchScore != nil {
+		eventScore = *matchScore
+	}
+
 	// Send appropriate event
 	if wasUpgrade {
 		events.PublishSubtitleUpgraded(ctx, events.SubtitleUpgradedData{
@@ -171,7 +208,7 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 			NewSubtitlePath: validatedOutputPath,
 			Language:        lang,
 			NewProvider:     providerName,
-			NewScore:        1.0, // Default score, could be enhanced
+			NewScore:        eventScore,
 			Timestamp:       time.Now(),
 		})
 	} else {
@@ -180,13 +217,13 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 			SubtitlePath: validatedOutputPath,
 			Language:     lang,
 			Provider:     providerName,
-			Score:        1.0, // Default score, could be enhanced
+			Score:        eventScore,
 			Size:         fileSize,
 			Timestamp:    time.Now(),
 		})
 	}
 	if store != nil {
-		_ = store.InsertDownload(&database.DownloadRecord{File: validatedOutputPath, VideoFile: path, Provider: providerName, Language: lang})
+		_ = store.InsertDownload(&database.DownloadRecord{File: validatedOutputPath, VideoFile: path, Provider: providerName, Language: lang, MatchScore: matchScore})
 	}
 	// Post-processing: chmod, auto-sync, custom script (all opt-in via config).
 	postprocess.AfterDownload(ctx, validatedOutputPath, path, lang)

--- a/pkg/scanner/scored.go
+++ b/pkg/scanner/scored.go
@@ -1,0 +1,122 @@
+// file: pkg/scanner/scored.go
+// version: 1.0.0
+// guid: 9f2c8b41-6d0e-4a7c-b3f5-1e8a0c2d4b6a
+// last-edited: 2026-07-23
+
+package scanner
+
+import (
+	"context"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/providers/opensubtitles"
+	"github.com/jdfalk/subtitle-manager/pkg/scoring"
+)
+
+// scoredProvider is the optional capability a provider implements when it can
+// return candidate results carrying quality metadata and then download a
+// specific candidate. Only the OpenSubtitles client implements it today; the
+// scanner type-asserts to it and falls back to the plain byte path otherwise.
+type scoredProvider interface {
+	SearchWithResults(ctx context.Context, mediaPath, lang string) ([]opensubtitles.SearchResult, error)
+	FetchByResult(ctx context.Context, result opensubtitles.SearchResult) ([]byte, error)
+}
+
+// scoringEnabled reports whether score-gated downloading is turned on. When it
+// is off (the default) the scanner keeps its previous behaviour exactly.
+func scoringEnabled() bool {
+	return viper.GetBool("scoring.enabled")
+}
+
+// scoredResult is a downloaded subtitle together with its computed score.
+type scoredResult struct {
+	data    []byte
+	total   int // 0-100
+	release string
+}
+
+// fetchBestScored searches sp for candidate subtitles, scores them against the
+// media, and downloads the best candidate that clears the profile's minimum
+// score. It returns (nil, nil) when no candidate clears the threshold (a normal
+// "nothing good enough" outcome, not an error) and a non-nil error only on a
+// search or download failure.
+func fetchBestScored(ctx context.Context, sp scoredProvider, mediaPath, lang string) (*scoredResult, error) {
+	results, err := sp.SearchWithResults(ctx, mediaPath, lang)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	profile := scoring.LoadProfileFromConfig()
+	if err := scoring.ValidateProfile(profile); err != nil {
+		profile = scoring.DefaultProfile()
+	}
+
+	subs := make([]scoring.Subtitle, len(results))
+	for i, r := range results {
+		subs[i] = scoring.FromOpenSubtitlesResult(r, "opensubtitles")
+	}
+	media := scoring.FromMediaPath(mediaPath)
+
+	best, score := scoring.SelectBest(subs, media, profile)
+	if best == nil || score == nil {
+		return nil, nil
+	}
+	// SelectBest falls back to the highest-scoring candidate even when it is
+	// below MinScore, so enforce the threshold here: below it, download nothing.
+	if score.Total < profile.MinScore {
+		return nil, nil
+	}
+
+	idx := selectedIndex(subs, best)
+	if idx < 0 {
+		return nil, nil
+	}
+
+	data, err := sp.FetchByResult(ctx, results[idx])
+	if err != nil {
+		return nil, err
+	}
+	return &scoredResult{data: data, total: score.Total, release: best.Release}, nil
+}
+
+// selectedIndex finds the candidate matching the chosen subtitle by its
+// distinguishing metadata. Returns -1 when no match is found.
+func selectedIndex(subs []scoring.Subtitle, best *scoring.Subtitle) int {
+	for i := range subs {
+		if subs[i].Release == best.Release &&
+			subs[i].DownloadCount == best.DownloadCount &&
+			subs[i].Rating == best.Rating {
+			return i
+		}
+	}
+	return -1
+}
+
+// priorMatchScore returns the highest match score previously recorded for the
+// given video/language pair, or nil when none is on file. It is used to decide
+// whether a freshly scored candidate is actually an upgrade.
+func priorMatchScore(store database.SubtitleStore, video, lang string) *float64 {
+	if store == nil {
+		return nil
+	}
+	recs, err := store.ListDownloadsByVideo(video)
+	if err != nil {
+		return nil
+	}
+	var best *float64
+	for i := range recs {
+		if recs[i].Language != lang || recs[i].MatchScore == nil {
+			continue
+		}
+		if best == nil || *recs[i].MatchScore > *best {
+			v := *recs[i].MatchScore
+			best = &v
+		}
+	}
+	return best
+}

--- a/pkg/scanner/scored_test.go
+++ b/pkg/scanner/scored_test.go
@@ -1,0 +1,152 @@
+// file: pkg/scanner/scored_test.go
+// version: 1.0.0
+// guid: c4e91a72-8b3d-4f60-a1c7-5d2e9f0b3a48
+// last-edited: 2026-07-23
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/providers/opensubtitles"
+)
+
+// fakeScored implements both providers.Provider and the scanner's scoredProvider
+// capability so ProcessFile takes the scored path.
+type fakeScored struct {
+	results []opensubtitles.SearchResult
+	byID    map[string][]byte
+}
+
+func (f *fakeScored) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return []byte("plain"), nil
+}
+
+func (f *fakeScored) SearchWithResults(ctx context.Context, mediaPath, lang string) ([]opensubtitles.SearchResult, error) {
+	return f.results, nil
+}
+
+func (f *fakeScored) FetchByResult(ctx context.Context, result opensubtitles.SearchResult) ([]byte, error) {
+	return f.byID[result.Attributes.SubtitleID], nil
+}
+
+func srResult(id, release string, trusted, hd bool, downloads, votes int, rating float64) opensubtitles.SearchResult {
+	var r opensubtitles.SearchResult
+	r.Attributes.SubtitleID = id
+	r.Attributes.Release = release
+	r.Attributes.FromTrusted = trusted
+	r.Attributes.HD = hd
+	r.Attributes.DownloadCount = downloads
+	r.Attributes.Votes = votes
+	r.Attributes.Ratings = rating
+	return r
+}
+
+// newFakeScored builds a provider offering a strong candidate ("good") matching
+// the release and a weak one ("bad").
+func newFakeScored(release string) *fakeScored {
+	good := srResult("good", release, true, true, 5000, 200, 9.0)
+	bad := srResult("bad", "", false, false, 0, 0, 0)
+	return &fakeScored{
+		results: []opensubtitles.SearchResult{bad, good}, // out of order on purpose
+		byID:    map[string][]byte{"good": []byte("good sub"), "bad": []byte("bad sub")},
+	}
+}
+
+// TestProcessFileScoredSelectsBest verifies that when scoring is enabled the
+// highest-scoring candidate is the one downloaded and its score is persisted.
+func TestProcessFileScoredSelectsBest(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("scoring.enabled", true)
+	viper.Set("scoring.min_score", 0)
+	defer viper.Reset()
+
+	base := "Inception.2010.1080p.BluRay.x264-GROUP"
+	vid := filepath.Join(dir, base+".mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	p := newFakeScored(base)
+	if err := ProcessFile(context.Background(), vid, "en", "opensubtitles", p, false, store); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	sub := filepath.Join(dir, base+".en.srt")
+	data, err := os.ReadFile(sub)
+	if err != nil {
+		t.Fatalf("read subtitle: %v", err)
+	}
+	if string(data) != "good sub" {
+		t.Fatalf("expected best candidate downloaded, got %q", data)
+	}
+
+	recs, err := store.ListDownloadsByVideo(vid)
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(recs) != 1 || recs[0].MatchScore == nil || *recs[0].MatchScore <= 0 {
+		t.Fatalf("expected persisted positive match score, got %+v", recs)
+	}
+}
+
+// TestProcessFileScoredGate verifies that when no candidate clears the minimum
+// score, nothing is written and no error is returned.
+func TestProcessFileScoredGate(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("scoring.enabled", true)
+	viper.Set("scoring.min_score", 100) // unreachable
+	defer viper.Reset()
+
+	base := "Inception.2010.1080p.BluRay.x264-GROUP"
+	vid := filepath.Join(dir, base+".mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+
+	p := newFakeScored(base)
+	if err := ProcessFile(context.Background(), vid, "en", "opensubtitles", p, false, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, base+".en.srt")); !os.IsNotExist(err) {
+		t.Fatalf("expected no subtitle written when below min score")
+	}
+}
+
+// TestPriorMatchScore verifies the helper returns the highest recorded score for
+// the video/language pair.
+func TestPriorMatchScore(t *testing.T) {
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	lo, hi := 0.4, 0.8
+	_ = store.InsertDownload(&database.DownloadRecord{File: "a.srt", VideoFile: "v.mkv", Language: "en", MatchScore: &lo})
+	_ = store.InsertDownload(&database.DownloadRecord{File: "b.srt", VideoFile: "v.mkv", Language: "en", MatchScore: &hi})
+	_ = store.InsertDownload(&database.DownloadRecord{File: "c.srt", VideoFile: "v.mkv", Language: "fr", MatchScore: &hi})
+
+	got := priorMatchScore(store, "v.mkv", "en")
+	if got == nil || *got != hi {
+		t.Fatalf("expected prior score %.2f, got %v", hi, got)
+	}
+	if priorMatchScore(store, "v.mkv", "de") != nil {
+		t.Fatal("expected nil for language with no records")
+	}
+}


### PR DESCRIPTION
## Summary

Parity item #2. Wires the existing quality-scoring engine (`pkg/scoring`) into the download path so the scanner **selects** which subtitle to download rather than taking the first search result — matching Bazarr's core scoring behavior. Off by default (`scoring.enabled=false`); existing behavior is byte-for-byte unchanged when disabled.

## The primitive that was missing

Even the existing `fetch-scored` command scored candidates and then downloaded `urls[0]` regardless of the winner (it admitted this in a comment). The provider layer only exposed "download the first match." This PR adds the missing primitive — **download a specific candidate** — and builds the scored flow on top.

## Changes

- **pkg/providers/opensubtitles**: `FetchByResult(result)` + `downloadURLForResult`; `Fetch` refactored to share a `download()` helper.
- **pkg/scanner**: an optional `scoredProvider` capability (consumer-defined interface: `SearchWithResults` + `FetchByResult`). When `scoring.enabled` and the provider satisfies it, `ProcessFile` does search → score → **gate on `scoring.min_score`** (downloads nothing when no candidate clears it) → download the best. Score-based upgrades compare the new candidate's score against the persisted `DownloadRecord.MatchScore` instead of file size.
- **cmd/fetch-scored**: downloads the selected candidate via `FetchByResult` (bug fix).
- No DB migration — `MatchScore` already round-trips through sqlite/postgres/pebble.
- Only the one real provider (OpenSubtitles) is touched; the ~52 stubs are untouched (that's the separate track #8).

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/scanner/ ./pkg/providers/opensubtitles/` — pass
- New tests: scored path selects the best candidate + persists its score; the min-score gate writes nothing; `priorMatchScore` picks the highest recorded score per video/language; `FetchByResult` downloads a specific candidate and rejects an id-less result. Live API isn't required — mocked via the `APIURL` override + an httptest server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)