### PR TITLE
feat(providers): real keyless napiprojekt provider + provider boundary doc

### DIFF
--- a/changelog.d/feat-napiprojekt-provider.md
+++ b/changelog.d/feat-napiprojekt-provider.md
@@ -1,0 +1,14 @@
+### Added
+
+#### Real napiprojekt subtitle provider (keyless)
+
+The `napiprojekt` provider is now a genuine integration instead of a stub. It
+identifies media by napiprojekt's hash (MD5 of the first 10 MiB plus the
+service's fixed digest transform) and downloads the matching subtitle from
+`napiprojekt.pl`'s anonymous `dl.php` endpoint — the same keyless, hash-based
+protocol subliminal and Bazarr use. No account or API key is required. A `NPc`
+response is treated as "no match".
+
+`docs/BAZARR_PARITY_STATUS.md` now documents the provider boundary: which of the
+remaining stubs are keyless (implementable), credential-gated (need operator
+accounts/keys), or site-scraping only.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,5 +1,5 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
 <!-- last-edited: 2026-07-23 -->
 
@@ -13,14 +13,37 @@ wired into the live path.
 
 ## The load-bearing caveat: the provider layer
 
-**~52 of ~55 registered subtitle providers are non-functional stubs** — each
+**~50 of ~55 registered subtitle providers are non-functional stubs** — each
 GETs a fictional `https://api.<name>.com/subtitles/<file>/<lang>` endpoint
-(`pkg/providers/*/*.go`). Only **opensubtitles** is a real integration;
-`generic` and `whisper` are configurable HTTP pass-throughs. Bazarr's provider
-breadth comes from Python's `subliminal`; porting dozens of real scrapers to Go
-is a large, separate effort. **Until that is done, automatic search/download
-works only through opensubtitles**, regardless of how good the surrounding
-engine is. This is the single biggest parity gap and is tracked separately.
+(`pkg/providers/*/*.go`). Real integrations: **opensubtitles** (hash + REST),
+**napiprojekt** (keyless hash protocol), plus **embedded** (ffmpeg track
+extraction) and the configurable **generic** / **whisper** HTTP pass-throughs.
+Bazarr's provider breadth comes from Python's `subliminal`; porting dozens of
+real scrapers to Go is a large, separate effort.
+
+### The provider boundary (what can be done autonomously vs. what needs you)
+
+Porting the remaining stubs splits into three buckets:
+
+- **Keyless / anonymous (implementable & unit-testable now):** hash- or
+  anonymous-search services that need no account. `napiprojekt` is done as the
+  reference implementation. A handful of others are theoretically keyless but
+  rely on **fragile HTML scraping of live sites** (e.g. `podnapisi`,
+  `yifysubtitles`, `subscene`), which cannot be implemented correctly or tested
+  offline without replicating each site's exact markup — high effort, brittle.
+- **Credential-gated (BLOCKED — needs the operator):** the majority require an
+  account, API key, or paid tier the agent cannot obtain — e.g. `addic7ed`,
+  `titlovi`, `legendasnet`, `ktuvit`, `avistaz`/`hdbits`/`karagarga`
+  (private trackers), `betaseries`, `assrt`. These stay stubs until you supply
+  credentials and confirm terms-of-service allow automated access.
+- **Large scraping track:** everything else is site-specific HTML scraping with
+  no stable API; porting them is the bulk of the `subliminal` effort and should
+  be scoped deliberately, provider by provider.
+
+**Net:** automatic search/download works through **opensubtitles** and
+**napiprojekt** today; `embedded` covers muxed tracks. Going materially further
+requires either operator-supplied credentials or a deliberate, funded scraping
+effort — it is not fully achievable autonomously.
 
 ## Matrix
 
@@ -93,7 +116,19 @@ Ordered by value × tractability. Items marked **done** are landing now.
    Gated behind `scoring.enabled` (off by default). **done.**
 3. Sonarr/Radarr: decode+apply `monitored`, `tags`, `seriesType`; apply path mappings. **done.**
 4. Real `embedded` source (ffmpeg extract) preferred before providers. **done.**
-5. Profile mass-edit; honor Forced/HI + cutoff-score; single-language filename option.
-6. Infra: outbound proxy; Plex webhook; external-Whisper model/timeout; Apprise notifications.
-7. Blacklist persistence; history retention.
-8. **(Large, separate track)** replace the ~52 stub providers with real integrations.
+5. Profile options: **single-language filename done**; honor per-language
+   Forced/HI + cutoff-score still open (needs the scored primitive threaded into
+   the profile-fetch path in `pkg/providers`, which currently can't import the
+   scanner-side scorer — a small refactor is required first).
+6. Infra: outbound proxy **done**; Plex webhook **done**; external-Whisper
+   model/URL/timeout **done**; Apprise notifications **done** (plus subtitle
+   events now actually reach all notification channels).
+7. Blacklist persistence; history retention. Still open: `AddToBlacklist` builds
+   a reason/expiry entry then discards it, and expiry is never honored;
+   `MonitoredItem` has no field for it, so real persistence needs a new
+   blacklist table migrated across sqlite/postgres/pebble.
+8. **(Large, separate track)** replace the stub providers with real integrations.
+   `napiprojekt` **done** (keyless hash protocol) as the reference; see the
+   provider-boundary section above for what is keyless vs. credential-gated vs.
+   scraping-only. The bulk is credential-gated or site-scraping and is not
+   fully achievable without operator input.

