### PR TITLE
feat(maintenance): download-history retention

### DIFF
--- a/changelog.d/feat-history-retention.md
+++ b/changelog.d/feat-history-retention.md
@@ -1,0 +1,10 @@
+### Added
+
+#### Download-history retention
+
+Set `history.retention_days` to automatically prune download-history records
+older than the given number of days, matching Bazarr's history retention. A
+background job (interval configurable via `history.prune_frequency`, default
+daily) deletes expired records; it runs only when `history.retention_days` is
+positive, so history is kept forever by default. Works across all database
+backends (sqlite/postgres/pebble) via the existing store interface.

--- a/pkg/maintenance/history_test.go
+++ b/pkg/maintenance/history_test.go
@@ -1,0 +1,55 @@
+// file: pkg/maintenance/history_test.go
+// version: 1.0.0
+// guid: c8e0a3f5-7b41-4d29-9a06-2f1d6e5b8074
+
+package maintenance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+)
+
+// TestPruneDownloadHistory verifies records older than the retention window are
+// deleted while newer ones are kept, and that a non-positive retention is a
+// no-op.
+func TestPruneDownloadHistory(t *testing.T) {
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	old := &database.DownloadRecord{File: "old.srt", VideoFile: "v.mkv", Language: "en", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	recent := &database.DownloadRecord{File: "new.srt", VideoFile: "v.mkv", Language: "en", CreatedAt: time.Now()}
+	if err := store.InsertDownload(old); err != nil {
+		t.Fatalf("insert old: %v", err)
+	}
+	if err := store.InsertDownload(recent); err != nil {
+		t.Fatalf("insert recent: %v", err)
+	}
+
+	// retention <= 0 is a no-op.
+	if n, err := PruneDownloadHistory(context.Background(), store, 0); err != nil || n != 0 {
+		t.Fatalf("no-op prune: n=%d err=%v", n, err)
+	}
+
+	// Prune everything older than 24h → removes only the old record.
+	n, err := PruneDownloadHistory(context.Background(), store, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+
+	remaining, err := store.ListDownloads()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].File != "new.srt" {
+		t.Fatalf("expected only new.srt to remain, got %+v", remaining)
+	}
+}

--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -1,3 +1,8 @@
+// file: pkg/maintenance/maintenance.go
+// version: 1.1.0
+// guid: a4cd70e3-111a-4925-9f52-160d4fc3b701
+// last-edited: 2026-07-23
+
 package maintenance
 
 import (
@@ -62,6 +67,49 @@ func StartDatabaseCleanup(ctx context.Context, db *sql.DB, frequency string) {
 	interval := frequencyToDuration(frequency)
 	go scheduler.Run(ctx, interval, func(c context.Context) error {
 		return CleanupDatabase(c, db)
+	})
+}
+
+// PruneDownloadHistory deletes download-history records older than retention.
+// A non-positive retention keeps everything. It returns the number of records
+// pruned. This implements Bazarr's history-retention behaviour.
+func PruneDownloadHistory(ctx context.Context, store database.SubtitleStore, retention time.Duration) (int, error) {
+	if store == nil || retention <= 0 {
+		return 0, nil
+	}
+	records, err := store.ListDownloads()
+	if err != nil {
+		return 0, err
+	}
+	cutoff := time.Now().Add(-retention)
+	pruned := 0
+	for _, r := range records {
+		select {
+		case <-ctx.Done():
+			return pruned, ctx.Err()
+		default:
+		}
+		if r.CreatedAt.Before(cutoff) {
+			if err := store.DeleteDownload(r.File); err != nil {
+				return pruned, err
+			}
+			pruned++
+		}
+	}
+	return pruned, nil
+}
+
+// StartHistoryPruning schedules PruneDownloadHistory to run periodically. It is
+// a no-op when retentionDays is not positive (history kept forever).
+func StartHistoryPruning(ctx context.Context, store database.SubtitleStore, retentionDays int, frequency string) {
+	if retentionDays <= 0 {
+		return
+	}
+	retention := time.Duration(retentionDays) * 24 * time.Hour
+	interval := frequencyToDuration(frequency)
+	go scheduler.Run(ctx, interval, func(c context.Context) error {
+		_, err := PruneDownloadHistory(c, store, retention)
+		return err
 	})
 }
 

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -363,6 +363,11 @@ func StartServer(addr string) error {
 
 	// Start Sonarr/Radarr sync tasks when configured
 	if store, err := database.OpenStoreWithConfig(); err == nil {
+		// Prune download history older than the configured retention (Bazarr's
+		// history-retention). No-op when history.retention_days is unset/<=0.
+		maintenance.StartHistoryPruning(context.Background(), store,
+			viper.GetInt("history.retention_days"),
+			viper.GetString("history.prune_frequency"))
 		if viper.GetBool("integrations.radarr.enabled") {
 			host := viper.GetString("integrations.radarr.host")
 			port := viper.GetString("integrations.radarr.port")


### PR DESCRIPTION
## Summary

Parity item #7 (history-retention half). Set `history.retention_days` to auto-prune download-history records older than N days — Bazarr's history retention.

## Changes

- **pkg/maintenance**: `PruneDownloadHistory` deletes records older than the retention window (non-positive = keep forever, the default); `StartHistoryPruning` schedules it via the existing `scheduler.Run`. Uses only the `SubtitleStore` interface (`ListDownloads`/`DeleteDownload`), so it works across **sqlite/postgres/pebble** with no migration.
- **pkg/webserver**: starts the pruning job in the existing store block when `history.retention_days > 0` (interval via `history.prune_frequency`, default daily).

## Note on the other half of #7 (blacklist persistence)

Blacklist persistence is deliberately **not** in this PR. `AddToBlacklist` currently builds a reason/expiry entry then discards it, and `MonitoredItem` has no field for it — real persistence requires a **new blacklist table migrated across all three backends (incl. pebble)**, which is a larger, separate change I'd rather scope explicitly than bundle here. Tracked in `docs/BAZARR_PARITY_STATUS.md`.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/maintenance/` — pass
- New `TestPruneDownloadHistory` (pebble-backed, the user's backend): a 48h-old record is pruned at 24h retention while a fresh one is kept; retention ≤ 0 is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)