### PR TITLE
fix(transcriber): use configured external whisper.transcribe_url

### DIFF
--- a/changelog.d/feat-external-whisper-url.md
+++ b/changelog.d/feat-external-whisper-url.md
@@ -1,0 +1,22 @@
+### Fixed
+
+#### Honor `whisper.transcribe_url` for an external self-hosted Whisper server
+
+Pointing `whisper.transcribe_url` at an already-running
+whisper-asr-webservice instance now actually works. Previously the key was
+read by nothing: transcription only used the OpenAI-compatible API or an
+app-managed Docker container, so a configured external server was silently
+ignored and the web "transcribe" flow failed with "OpenAI API key not
+configured and container not available".
+
+`WhisperTranscribe` now prefers `whisper.transcribe_url` when set — speaking
+the webservice's native `/asr` protocol (no API key required) — so every
+transcription entry point (CLI, sync, verify, and the web endpoint) uses the
+external server. When the URL is unset, behaviour is unchanged. An optional
+`whisper.transcribe_timeout` (seconds) overrides the default 30-minute client
+timeout.
+
+`whisper.transcribe_model` is now wired to the OpenAI-compatible transcription
+path via `SetWhisperModel`. Note: the self-hosted `/asr` server's model is
+fixed at its own startup and cannot be selected per request, so this setting
+does not affect the `whisper.transcribe_url` path.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -357,6 +357,12 @@ func initConfig() {
 	if u := viper.GetString("openai_api_url"); u != "" {
 		transcriber.SetBaseURL(u)
 	}
+	// The transcription model applies to the OpenAI-compatible path only; the
+	// self-hosted whisper.transcribe_url (/asr) server's model is fixed at its
+	// own startup and cannot be selected per-request.
+	if m := viper.GetString("whisper.transcribe_model"); m != "" {
+		transcriber.SetWhisperModel(m)
+	}
 	// Initialize Whisper container defaults
 	transcriber.SetDefaultConfig()
 	if u := viper.GetString("anticaptcha.api_url"); u != "" {

--- a/pkg/transcriber/transcriber.go
+++ b/pkg/transcriber/transcriber.go
@@ -1,10 +1,17 @@
+// file: pkg/transcriber/transcriber.go
+// version: 1.1.0
+// guid: b7d3f0a2-1c64-4e58-9a0d-6f2b8c5e1a37
+// last-edited: 2026-07-23
+
 package transcriber
 
 import (
 	"context"
 	"fmt"
+	"time"
 
 	openai "github.com/sashabaranov/go-openai"
+	"github.com/spf13/viper"
 )
 
 // TranscriptionMethod represents the method used for transcription
@@ -60,6 +67,20 @@ func TranscribeWithMethod(ctx context.Context, method TranscriptionMethod, path,
 // The language code may be empty to enable auto detection. The API key is
 // required. It returns the SRT subtitle bytes produced by the service.
 func WhisperTranscribe(path, lang, apiKey string) ([]byte, error) {
+	// Prefer a self-hosted whisper-asr-webservice when its URL is configured.
+	// This speaks the native /asr protocol (no API key required) and takes
+	// precedence over the OpenAI-compatible path, so a user who points
+	// whisper.transcribe_url at their own server gets it used everywhere
+	// transcription happens (CLI, sync, verify, web).
+	if u := viper.GetString("whisper.transcribe_url"); u != "" {
+		ctx := context.Background()
+		if secs := viper.GetInt("whisper.transcribe_timeout"); secs > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(secs)*time.Second)
+			defer cancel()
+		}
+		return ASRTranscribe(ctx, nil, u, path, ASROptions{Language: lang, Output: "srt"})
+	}
 	if apiKey == "" {
 		return nil, fmt.Errorf("api key required")
 	}

--- a/pkg/transcriber/transcriber_test.go
+++ b/pkg/transcriber/transcriber_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestWhisperTranscribe verifies that the request is made to the correct
@@ -35,6 +37,44 @@ func TestWhisperTranscribe(t *testing.T) {
 	}
 	if gotPath != "/v1/audio/transcriptions" {
 		t.Fatalf("unexpected path %s", gotPath)
+	}
+	if len(b) == 0 {
+		t.Fatalf("empty result")
+	}
+}
+
+// TestWhisperTranscribeRoutesToASR verifies that when whisper.transcribe_url is
+// configured, WhisperTranscribe talks to the self-hosted /asr webservice (no API
+// key required) instead of the OpenAI-compatible endpoint.
+func TestWhisperTranscribeRoutesToASR(t *testing.T) {
+	var gotPath, gotLang string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotLang = r.URL.Query().Get("language")
+		fmt.Fprint(w, "1\n00:00:00,000 --> 00:00:01,000\nhola\n")
+	}))
+	defer srv.Close()
+
+	viper.Reset()
+	viper.Set("whisper.transcribe_url", srv.URL)
+	defer viper.Reset()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.wav")
+	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Empty API key on purpose: the ASR path must not require one.
+	b, err := WhisperTranscribe(file, "es", "")
+	if err != nil {
+		t.Fatalf("transcribe: %v", err)
+	}
+	if gotPath != "/asr" {
+		t.Fatalf("expected /asr, got %s", gotPath)
+	}
+	if gotLang != "es" {
+		t.Fatalf("expected language es, got %q", gotLang)
 	}
 	if len(b) == 0 {
 		t.Fatalf("empty result")

--- a/pkg/transcriber/whisper_container.go
+++ b/pkg/transcriber/whisper_container.go
@@ -311,7 +311,9 @@ func (w *WhisperContainer) transcribeWithExternalAPI(ctx context.Context, taskID
 	tasks.Update(taskID, 20) // Falling back to external API
 
 	apiKey := viper.GetString("openai.api_key")
-	if apiKey == "" {
+	// A configured self-hosted whisper.transcribe_url needs no API key; only
+	// require one when there is no external ASR server to fall back to.
+	if apiKey == "" && viper.GetString("whisper.transcribe_url") == "" {
 		return fmt.Errorf("OpenAI API key not configured and container not available")
 	}
 


### PR DESCRIPTION
## Summary

The user's configured `whisper.transcribe_url` (an already-running self-hosted whisper-asr-webservice) was **read by nothing** — transcription only used the OpenAI API or an app-managed Docker container. The web "open a movie → transcribe" flow failed with `OpenAI API key not configured and container not available`, even with the server configured.

## Fix

- **pkg/transcriber**: `WhisperTranscribe` now prefers `whisper.transcribe_url` when set, calling the webservice's native `/asr` protocol (no API key) via the existing `ASRTranscribe`. This one seam reaches every entry point — CLI, sync, verify, and the web endpoint — with no call-site changes. Optional `whisper.transcribe_timeout` (seconds) overrides the 30-minute default.
- **whisper_container**: the external-API fallback no longer requires an OpenAI key when `whisper.transcribe_url` is set, so the web flow actually reaches the server.
- **cmd/root**: `whisper.transcribe_model` is wired to `SetWhisperModel`.

## Precedence & scope notes

- `whisper.transcribe_url` (explicit self-hosted server) takes precedence over the OpenAI-compatible `openai_api_url` path.
- `whisper.transcribe_model` applies **only** to the OpenAI-compatible path. The `/asr` server's model is fixed at its own container startup and can't be selected per request, so the model key is a no-op for the `transcribe_url` path (documented in code + changelog to avoid implying otherwise).
- Entirely off unless `whisper.transcribe_url` is set — existing behavior unchanged.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/transcriber/` — pass
- New `TestWhisperTranscribeRoutesToASR`: with `whisper.transcribe_url` set and an **empty** API key, `WhisperTranscribe` hits `/asr` with the right language and returns SRT. Uses an httptest server — no real network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)