### PR TITLE
feat(naming): single-language subtitle filename option

### DIFF
--- a/changelog.d/feat-single-language-filename.md
+++ b/changelog.d/feat-single-language-filename.md
@@ -1,0 +1,11 @@
+### Added
+
+#### Single-language subtitle filename option
+
+Set `subtitles.single_language: true` to write subtitles without the language
+code in the filename (`movie.srt` instead of `movie.en.srt`), matching Bazarr's
+single-language naming option. This applies to the scanner download paths
+(`ProcessFile` and the profile-based `ProcessFileWithProfile`). The language is
+still validated and recorded in the download history; a single-language layout
+holds one subtitle language per media file. Default is off — existing
+`<base>.<lang>.srt` naming is unchanged.

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/scanner.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
 package scanner
 
@@ -99,8 +99,9 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 		return err
 	}
 
-	// Construct and validate the output path securely
-	validatedOutputPath, err := security.ValidateSubtitleOutputPath(path, lang)
+	// Construct and validate the output path securely. When single-language
+	// naming is enabled the language code is omitted from the filename.
+	validatedOutputPath, err := security.ValidateSubtitleOutputPathWithOptions(path, lang, singleLanguageNaming())
 	if err != nil {
 		logger.Warnf("invalid subtitle output path: %v", err)
 		return err
@@ -302,7 +303,7 @@ func ProcessFileWithProfile(ctx context.Context, path string, db *sql.DB, upgrad
 	}
 
 	// Construct and validate the output path securely using the actual language found
-	out, err := security.ValidateSubtitleOutputPath(sanitizedPath, actualLang)
+	out, err := security.ValidateSubtitleOutputPathWithOptions(sanitizedPath, actualLang, singleLanguageNaming())
 	if err != nil {
 		logger.Warnf("invalid subtitle output path: %v", err)
 		return err

--- a/pkg/scanner/scored.go
+++ b/pkg/scanner/scored.go
@@ -30,6 +30,13 @@ func scoringEnabled() bool {
 	return viper.GetBool("scoring.enabled")
 }
 
+// singleLanguageNaming reports whether subtitles should be written without the
+// language code in the filename ("<base>.srt" rather than "<base>.<lang>.srt"),
+// matching Bazarr's single-language naming option.
+func singleLanguageNaming() bool {
+	return viper.GetBool("subtitles.single_language")
+}
+
 // scoredResult is a downloaded subtitle together with its computed score.
 type scoredResult struct {
 	data    []byte

--- a/pkg/security/path_test.go
+++ b/pkg/security/path_test.go
@@ -1,5 +1,5 @@
 // file: pkg/security/path_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 0f457ffd-07c4-4ea3-b917-e86abb3ed750
 package security
 
@@ -136,6 +136,40 @@ func TestValidateSubtitleOutputPath(t *testing.T) {
 	_, err = ValidateSubtitleOutputPath("/etc/passwd", "en")
 	if err == nil {
 		t.Error("expected error for path traversal in video path")
+	}
+}
+
+func TestValidateSubtitleOutputPathSingleLanguage(t *testing.T) {
+	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	videoPath := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(videoPath, []byte("test"), 0644); err != nil {
+		t.Fatalf("create video file: %v", err)
+	}
+
+	// singleLanguage=true omits the language code from the filename.
+	output, err := ValidateSubtitleOutputPathWithOptions(videoPath, "en", true)
+	if err != nil {
+		t.Fatalf("expected valid output path, got error: %v", err)
+	}
+	if want := filepath.Join(dir, "movie.srt"); output != want {
+		t.Errorf("expected %s, got %s", want, output)
+	}
+
+	// singleLanguage=false keeps the language code.
+	output, err = ValidateSubtitleOutputPathWithOptions(videoPath, "en", false)
+	if err != nil {
+		t.Fatalf("expected valid output path, got error: %v", err)
+	}
+	if want := filepath.Join(dir, "movie.en.srt"); output != want {
+		t.Errorf("expected %s, got %s", want, output)
+	}
+
+	// Language is still validated even when omitted from the filename.
+	if _, err := ValidateSubtitleOutputPathWithOptions(videoPath, "../en", true); err == nil {
+		t.Error("expected error for invalid language even in single-language mode")
 	}
 }
 

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -1,5 +1,5 @@
 // file: pkg/security/security.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: efe90a08-389d-4157-a46e-8a57bfc1181a
 package security
 
@@ -268,8 +268,19 @@ func ValidateProviderName(provider string) error {
 	return nil
 }
 
-// ValidateSubtitleOutputPath validates and constructs a safe subtitle output path
+// ValidateSubtitleOutputPath validates and constructs a safe subtitle output
+// path of the form "<base>.<lang>.srt".
 func ValidateSubtitleOutputPath(videoPath, lang string) (string, error) {
+	return ValidateSubtitleOutputPathWithOptions(videoPath, lang, false)
+}
+
+// ValidateSubtitleOutputPathWithOptions validates and constructs a safe subtitle
+// output path. When singleLanguage is true the language code is omitted from the
+// filename ("<base>.srt" instead of "<base>.<lang>.srt"), matching Bazarr's
+// "single language" naming option; lang is still validated so it can be recorded
+// in the download history. A single-language layout can only hold one subtitle
+// language per media file.
+func ValidateSubtitleOutputPathWithOptions(videoPath, lang string, singleLanguage bool) (string, error) {
 	// Validate inputs
 	sanitizedVideoPath, err := ValidateAndSanitizePath(videoPath)
 	if err != nil {
@@ -290,7 +301,11 @@ func ValidateSubtitleOutputPath(videoPath, lang string) (string, error) {
 		return "", fmt.Errorf("invalid characters in video filename")
 	}
 
-	subtitlePath := filepath.Join(dir, base+"."+lang+".srt")
+	name := base + "." + lang + ".srt"
+	if singleLanguage {
+		name = base + ".srt"
+	}
+	subtitlePath := filepath.Join(dir, name)
 	subtitlePath = filepath.Clean(subtitlePath)
 
 	// Ensure the output path is still within allowed directories


### PR DESCRIPTION
## Summary

Parity item #5 (partial). Adds Bazarr's **single-language naming** option: with `subtitles.single_language: true`, subtitles are written as `movie.srt` instead of `movie.en.srt`.

## Changes

- **pkg/security**: `ValidateSubtitleOutputPathWithOptions(videoPath, lang, singleLanguage)`; the existing `ValidateSubtitleOutputPath` delegates to it with `false`. The language code is still validated (so it's recorded in history) — it's just omitted from the filename.
- **pkg/scanner**: `ProcessFile` and `ProcessFileWithProfile` honor the option via a `singleLanguageNaming()` config helper.

A single-language layout holds one subtitle language per media file (that's the point of the option). Default off — existing `<base>.<lang>.srt` naming is byte-for-byte unchanged.

## Testing

- `go build ./...` — clean
- `go test ./pkg/security/ ./pkg/scanner/` — pass
- New `TestValidateSubtitleOutputPathSingleLanguage`: `true` → `movie.srt`, `false` → `movie.en.srt`, and an invalid language still errors in single-language mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)