### PR TITLE
feat(proxy): configurable outbound HTTP proxy

### DIFF
--- a/changelog.d/feat-outbound-proxy.md
+++ b/changelog.d/feat-outbound-proxy.md
@@ -1,0 +1,10 @@
+### Added
+
+#### Configurable outbound HTTP proxy
+
+Set `proxy_url` (e.g. `http://proxy.local:3128`) to route all outbound HTTP
+traffic — subtitle providers, Sonarr/Radarr, Whisper, notifications — through a
+proxy, matching Bazarr's proxy setting. It is applied to `http.DefaultTransport`
+at startup, so every client that uses the default transport (all of them) picks
+it up. When `proxy_url` is unset, the standard `HTTP_PROXY`/`HTTPS_PROXY`/
+`NO_PROXY` environment variables continue to apply.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	gconfig "github.com/jdfalk/subtitle-manager/pkg/gcommon/config"
 	"github.com/jdfalk/subtitle-manager/pkg/i18n"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/proxy"
 	"github.com/jdfalk/subtitle-manager/pkg/transcriber"
 	"github.com/jdfalk/subtitle-manager/pkg/translator"
 )
@@ -356,6 +357,13 @@ func initConfig() {
 	}
 	if u := viper.GetString("openai_api_url"); u != "" {
 		transcriber.SetBaseURL(u)
+	}
+	// Route all outbound HTTP through a configured proxy when set. Applies to
+	// every client using the default transport (providers, integrations, ...).
+	if p := viper.GetString("proxy_url"); p != "" {
+		if err := proxy.Configure(p); err != nil {
+			logrus.Warnf("invalid proxy_url: %v", err)
+		}
 	}
 	// The transcription model applies to the OpenAI-compatible path only; the
 	// self-hosted whisper.transcribe_url (/asr) server's model is fixed at its

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,49 @@
+// file: pkg/proxy/proxy.go
+// version: 1.0.0
+// guid: 5c9e2a01-7f43-4b68-9d2c-6a1f0e3b8547
+// last-edited: 2026-07-23
+
+// Package proxy configures an outbound HTTP proxy for the process. Setting a
+// proxy routes every HTTP client that uses http.DefaultTransport (which is all
+// of subtitle-manager's provider/integration clients, since they leave
+// Transport nil) through the configured proxy — matching Bazarr's proxy
+// setting.
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ProxyForURL returns the proxy function to install for the given proxy URL.
+// An empty proxyURL yields http.ProxyFromEnvironment (the standard
+// HTTP(S)_PROXY/NO_PROXY behaviour). A malformed URL returns an error.
+func ProxyForURL(proxyURL string) (func(*http.Request) (*url.URL, error), error) {
+	if proxyURL == "" {
+		return http.ProxyFromEnvironment, nil
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy URL %q: %w", proxyURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid proxy URL %q: scheme and host are required", proxyURL)
+	}
+	return http.ProxyURL(u), nil
+}
+
+// Configure installs proxyURL as the proxy on http.DefaultTransport. When
+// proxyURL is empty the environment-variable proxy behaviour is (re)applied.
+// It is a no-op if the default transport has been replaced with a non-standard
+// type.
+func Configure(proxyURL string) error {
+	fn, err := ProxyForURL(proxyURL)
+	if err != nil {
+		return err
+	}
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		t.Proxy = fn
+	}
+	return nil
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,48 @@
+// file: pkg/proxy/proxy_test.go
+// version: 1.0.0
+// guid: 9a1c4e73-2d80-4f56-b3e9-0c7f1a6d5824
+
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestProxyForURL(t *testing.T) {
+	// Empty → environment behaviour (non-nil func), no error.
+	fn, err := ProxyForURL("")
+	if err != nil || fn == nil {
+		t.Fatalf("empty proxy: fn==nil is %v, err=%v", fn == nil, err)
+	}
+
+	// Valid → routes requests to the configured proxy host.
+	fn, err = ProxyForURL("http://proxy.local:3128")
+	if err != nil {
+		t.Fatalf("valid proxy: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/movie", nil)
+	u, err := fn(req)
+	if err != nil || u == nil || u.Host != "proxy.local:3128" {
+		t.Fatalf("expected proxy host proxy.local:3128, got u=%v err=%v", u, err)
+	}
+
+	// Malformed → error.
+	if _, err := ProxyForURL("://nope"); err == nil {
+		t.Fatal("expected error for malformed proxy URL")
+	}
+}
+
+func TestConfigureSetsDefaultTransport(t *testing.T) {
+	orig := http.DefaultTransport.(*http.Transport).Proxy
+	defer func() { http.DefaultTransport.(*http.Transport).Proxy = orig }()
+
+	if err := Configure("http://proxy.local:8080"); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	u, err := http.DefaultTransport.(*http.Transport).Proxy(req)
+	if err != nil || u == nil || u.Host != "proxy.local:8080" {
+		t.Fatalf("default transport proxy not set: u=%v err=%v", u, err)
+	}
+}


### PR DESCRIPTION
## Summary

Parity item #6 (outbound proxy). Set `proxy_url` to route all outbound HTTP (subtitle providers, Sonarr/Radarr, Whisper, notifications) through a proxy — Bazarr's proxy setting.

## Changes

- **pkg/proxy**: `ProxyForURL` builds a proxy function (empty → `http.ProxyFromEnvironment`, malformed → error); `Configure` installs it on `http.DefaultTransport`. Since every client in the codebase leaves `Transport` nil (uses the default), this one setting applies everywhere.
- **cmd/root**: applies `proxy_url` at startup. When unset, standard `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars continue to apply.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/proxy/` — pass
- Tests: `ProxyForURL` returns the env func for empty, the configured host for a valid URL, and errors on malformed; `Configure` sets `http.DefaultTransport`'s proxy (save/restore around the global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)