### PR TITLE
feat(webhooks): add Plex webhook receiver

### DIFF
--- a/changelog.d/feat-plex-webhook.md
+++ b/changelog.d/feat-plex-webhook.md
@@ -1,0 +1,10 @@
+### Added
+
+#### Plex webhook receiver
+
+New incoming webhook endpoint `POST /api/webhooks/plex` accepts Plex webhooks
+and, on a `library.new` event (new media added to a Plex library), fetches
+subtitles for the newly-added file. Plex posts the event as the `payload` field
+of a multipart/form-data request; a raw JSON body is also accepted. Events other
+than `library.new` are acknowledged and ignored. The subtitle language defaults
+to English and can be set with `webhooks.plex.language`.

--- a/pkg/webhooks/plex.go
+++ b/pkg/webhooks/plex.go
@@ -1,0 +1,113 @@
+// file: pkg/webhooks/plex.go
+// version: 1.0.0
+// guid: d6b1f39c-4e07-4a52-9c8b-2f0a7d54e916
+// last-edited: 2026-07-23
+
+package webhooks
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+)
+
+// plexPayload is the subset of a Plex webhook payload we care about. Plex sends
+// a JSON document (as the "payload" field of a multipart/form-data request)
+// describing library and playback events.
+type plexPayload struct {
+	Event    string `json:"event"`
+	Metadata struct {
+		LibrarySectionType string `json:"librarySectionType"`
+		Title              string `json:"title"`
+		Media              []struct {
+			Part []struct {
+				File string `json:"file"`
+			} `json:"Part"`
+		} `json:"Media"`
+	} `json:"Metadata"`
+}
+
+// firstFile returns the first media part file path in the payload, or "".
+func (p *plexPayload) firstFile() string {
+	for _, m := range p.Metadata.Media {
+		for _, part := range m.Part {
+			if part.File != "" {
+				return part.File
+			}
+		}
+	}
+	return ""
+}
+
+// PlexHandler accepts Plex webhook events and, on "library.new" (new media
+// added to a library), fetches subtitles for the newly-added file. Plex sends
+// the event as the "payload" field of a multipart/form-data POST; a raw JSON
+// body is also accepted for flexibility. Events other than library.new are
+// acknowledged and ignored.
+func PlexHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		logger := logging.GetLogger("plex-webhook")
+
+		raw := plexRawPayload(r)
+		if raw == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var p plexPayload
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			logger.Warnf("failed to parse Plex payload: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Only new library items trigger a subtitle fetch.
+		if p.Event != "library.new" {
+			logger.Debugf("ignoring Plex event: %s", p.Event)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		file := p.firstFile()
+		if file == "" {
+			logger.Warnf("no media file in Plex library.new for %q", p.Metadata.Title)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		lang := viper.GetString("webhooks.plex.language")
+		if lang == "" {
+			lang = "en"
+		}
+
+		handle(w, r, event{Path: file, Lang: lang})
+	})
+}
+
+// plexRawPayload extracts the Plex payload JSON from either a multipart form
+// ("payload" field, how Plex actually posts) or a raw JSON request body.
+func plexRawPayload(r *http.Request) string {
+	ct := r.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, "multipart/form-data") {
+		// 1 MiB is plenty for a Plex payload; it references a file, not content.
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			return ""
+		}
+		return r.FormValue("payload")
+	}
+	// Fall back to a raw JSON body.
+	dec := json.NewDecoder(r.Body)
+	var buf json.RawMessage
+	if err := dec.Decode(&buf); err != nil {
+		return ""
+	}
+	return string(buf)
+}

--- a/pkg/webhooks/plex_test.go
+++ b/pkg/webhooks/plex_test.go
@@ -1,0 +1,79 @@
+// file: pkg/webhooks/plex_test.go
+// version: 1.0.0
+// guid: f2a9c7d1-5b83-4e60-9a14-7c0e2d8b6035
+
+package webhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const plexLibraryNew = `{"event":"library.new","Metadata":{"librarySectionType":"movie","title":"Inception","Media":[{"Part":[{"file":"/media/Inception.mkv"}]}]}}`
+
+func newPlexMultipart(t *testing.T, payload string) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("payload", payload); err != nil {
+		t.Fatalf("write field: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/plex", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+func TestPlexRawPayloadMultipart(t *testing.T) {
+	req := newPlexMultipart(t, plexLibraryNew)
+	if got := plexRawPayload(req); got != plexLibraryNew {
+		t.Fatalf("expected extracted payload, got %q", got)
+	}
+}
+
+func TestPlexPayloadFirstFile(t *testing.T) {
+	req := newPlexMultipart(t, plexLibraryNew)
+	raw := plexRawPayload(req)
+	var p plexPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.Event != "library.new" {
+		t.Fatalf("event = %q", p.Event)
+	}
+	if got := p.firstFile(); got != "/media/Inception.mkv" {
+		t.Fatalf("firstFile = %q", got)
+	}
+}
+
+func TestPlexHandlerIgnoresNonLibraryNew(t *testing.T) {
+	req := newPlexMultipart(t, `{"event":"media.play","Metadata":{"Media":[{"Part":[{"file":"/media/x.mkv"}]}]}}`)
+	w := httptest.NewRecorder()
+	PlexHandler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for ignored event, got %d", w.Code)
+	}
+}
+
+func TestPlexHandlerBadBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/plex", bytes.NewBufferString("not json"))
+	w := httptest.NewRecorder()
+	PlexHandler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad body, got %d", w.Code)
+	}
+}
+
+func TestPlexHandlerMethod(t *testing.T) {
+	w := httptest.NewRecorder()
+	PlexHandler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", w.Code)
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -193,6 +193,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/webhooks/sonarr", webhooks.SonarrHandler())
 	mux.Handle(prefix+"/api/webhooks/radarr", webhooks.RadarrHandler())
 	mux.Handle(prefix+"/api/webhooks/custom", webhooks.CustomHandler())
+	mux.Handle(prefix+"/api/webhooks/plex", webhooks.PlexHandler())
 	// Webhook management endpoints
 	mux.Handle(prefix+"/api/webhooks/config", authMiddleware(db, "basic", webhookConfigHandler()))
 	mux.Handle(prefix+"/api/webhooks/test", authMiddleware(db, "basic", webhookTestHandler()))


### PR DESCRIPTION
## Summary

Parity item #6 (Plex webhook). New incoming endpoint `POST /api/webhooks/plex`: when Plex fires a `library.new` event (new media added), subtitle-manager fetches subtitles for the newly-added file.

## Changes

- **pkg/webhooks**: `PlexHandler` extracts the payload (Plex posts it as the multipart `payload` field; a raw JSON body is also accepted), acts only on `library.new`, pulls the media path from `Metadata.Media[].Part[].file`, and routes it through the existing `handle` → `scanner.ProcessFile` path. Language via `webhooks.plex.language` (default `en`). Other events are acknowledged (204) and ignored.
- **pkg/webserver**: registers the `/api/webhooks/plex` route alongside the Sonarr/Radarr/custom ones.

Reuses the existing simple webhook path, so it sidesteps the separate manager's payload handling.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/webhooks/` — pass
- New tests: multipart payload extraction; `firstFile()`/event parsing; non-`library.new` → 204; bad body → 400; GET → 405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)