### PR TITLE
feat(monitoring): persistent subtitle blacklist with reason + expiry

### DIFF
--- a/changelog.d/feat-blacklist-persistence.md
+++ b/changelog.d/feat-blacklist-persistence.md
@@ -1,0 +1,17 @@
+### Added
+
+#### Persistent subtitle blacklist with expiry
+
+Blacklist entries now persist across restarts, with their reason and optional
+expiry, instead of only flipping a monitored item's status (the old
+`AddToBlacklist` built a rich entry then discarded it, and expiry was never
+honored). A new `BlacklistStore` optional-capability interface is implemented
+across all three database backends (sqlite/postgres/pebble). `IsBlacklisted`
+now honors expiry (expired entries no longer count and are language-scoped),
+`RemoveFromBlacklist` clears persisted entries, and `CleanupExpiredBlacklist`
+actually removes expired entries. Stores that don't implement the capability
+fall back to the previous item-status behaviour.
+
+The Pebble implementation uses a bounded prefix scan (adopted from
+audiobook-organizer's Pebble store) so listing the blacklist touches only the
+blacklist rows rather than the whole keyspace.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,5 +1,5 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
 <!-- last-edited: 2026-07-23 -->
 
@@ -123,10 +123,11 @@ Ordered by value × tractability. Items marked **done** are landing now.
 6. Infra: outbound proxy **done**; Plex webhook **done**; external-Whisper
    model/URL/timeout **done**; Apprise notifications **done** (plus subtitle
    events now actually reach all notification channels).
-7. Blacklist persistence; history retention. Still open: `AddToBlacklist` builds
-   a reason/expiry entry then discards it, and expiry is never honored;
-   `MonitoredItem` has no field for it, so real persistence needs a new
-   blacklist table migrated across sqlite/postgres/pebble.
+7. Blacklist persistence + history retention — **done**. History retention
+   (`history.retention_days`) prunes old download records. Blacklist entries
+   (reason + expiry) now persist via a new `BlacklistStore` optional-capability
+   interface implemented across sqlite/postgres/pebble; `IsBlacklisted` honors
+   expiry and `CleanupExpiredBlacklist` actually removes expired entries.
 8. **(Large, separate track)** replace the stub providers with real integrations.
    `napiprojekt` **done** (keyless hash protocol) as the reference; see the
    provider-boundary section above for what is keyless vs. credential-gated vs.

--- a/pkg/database/blacklist.go
+++ b/pkg/database/blacklist.go
@@ -1,0 +1,286 @@
+// file: pkg/database/blacklist.go
+// version: 1.0.0
+// guid: 6f3a1c94-8b02-4e57-9d16-2a7c0e5b4831
+// last-edited: 2026-07-23
+
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/google/uuid"
+)
+
+// BlacklistItem is a persisted subtitle blacklist entry. An entry prevents
+// re-downloading subtitles for a monitored item (optionally scoped to one
+// language) until it is removed or, when ExpiresAt is set, until it expires.
+type BlacklistItem struct {
+	ID        string     `json:"id"`
+	ItemID    string     `json:"item_id"`  // the MonitoredItem this applies to
+	Path      string     `json:"path"`     // media path (informational)
+	Language  string     `json:"language"` // "" means all languages
+	Reason    string     `json:"reason"`
+	Details   string     `json:"details"`
+	CreatedAt time.Time  `json:"created_at"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// Expired reports whether the entry has an expiry that has passed as of now.
+func (b *BlacklistItem) Expired(now time.Time) bool {
+	return b.ExpiresAt != nil && now.After(*b.ExpiresAt)
+}
+
+// BlacklistStore is an optional capability implemented by stores that can
+// persist a subtitle blacklist with reasons and expiry. It is intentionally
+// separate from SubtitleStore so the large mocked interface is untouched;
+// callers type-assert to it and fall back gracefully when it is absent.
+type BlacklistStore interface {
+	// InsertBlacklist stores a blacklist entry, assigning an ID when unset.
+	InsertBlacklist(item *BlacklistItem) error
+	// ListBlacklist returns all blacklist entries.
+	ListBlacklist() ([]BlacklistItem, error)
+	// DeleteBlacklist removes an entry by ID.
+	DeleteBlacklist(id string) error
+	// DeleteBlacklistByItem removes all entries for a monitored item, returning
+	// the number removed.
+	DeleteBlacklistByItem(itemID string) (int, error)
+	// DeleteExpiredBlacklist removes entries whose expiry has passed as of now,
+	// returning the number removed.
+	DeleteExpiredBlacklist(now time.Time) (int, error)
+}
+
+// Compile-time assertions that every concrete store implements BlacklistStore.
+var (
+	_ BlacklistStore = (*SQLStore)(nil)
+	_ BlacklistStore = (*PostgresStore)(nil)
+	_ BlacklistStore = (*PebbleStore)(nil)
+)
+
+func ensureBlacklistID(item *BlacklistItem) {
+	if item.ID == "" {
+		item.ID = uuid.NewString()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now()
+	}
+}
+
+// --- SQLStore (sqlite) ---
+
+// InsertBlacklist stores a blacklist entry in the SQLite-backed store.
+func (s *SQLStore) InsertBlacklist(item *BlacklistItem) error {
+	ensureBlacklistID(item)
+	var exp interface{}
+	if item.ExpiresAt != nil {
+		exp = *item.ExpiresAt
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO blacklist (id, item_id, path, language, reason, details, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		item.ID, item.ItemID, item.Path, item.Language, item.Reason, item.Details, item.CreatedAt, exp)
+	return err
+}
+
+// ListBlacklist returns all blacklist entries from the SQLite store.
+func (s *SQLStore) ListBlacklist() ([]BlacklistItem, error) {
+	rows, err := s.db.Query(`SELECT id, item_id, path, language, reason, details, created_at, expires_at FROM blacklist`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanBlacklistRows(rows)
+}
+
+// DeleteBlacklist removes a blacklist entry by ID from the SQLite store.
+func (s *SQLStore) DeleteBlacklist(id string) error {
+	_, err := s.db.Exec(`DELETE FROM blacklist WHERE id = ?`, id)
+	return err
+}
+
+// DeleteBlacklistByItem removes all entries for itemID from the SQLite store.
+func (s *SQLStore) DeleteBlacklistByItem(itemID string) (int, error) {
+	res, err := s.db.Exec(`DELETE FROM blacklist WHERE item_id = ?`, itemID)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// DeleteExpiredBlacklist removes expired entries from the SQLite store.
+func (s *SQLStore) DeleteExpiredBlacklist(now time.Time) (int, error) {
+	res, err := s.db.Exec(`DELETE FROM blacklist WHERE expires_at IS NOT NULL AND expires_at < ?`, now)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// --- PostgresStore ---
+
+// InsertBlacklist stores a blacklist entry in the Postgres-backed store.
+func (p *PostgresStore) InsertBlacklist(item *BlacklistItem) error {
+	ensureBlacklistID(item)
+	var exp interface{}
+	if item.ExpiresAt != nil {
+		exp = *item.ExpiresAt
+	}
+	_, err := p.db.Exec(
+		`INSERT INTO blacklist (id, item_id, path, language, reason, details, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		item.ID, item.ItemID, item.Path, item.Language, item.Reason, item.Details, item.CreatedAt, exp)
+	return err
+}
+
+// ListBlacklist returns all blacklist entries from the Postgres store.
+func (p *PostgresStore) ListBlacklist() ([]BlacklistItem, error) {
+	rows, err := p.db.Query(`SELECT id, item_id, path, language, reason, details, created_at, expires_at FROM blacklist`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanBlacklistRows(rows)
+}
+
+// DeleteBlacklist removes a blacklist entry by ID from the Postgres store.
+func (p *PostgresStore) DeleteBlacklist(id string) error {
+	_, err := p.db.Exec(`DELETE FROM blacklist WHERE id = $1`, id)
+	return err
+}
+
+// DeleteBlacklistByItem removes all entries for itemID from the Postgres store.
+func (p *PostgresStore) DeleteBlacklistByItem(itemID string) (int, error) {
+	res, err := p.db.Exec(`DELETE FROM blacklist WHERE item_id = $1`, itemID)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// DeleteExpiredBlacklist removes expired entries from the Postgres store.
+func (p *PostgresStore) DeleteExpiredBlacklist(now time.Time) (int, error) {
+	res, err := p.db.Exec(`DELETE FROM blacklist WHERE expires_at IS NOT NULL AND expires_at < $1`, now)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// scanBlacklistRows converts SQL rows into BlacklistItem values, shared by the
+// SQLite and Postgres stores.
+func scanBlacklistRows(rows *sql.Rows) ([]BlacklistItem, error) {
+	var items []BlacklistItem
+	for rows.Next() {
+		var it BlacklistItem
+		var exp sql.NullTime
+		if err := rows.Scan(&it.ID, &it.ItemID, &it.Path, &it.Language, &it.Reason, &it.Details, &it.CreatedAt, &exp); err != nil {
+			return nil, err
+		}
+		if exp.Valid {
+			t := exp.Time
+			it.ExpiresAt = &t
+		}
+		items = append(items, it)
+	}
+	return items, rows.Err()
+}
+
+// --- PebbleStore ---
+
+const blacklistPrefix = "blacklist:"
+
+// prefixUpperBound returns the exclusive upper-bound key for iterating every
+// key sharing prefix, so a Pebble range scan touches only the matching rows
+// instead of the whole keyspace. (Pattern adopted from audiobook-organizer's
+// pebble store.)
+func prefixUpperBound(prefix string) []byte {
+	b := []byte(prefix)
+	upper := make([]byte, len(b))
+	copy(upper, b)
+	upper[len(upper)-1]++
+	return upper
+}
+
+// InsertBlacklist stores a blacklist entry in the Pebble-backed store.
+func (p *PebbleStore) InsertBlacklist(item *BlacklistItem) error {
+	ensureBlacklistID(item)
+	b, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	return p.db.Set([]byte(blacklistPrefix+item.ID), b, pebble.Sync)
+}
+
+// ListBlacklist returns all blacklist entries from the Pebble store using a
+// bounded prefix scan.
+func (p *PebbleStore) ListBlacklist() ([]BlacklistItem, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(blacklistPrefix),
+		UpperBound: prefixUpperBound(blacklistPrefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	var items []BlacklistItem
+	for iter.First(); iter.Valid(); iter.Next() {
+		var it BlacklistItem
+		if err := json.Unmarshal(iter.Value(), &it); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.After(items[j].CreatedAt) })
+	return items, nil
+}
+
+// DeleteBlacklist removes a blacklist entry by ID from the Pebble store.
+func (p *PebbleStore) DeleteBlacklist(id string) error {
+	return p.db.Delete([]byte(blacklistPrefix+id), pebble.Sync)
+}
+
+// DeleteBlacklistByItem removes all entries for itemID from the Pebble store.
+func (p *PebbleStore) DeleteBlacklistByItem(itemID string) (int, error) {
+	items, err := p.ListBlacklist()
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, it := range items {
+		if it.ItemID == itemID {
+			if err := p.DeleteBlacklist(it.ID); err != nil {
+				return n, err
+			}
+			n++
+		}
+	}
+	return n, nil
+}
+
+// DeleteExpiredBlacklist removes expired entries from the Pebble store.
+func (p *PebbleStore) DeleteExpiredBlacklist(now time.Time) (int, error) {
+	items, err := p.ListBlacklist()
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for i := range items {
+		if items[i].Expired(now) {
+			if err := p.DeleteBlacklist(items[i].ID); err != nil {
+				return n, err
+			}
+			n++
+		}
+	}
+	return n, nil
+}

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -1,3 +1,8 @@
+// file: pkg/database/postgres.go
+// version: 1.1.0
+// guid: 29e61686-4676-4b4a-b4be-b0cb294239a3
+// last-edited: 2026-07-23
+
 package database
 
 import (
@@ -50,6 +55,16 @@ func initPostgresSchema(db *sql.DB) error {
 			provider TEXT NOT NULL,
 			language TEXT NOT NULL,
 			created_at TIMESTAMP NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS blacklist (
+			id TEXT PRIMARY KEY,
+			item_id TEXT,
+			path TEXT,
+			language TEXT,
+			reason TEXT,
+			details TEXT,
+			created_at TIMESTAMP NOT NULL,
+			expires_at TIMESTAMP
 		)`,
 		`CREATE TABLE IF NOT EXISTS search_history (
 			id SERIAL PRIMARY KEY,

--- a/pkg/database/sqlite_enabled.go
+++ b/pkg/database/sqlite_enabled.go
@@ -2,7 +2,7 @@
 // +build sqlite
 
 // file: pkg/database/sqlite_enabled.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e6f5a4b-3c2d-8e7f-1a0b-4c3d2e1f0a9b
 
 package database
@@ -67,6 +67,19 @@ func initSchema(db *sql.DB) error {
 		error_message TEXT,
 		response_time_ms INTEGER,
 		created_at TIMESTAMP NOT NULL
+	)`); err != nil {
+		return err
+	}
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS blacklist (
+		id TEXT PRIMARY KEY,
+		item_id TEXT,
+		path TEXT,
+		language TEXT,
+		reason TEXT,
+		details TEXT,
+		created_at TIMESTAMP NOT NULL,
+		expires_at TIMESTAMP
 	)`); err != nil {
 		return err
 	}

--- a/pkg/monitoring/blacklist.go
+++ b/pkg/monitoring/blacklist.go
@@ -1,11 +1,10 @@
 // file: pkg/monitoring/blacklist.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12345678-1234-1234-1234-123456789017
 
 package monitoring
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/jdfalk/subtitle-manager/pkg/database"
@@ -63,9 +62,21 @@ func (m *EpisodeMonitor) AddToBlacklist(itemID, path, language string, reason Bl
 		ExpiresAt:     expiresAt,
 	}
 
-	// Store blacklist entry as a tag association
-	if _, err := json.Marshal(entry); err != nil {
-		return err
+	// Persist the full entry (reason + expiry) when the store supports it, so
+	// the blacklist — including expiry — survives restarts. Otherwise the
+	// entry's metadata is not durable and only the item status is kept.
+	if bs, ok := m.store.(database.BlacklistStore); ok {
+		if err := bs.InsertBlacklist(&database.BlacklistItem{
+			ItemID:    entry.ItemID,
+			Path:      entry.Path,
+			Language:  entry.Language,
+			Reason:    string(entry.Reason),
+			Details:   entry.Details,
+			CreatedAt: entry.BlacklistedAt,
+			ExpiresAt: entry.ExpiresAt,
+		}); err != nil {
+			return err
+		}
 	}
 
 	// Update the monitored item status to blacklisted
@@ -94,6 +105,13 @@ func (m *EpisodeMonitor) RemoveFromBlacklist(itemID string) error {
 		return err
 	}
 
+	// Drop any persisted blacklist entries for this item.
+	if bs, ok := m.store.(database.BlacklistStore); ok {
+		if _, err := bs.DeleteBlacklistByItem(itemID); err != nil {
+			return err
+		}
+	}
+
 	for _, item := range items {
 		if item.ID == itemID && item.Status == "blacklisted" {
 			item.Status = "pending"
@@ -110,8 +128,28 @@ func (m *EpisodeMonitor) RemoveFromBlacklist(itemID string) error {
 	return nil
 }
 
-// IsBlacklisted checks if an item is currently blacklisted.
+// IsBlacklisted checks if an item is currently blacklisted. When the store
+// persists blacklist entries, a matching non-expired entry (for the same
+// language, or an all-language entry) counts; expired entries are ignored.
+// Otherwise it falls back to the monitored item's status.
 func (m *EpisodeMonitor) IsBlacklisted(itemID, language string) bool {
+	if bs, ok := m.store.(database.BlacklistStore); ok {
+		entries, err := bs.ListBlacklist()
+		if err == nil {
+			now := time.Now()
+			for i := range entries {
+				e := &entries[i]
+				if e.ItemID != itemID || e.Expired(now) {
+					continue
+				}
+				if e.Language == "" || language == "" || e.Language == language {
+					return true
+				}
+			}
+			return false
+		}
+	}
+
 	items, err := m.store.ListMonitoredItems()
 	if err != nil {
 		return false
@@ -126,11 +164,21 @@ func (m *EpisodeMonitor) IsBlacklisted(itemID, language string) bool {
 	return false
 }
 
-// CleanupExpiredBlacklist removes expired blacklist entries.
+// CleanupExpiredBlacklist removes expired blacklist entries from persistent
+// storage. It is a no-op when the store does not persist the blacklist.
 func (m *EpisodeMonitor) CleanupExpiredBlacklist() error {
-	// This would be implemented when we have proper blacklist storage
-	// For now, blacklisted items remain blacklisted until manually removed
-	m.logger.Debug("Cleanup expired blacklist entries (not implemented)")
+	bs, ok := m.store.(database.BlacklistStore)
+	if !ok {
+		m.logger.Debug("blacklist store does not persist entries; nothing to expire")
+		return nil
+	}
+	n, err := bs.DeleteExpiredBlacklist(time.Now())
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		m.logger.Infof("removed %d expired blacklist entries", n)
+	}
 	return nil
 }
 

--- a/pkg/monitoring/blacklist_persist_test.go
+++ b/pkg/monitoring/blacklist_persist_test.go
@@ -1,0 +1,77 @@
+// file: pkg/monitoring/blacklist_persist_test.go
+// version: 1.0.0
+// guid: 2d7b9e04-6a13-4c58-8f21-0e5c3a9b7146
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+)
+
+func newPersistMonitor(t *testing.T) (*EpisodeMonitor, database.SubtitleStore) {
+	t.Helper()
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	return &EpisodeMonitor{store: store, logger: logging.GetLogger("test")}, store
+}
+
+// TestBlacklistPersistenceRoundTrip verifies entries persist, are honored by
+// IsBlacklisted with language scoping, and are removed on request.
+func TestBlacklistPersistenceRoundTrip(t *testing.T) {
+	m, store := newPersistMonitor(t)
+	defer store.Close()
+
+	dur := time.Hour
+	if err := m.AddToBlacklist("item1", "/media/a.mkv", "en", ReasonManualBlacklist, "manual", &dur); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if !m.IsBlacklisted("item1", "en") {
+		t.Fatal("expected item1/en blacklisted")
+	}
+	if m.IsBlacklisted("item2", "en") {
+		t.Fatal("item2 should not be blacklisted")
+	}
+	if m.IsBlacklisted("item1", "fr") {
+		t.Fatal("language-scoped entry should not match a different language")
+	}
+
+	if err := m.RemoveFromBlacklist("item1"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if m.IsBlacklisted("item1", "en") {
+		t.Fatal("expected item1 removed from blacklist")
+	}
+	entries, _ := store.(database.BlacklistStore).ListBlacklist()
+	if len(entries) != 0 {
+		t.Fatalf("expected no persisted entries after removal, got %d", len(entries))
+	}
+}
+
+// TestBlacklistExpiry verifies expired entries are ignored and cleaned up.
+func TestBlacklistExpiry(t *testing.T) {
+	m, store := newPersistMonitor(t)
+	defer store.Close()
+
+	past := -time.Hour // expiry already in the past
+	if err := m.AddToBlacklist("item1", "/media/a.mkv", "", ReasonMaxRetriesExceeded, "retries", &past); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if m.IsBlacklisted("item1", "en") {
+		t.Fatal("expired entry should not count as blacklisted")
+	}
+	if err := m.CleanupExpiredBlacklist(); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	entries, _ := store.(database.BlacklistStore).ListBlacklist()
+	if len(entries) != 0 {
+		t.Fatalf("expected expired entries cleaned, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

Parity item #7 (blacklist-persistence half; history-retention already merged in #2191). Blacklist entries now **persist across restarts** with their reason and optional expiry, instead of only flipping a monitored item's status. Previously `AddToBlacklist` built a rich `BlacklistEntry` and then `json.Marshal`ed + discarded it; expiry was computed but never honored; `CleanupExpiredBlacklist` was a no-op stub.

## Design

Uses the same **optional-capability pattern** as the scoring work, so the large mocked `SubtitleStore` interface is untouched:

- **pkg/database**: new `BlacklistStore` interface (`InsertBlacklist`/`ListBlacklist`/`DeleteBlacklist`/`DeleteBlacklistByItem`/`DeleteExpiredBlacklist`), implemented on **SQLStore, PostgresStore, and PebbleStore** (compile-time asserted). New `blacklist` table for sqlite/postgres; JSON rows for pebble.
- **pkg/monitoring**: `AddToBlacklist` persists the entry when the store supports it; `IsBlacklisted` honors expiry + language scope; `RemoveFromBlacklist` deletes persisted entries; `CleanupExpiredBlacklist` actually removes expired ones. Stores without the capability (e.g. the test mock) fall back to the previous item-status behaviour — existing tests still pass.

## Borrowed from audiobook-organizer

Its Pebble store uses bounded prefix iteration (`IterOptions{LowerBound, UpperBound}`) instead of scanning the whole keyspace and filtering in Go. I adopted that `prefixUpperBound` idiom for `ListBlacklist`, so it touches only blacklist rows.

## Testing

- `go build ./...` (default + `-tags sqlite`) — clean; `go vet` — clean
- `go test ./pkg/database/ ./pkg/monitoring/` — pass (2 pre-existing `-tags sqlite` failures — `TestLanguageProfileSQLiteIntegration`, `TestSQLiteAvailability` — reproduce on clean `main` and are unrelated)
- New tests: persist→IsBlacklisted (with language scoping)→remove round-trip; expired entries ignored + cleaned up. Pebble-backed (the user's backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)