### PR TITLE
feat(arr): configurable Sonarr/Radarr request timeout

### DIFF
--- a/changelog.d/feat-arr-timeout.md
+++ b/changelog.d/feat-arr-timeout.md
@@ -1,0 +1,8 @@
+### Added
+
+#### Configurable Sonarr/Radarr request timeout
+
+The Sonarr and Radarr API clients' request timeout is now configurable via
+`integrations.sonarr.timeout` and `integrations.radarr.timeout` (in seconds),
+matching Bazarr. It defaults to 30 seconds when unset, so behaviour is unchanged
+unless configured.

--- a/pkg/arr/timeout.go
+++ b/pkg/arr/timeout.go
@@ -1,0 +1,27 @@
+// file: pkg/arr/timeout.go
+// version: 1.0.0
+// guid: 8b2f0e4c-6a19-4d73-9c50-1e7a3d6b8042
+// last-edited: 2026-07-23
+
+package arr
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// DefaultTimeout is the request timeout used for Sonarr/Radarr calls when none
+// is configured.
+const DefaultTimeout = 30 * time.Second
+
+// Timeout returns the configured HTTP request timeout for the given config
+// prefix (e.g. "integrations.sonarr"), read from "<prefix>.timeout" in seconds.
+// It falls back to DefaultTimeout when unset or non-positive, matching Bazarr's
+// configurable Sonarr/Radarr request timeout.
+func Timeout(prefix string) time.Duration {
+	if secs := viper.GetInt(prefix + ".timeout"); secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return DefaultTimeout
+}

--- a/pkg/arr/timeout_test.go
+++ b/pkg/arr/timeout_test.go
@@ -1,0 +1,34 @@
+// file: pkg/arr/timeout_test.go
+// version: 1.0.0
+// guid: 1f7c3a90-8d24-4b56-9e01-6a2f5d8c0473
+
+package arr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func TestTimeout(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	// Unset → default.
+	if got := Timeout("integrations.sonarr"); got != DefaultTimeout {
+		t.Fatalf("expected default %v, got %v", DefaultTimeout, got)
+	}
+
+	// Configured value in seconds.
+	viper.Set("integrations.sonarr.timeout", 5)
+	if got := Timeout("integrations.sonarr"); got != 5*time.Second {
+		t.Fatalf("expected 5s, got %v", got)
+	}
+
+	// Non-positive → default.
+	viper.Set("integrations.radarr.timeout", 0)
+	if got := Timeout("integrations.radarr"); got != DefaultTimeout {
+		t.Fatalf("expected default for 0, got %v", got)
+	}
+}

--- a/pkg/radarr/client.go
+++ b/pkg/radarr/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/jdfalk/subtitle-manager/pkg/arr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
@@ -23,12 +22,13 @@ type Client struct {
 	client  *http.Client
 }
 
-// NewClient returns a configured Radarr API client.
+// NewClient returns a configured Radarr API client. The request timeout is read
+// from integrations.radarr.timeout (seconds), defaulting to 30s.
 func NewClient(baseURL, apiKey string) *Client {
 	return &Client{
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		APIKey:  apiKey,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		client:  &http.Client{Timeout: arr.Timeout("integrations.radarr")},
 	}
 }
 

--- a/pkg/sonarr/client.go
+++ b/pkg/sonarr/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/jdfalk/subtitle-manager/pkg/arr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
@@ -24,12 +23,13 @@ type Client struct {
 	client  *http.Client
 }
 
-// NewClient returns a configured Sonarr API client.
+// NewClient returns a configured Sonarr API client. The request timeout is read
+// from integrations.sonarr.timeout (seconds), defaulting to 30s.
 func NewClient(baseURL, apiKey string) *Client {
 	return &Client{
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		APIKey:  apiKey,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		client:  &http.Client{Timeout: arr.Timeout("integrations.sonarr")},
 	}
 }
 


### PR DESCRIPTION
## Summary

Bazarr changelog gap: **configurable request timeout to Sonarr and Radarr**. Our clients hardcoded 30s.

## Changes

- **pkg/arr**: `Timeout(prefix)` reads `<prefix>.timeout` (seconds), default 30s.
- **pkg/sonarr / pkg/radarr**: `NewClient` uses `arr.Timeout("integrations.sonarr"|"integrations.radarr")`.

Default unchanged (30s) unless `integrations.{sonarr,radarr}.timeout` is set.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/arr/ ./pkg/sonarr/ ./pkg/radarr/` — pass
- New `TestTimeout`: unset → default; `5` → 5s; `0` → default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)