--- a/pkg/providers/napiprojekt/napiprojekt.go
+++ b/pkg/providers/napiprojekt/napiprojekt.go
@@ -1,19 +1,36 @@
 // file: pkg/providers/napiprojekt/napiprojekt.go
+// version: 2.0.0
+// guid: 4b8e1d70-9a25-4c63-8f01-5d2e7a6c9b34
+// last-edited: 2026-07-23
+
+// Package napiprojekt implements a real, keyless subtitle provider for the
+// Polish napiprojekt.pl service. It identifies a file by a napiprojekt-specific
+// hash (MD5 of the first 10 MiB plus a fixed digest transform) and downloads
+// the matching subtitle — the same anonymous, hash-based protocol subliminal
+// and Bazarr use. No account or API key is required.
 package napiprojekt
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 )
 
-// Client implements the providers.Provider interface for Napiprojekt.
-// It performs a simple HTTP GET to download subtitles.
+// hashChunk is the number of leading bytes of the media file hashed to identify
+// it to napiprojekt (10 MiB, matching the reference implementations).
+const hashChunk = 10 * 1024 * 1024
+
+// Client implements the providers.Provider interface for napiprojekt.pl.
 type Client struct {
-	// APIURL is the base URL of the Napiprojekt API.
+	// APIURL is the base URL of the napiprojekt service (overridable for tests).
 	APIURL string
 	// HTTPClient is used to make requests.
 	HTTPClient *http.Client
@@ -22,17 +39,39 @@ type Client struct {
 // New returns a Client configured with reasonable defaults.
 func New() *Client {
 	return &Client{
-		APIURL:     "https://api.napiprojekt.com",
-		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		APIURL:     "http://napiprojekt.pl",
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
-// Fetch downloads the subtitle for mediaPath in lang.
-// It returns the subtitle bytes or an error.
+// Fetch downloads the subtitle matching mediaPath from napiprojekt. lang selects
+// the napiprojekt language code (defaults to Polish, the service's primary
+// language). It returns the subtitle bytes or an error when no match exists.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	name := filepath.Base(mediaPath)
-	url := fmt.Sprintf("%s/subtitles/%s/%s", c.APIURL, name, lang)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	md5hex, err := fileMD5(mediaPath)
+	if err != nil {
+		return nil, err
+	}
+	sub := subHash(md5hex)
+
+	l := strings.ToUpper(strings.TrimSpace(lang))
+	if l == "" {
+		l = "PL"
+	}
+
+	q := url.Values{
+		"l":       {l},
+		"f":       {md5hex},
+		"t":       {sub},
+		"v":       {"dreambox"},
+		"kolejka": {"false"},
+		"nick":    {""},
+		"pass":    {""},
+		"napios":  {"posix"},
+	}
+	endpoint := strings.TrimRight(c.APIURL, "/") + "/unit_napisy/dl.php?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +81,59 @@ func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+		return nil, fmt.Errorf("napiprojekt returned status %d", resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// napiprojekt signals "no subtitle for this hash" with a short "NPc" body.
+	if len(data) == 0 || strings.HasPrefix(strings.TrimSpace(string(data)), "NPc") {
+		return nil, fmt.Errorf("no napiprojekt subtitle for %s", mediaPath)
+	}
+	return data, nil
+}
+
+// fileMD5 returns the hex MD5 of the first hashChunk bytes of path (or the whole
+// file if it is smaller), which is how napiprojekt identifies media.
+func fileMD5(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := md5.New()
+	if _, err := io.Copy(h, io.LimitReader(f, hashChunk)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// subHash derives napiprojekt's 5-character sub-hash from the media MD5 hex
+// digest, using the service's fixed index/multiplier/addend transform. This is
+// the standard algorithm used by subliminal and Bazarr.
+func subHash(md5hex string) string {
+	idx := []int{0xe, 0x3, 0x6, 0x8, 0x2}
+	mul := []int{2, 2, 5, 4, 3}
+	add := []int{0, 0xd, 0x10, 0xb, 0x5}
+
+	var b strings.Builder
+	for i := 0; i < 5; i++ {
+		// One hex digit selects the offset of a two-digit hex slice.
+		g, err := strconv.ParseInt(string(md5hex[idx[i]]), 16, 0)
+		if err != nil {
+			return ""
+		}
+		t := add[i] + int(g)
+		if t+2 > len(md5hex) {
+			return ""
+		}
+		v, err := strconv.ParseInt(md5hex[t:t+2], 16, 0)
+		if err != nil {
+			return ""
+		}
+		s := strconv.FormatInt(v*int64(mul[i]), 16)
+		b.WriteByte(s[len(s)-1])
+	}
+	return b.String()
 }

--- a/pkg/providers/napiprojekt/napiprojekt_test.go
+++ b/pkg/providers/napiprojekt/napiprojekt_test.go
@@ -1,32 +1,89 @@
+// file: pkg/providers/napiprojekt/napiprojekt_test.go
+// version: 2.0.0
+// guid: 8c3f0a95-1e47-4d82-b6a0-9f2d5c7e1043
+
 package napiprojekt
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-// TestClientFetch verifies that the client downloads subtitles using the expected URL.
-func TestClientFetch(t *testing.T) {
-	var gotURL string
+func writeMedia(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(p, []byte("some media bytes for hashing"), 0o644); err != nil {
+		t.Fatalf("write media: %v", err)
+	}
+	return p
+}
+
+// TestFetchHashProtocol verifies Fetch computes a napiprojekt hash, calls the
+// dl.php endpoint with the f/t parameters, and returns the subtitle body.
+func TestFetchHashProtocol(t *testing.T) {
+	var gotPath, gotF, gotT string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		fmt.Fprint(w, "data")
+		gotPath = r.URL.Path
+		gotF = r.URL.Query().Get("f")
+		gotT = r.URL.Query().Get("t")
+		_, _ = w.Write([]byte("1\n00:00:01,000 --> 00:00:02,000\nCzesc\n"))
 	}))
 	defer srv.Close()
 
 	c := New()
 	c.APIURL = srv.URL
-	b, err := c.Fetch(context.Background(), "/path/movie.mkv", "en")
+	data, err := c.Fetch(context.Background(), writeMedia(t), "pl")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
-	if string(b) != "data" {
-		t.Fatalf("unexpected body: %s", b)
+	if gotPath != "/unit_napisy/dl.php" {
+		t.Fatalf("unexpected path %q", gotPath)
 	}
-	if gotURL != "/subtitles/movie.mkv/en" {
-		t.Fatalf("unexpected url: %s", gotURL)
+	if len(gotF) != 32 {
+		t.Fatalf("expected 32-char md5 hash, got %q", gotF)
+	}
+	if len(gotT) != 5 {
+		t.Fatalf("expected 5-char sub-hash, got %q", gotT)
+	}
+	if string(data) == "" {
+		t.Fatal("expected subtitle body")
+	}
+}
+
+// TestFetchNotFound verifies the "NPc" sentinel is treated as no-match.
+func TestFetchNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("NPc0"))
+	}))
+	defer srv.Close()
+
+	c := New()
+	c.APIURL = srv.URL
+	if _, err := c.Fetch(context.Background(), writeMedia(t), "pl"); err == nil {
+		t.Fatal("expected error for NPc0 not-found sentinel")
+	}
+}
+
+// TestSubHashDeterministic verifies the sub-hash transform is stable, 5 chars,
+// and hex-only for a representative 32-char MD5 digest.
+func TestSubHashDeterministic(t *testing.T) {
+	const md5hex = "0123456789abcdef0123456789abcdef"
+	h1 := subHash(md5hex)
+	h2 := subHash(md5hex)
+	if h1 != h2 {
+		t.Fatalf("sub-hash not deterministic: %q vs %q", h1, h2)
+	}
+	if len(h1) != 5 {
+		t.Fatalf("expected 5-char sub-hash, got %q", h1)
+	}
+	for _, ch := range h1 {
+		if !((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f')) {
+			t.Fatalf("sub-hash has non-hex char: %q", h1)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Parity item #8 (first real increment). Converts the `napiprojekt` stub into a **genuine keyless provider**, and documents the true provider boundary so item #8's status is honest.

## Why napiprojekt

Of the ~50 stub providers, most need accounts/API keys (which an agent can't obtain) or fragile HTML scraping (which can't be implemented correctly or tested offline). **napiprojekt** uses an anonymous, deterministic, hash-based protocol — the one keyless service that can be implemented *correctly* and *unit-tested* without hitting the live site. It's the reference implementation for the pattern.

## Changes

- **pkg/providers/napiprojekt**: identify media by napiprojekt's hash (MD5 of the first 10 MiB + the fixed sub-hash transform used by subliminal/Bazarr); download from `napiprojekt.pl/unit_napisy/dl.php` with the `f`/`t` params; treat an `NPc` body as no-match. No account/key. `APIURL` overridable for tests.
- **docs/BAZARR_PARITY_STATUS.md**: documents the **provider boundary** — keyless (implementable) vs credential-gated (needs operator accounts) vs scraping-only — and updates the plan (items #6 done, #5 partial, #8 first increment). This is the decision artifact: going materially further on providers needs operator-supplied credentials or a deliberate scraping effort.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/providers/napiprojekt/` — pass
- Tests: full hash→dl.php round-trip (asserts 32-char `f` + 5-char `t`); `NPc0` → no-match error; sub-hash is deterministic/5-char/hex. Mock server — no real network.

## Note

napiprojekt is predominantly Polish subtitles — it's a real, working provider but niche. The larger provider gap remains credential-gated/scraping and is called out in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)