### PR TITLE
feat(scanner): Whisper fallback when no provider has a subtitle

### DIFF
--- a/changelog.d/feat-whisper-fallback.md
+++ b/changelog.d/feat-whisper-fallback.md
@@ -1,0 +1,10 @@
+### Added
+
+#### Whisper fallback when no subtitle provider has a match
+
+When subtitle providers return nothing for a file, subtitle-manager can now
+transcribe the media with Whisper and use that as the subtitle, matching
+Bazarr's "Whisper fallback". Enable with `whisper.fallback_enabled`; it uses the
+self-hosted `whisper.transcribe_url` (native `/asr`, no key) when configured,
+otherwise the OpenAI-compatible API with `openai_api_key`. Disabled by default —
+a provider failure is returned unchanged when the fallback is off.

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/scanner.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
 package scanner
 
@@ -141,18 +141,27 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 		}
 	}
 	if err != nil {
-		logger.Warnf("fetch %s: %v", path, err)
+		// Whisper fallback: transcribe the media when no provider had a subtitle.
+		if fbData, ok := whisperFallback(ctx, path, lang); ok {
+			logger.Infof("whisper fallback produced a subtitle for %s", path)
+			data = fbData
+			providerName = "whisper"
+			matchScore = nil
+			err = nil
+		} else {
+			logger.Warnf("fetch %s: %v", path, err)
 
-		// Send event for subtitle fetch failure
-		events.PublishSubtitleFailed(ctx, events.SubtitleFailedData{
-			FilePath:  path,
-			Language:  lang,
-			Provider:  providerName,
-			Error:     err.Error(),
-			Timestamp: time.Now(),
-		})
+			// Send event for subtitle fetch failure
+			events.PublishSubtitleFailed(ctx, events.SubtitleFailedData{
+				FilePath:  path,
+				Language:  lang,
+				Provider:  providerName,
+				Error:     err.Error(),
+				Timestamp: time.Now(),
+			})
 
-		return err
+			return err
+		}
 	}
 	var wasUpgrade bool
 	if upgrade {

--- a/pkg/scanner/whisper_fallback.go
+++ b/pkg/scanner/whisper_fallback.go
@@ -1,0 +1,36 @@
+// file: pkg/scanner/whisper_fallback.go
+// version: 1.0.0
+// guid: 5e1c8a37-0b46-4d92-9f28-3a7d6c40e159
+// last-edited: 2026-07-23
+
+package scanner
+
+import (
+	"context"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/transcriber"
+)
+
+// whisperFallback transcribes mediaPath with Whisper when no subtitle provider
+// produced one, matching Bazarr's "Whisper fallback". It returns (data, true)
+// on success or (nil, false) to leave the original fetch failure in place. It is
+// active only when whisper.fallback_enabled is set and a Whisper backend is
+// configured (a self-hosted whisper.transcribe_url, or an OpenAI key).
+func whisperFallback(ctx context.Context, mediaPath, lang string) ([]byte, bool) {
+	if !viper.GetBool("whisper.fallback_enabled") {
+		return nil, false
+	}
+	apiKey := viper.GetString("openai_api_key")
+	if viper.GetString("whisper.transcribe_url") == "" && apiKey == "" {
+		return nil, false
+	}
+	// WhisperTranscribe prefers whisper.transcribe_url (native /asr, no key) and
+	// otherwise uses the OpenAI-compatible API with apiKey.
+	data, err := transcriber.WhisperTranscribe(mediaPath, lang, apiKey)
+	if err != nil || len(data) == 0 {
+		return nil, false
+	}
+	return data, true
+}

--- a/pkg/scanner/whisper_fallback_test.go
+++ b/pkg/scanner/whisper_fallback_test.go
@@ -1,0 +1,79 @@
+// file: pkg/scanner/whisper_fallback_test.go
+// version: 1.0.0
+// guid: b9f2c650-1a83-4e07-8d24-6c5f0a9e3b71
+
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// failingProvider always fails to fetch, forcing the fallback path.
+type failingProvider struct{}
+
+func (failingProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return nil, fmt.Errorf("no subtitle")
+}
+
+// TestWhisperFallbackWritesSubtitle verifies that when the provider fails and
+// whisper fallback is enabled, ProcessFile transcribes via the configured ASR
+// server and writes the resulting subtitle.
+func TestWhisperFallbackWritesSubtitle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "1\n00:00:00,000 --> 00:00:01,000\ntranscribed\n")
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("whisper.fallback_enabled", true)
+	viper.Set("whisper.transcribe_url", srv.URL)
+	defer viper.Reset()
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("media"), 0o644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+
+	if err := ProcessFile(context.Background(), vid, "en", "test", failingProvider{}, false, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "movie.en.srt"))
+	if err != nil {
+		t.Fatalf("expected fallback subtitle written: %v", err)
+	}
+	if string(data) == "" {
+		t.Fatal("expected non-empty fallback subtitle")
+	}
+}
+
+// TestWhisperFallbackDisabled verifies the provider error is returned when the
+// fallback is off.
+func TestWhisperFallbackDisabled(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("media"), 0o644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+
+	if err := ProcessFile(context.Background(), vid, "en", "test", failingProvider{}, false, nil); err == nil {
+		t.Fatal("expected error when fallback disabled and provider fails")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "movie.en.srt")); !os.IsNotExist(err) {
+		t.Fatal("no subtitle should be written when fallback is disabled")
+	}
+}


### PR DESCRIPTION
## Summary

Bazarr's **Whisper fallback** (found in the upstream changelog, missing from our audit): when subtitle providers return nothing for a file, transcribe the media with Whisper and use that as the subtitle. This makes the Whisper pipeline we already built kick in automatically instead of only via explicit CLI/API.

## Changes

- **pkg/scanner**: `whisperFallback` transcribes via `transcriber.WhisperTranscribe`, which prefers the self-hosted `whisper.transcribe_url` (native `/asr`, no key) and otherwise uses the OpenAI-compatible API with `openai_api_key`. Wired into `ProcessFile`'s fetch-failure branch.
- Gated by `whisper.fallback_enabled` (**off by default**); when off, a provider failure is returned unchanged (the failure event still fires).

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/scanner/` — pass
- New tests: provider fails + fallback enabled + `whisper.transcribe_url` set → subtitle written from the (mock `/asr`) transcription; fallback disabled → provider error returned and no file written. httptest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)