### PR TITLE
feat(postprocess): provider/score script vars + score threshold

### DIFF
--- a/changelog.d/feat-postprocess-vars.md
+++ b/changelog.d/feat-postprocess-vars.md
@@ -1,0 +1,10 @@
+### Added
+
+#### Provider/score variables and score threshold for custom post-processing
+
+The custom post-processing script now receives `SM_PROVIDER` (the subtitle
+provider) and `SM_SCORE` (the quality score, 0-100) in addition to the existing
+`SM_SUBTITLE_PATH` / `SM_MEDIA_PATH` / `SM_LANG`, matching Bazarr's
+post-processing variables. A new `postprocess.score_threshold` (0-100) gates the
+script so it only runs when the subtitle's score meets the threshold; an unset
+threshold or an unknown score never gates.

--- a/pkg/postprocess/postprocess.go
+++ b/pkg/postprocess/postprocess.go
@@ -1,5 +1,5 @@
 // file: pkg/postprocess/postprocess.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e05a04c4-5ff1-4ed0-8c91-3b114e2a3d94
 
 // Package postprocess implements the Bazarr-style post-processing pipeline that
@@ -61,11 +61,21 @@ func EncodeUTF8IfEnabled(data []byte) []byte {
 	return EncodeUTF8(data)
 }
 
+// Info carries optional metadata about the download for the custom
+// post-processing script and its score-threshold gate.
+type Info struct {
+	// Provider is the subtitle provider name (may be empty).
+	Provider string
+	// Score is the normalized quality score in [0,1], or nil when unknown.
+	Score *float64
+}
+
 // AfterDownload runs the post-write steps (chmod, auto-sync, custom script) on a
 // subtitle that has just been written for the given media file. Each step is
 // gated by config and errors are logged, not returned, so post-processing never
-// fails a completed download.
-func AfterDownload(ctx context.Context, subtitlePath, mediaPath, lang string) {
+// fails a completed download. info supplies the provider and score exposed to
+// the custom script and the score-threshold gate.
+func AfterDownload(ctx context.Context, subtitlePath, mediaPath, lang string, info Info) {
 	logger := logging.GetLogger("postprocess")
 
 	if mode := viper.GetString("postprocess.chmod"); mode != "" {
@@ -85,10 +95,23 @@ func AfterDownload(ctx context.Context, subtitlePath, mediaPath, lang string) {
 	}
 
 	if script := viper.GetString("postprocess.custom_script"); script != "" {
-		if err := runScript(ctx, script, subtitlePath, mediaPath, lang); err != nil {
+		if scoreBelowThreshold(info.Score) {
+			logger.Debugf("skipping custom script: score below postprocess.score_threshold")
+		} else if err := runScript(ctx, script, subtitlePath, mediaPath, lang, info); err != nil {
 			logger.Warnf("custom script: %v", err)
 		}
 	}
+}
+
+// scoreBelowThreshold reports whether a known score is below the configured
+// postprocess.score_threshold (0-100). An unset threshold, or an unknown score,
+// never gates.
+func scoreBelowThreshold(score *float64) bool {
+	threshold := viper.GetInt("postprocess.score_threshold")
+	if threshold <= 0 || score == nil {
+		return false
+	}
+	return *score*100 < float64(threshold)
 }
 
 // autoSync synchronizes subtitlePath to mediaPath (using embedded subtitles as
@@ -110,12 +133,18 @@ func autoSync(mediaPath, subtitlePath string) error {
 // runScript executes the configured shell command, passing the subtitle, media
 // and language via environment variables (SM_SUBTITLE_PATH / SM_MEDIA_PATH /
 // SM_LANG) so paths are never interpolated into the command string.
-func runScript(ctx context.Context, script, subtitlePath, mediaPath, lang string) error {
+func runScript(ctx context.Context, script, subtitlePath, mediaPath, lang string, info Info) error {
+	score := ""
+	if info.Score != nil {
+		score = strconv.Itoa(int(*info.Score * 100))
+	}
 	cmd := exec.CommandContext(ctx, "sh", "-c", script)
 	cmd.Env = append(os.Environ(),
 		"SM_SUBTITLE_PATH="+subtitlePath,
 		"SM_MEDIA_PATH="+mediaPath,
 		"SM_LANG="+lang,
+		"SM_PROVIDER="+info.Provider,
+		"SM_SCORE="+score,
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/postprocess/postprocess_test.go
+++ b/pkg/postprocess/postprocess_test.go
@@ -62,7 +62,7 @@ func TestAfterDownloadChmodAndScript(t *testing.T) {
 	// Script records the env vars it received.
 	viper.Set("postprocess.custom_script", "printf '%s|%s|%s' \"$SM_SUBTITLE_PATH\" \"$SM_MEDIA_PATH\" \"$SM_LANG\" > "+marker)
 
-	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en")
+	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en", Info{})
 
 	fi, err := os.Stat(sub)
 	if err != nil {
@@ -78,5 +78,57 @@ func TestAfterDownloadChmodAndScript(t *testing.T) {
 	want := sub + "|" + filepath.Join(dir, "movie.mkv") + "|en"
 	if string(data) != want {
 		t.Fatalf("script env mismatch: got %q want %q", data, want)
+	}
+}
+
+// TestAfterDownloadProviderScoreVars verifies SM_PROVIDER and SM_SCORE are
+// exposed to the custom script.
+func TestAfterDownloadProviderScoreVars(t *testing.T) {
+	defer viper.Reset()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "movie.en.srt")
+	if err := os.WriteFile(sub, []byte("1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	marker := filepath.Join(dir, "vars.txt")
+	viper.Set("postprocess.custom_script", "printf '%s|%s' \"$SM_PROVIDER\" \"$SM_SCORE\" > "+marker)
+
+	score := 0.87
+	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en", Info{Provider: "opensubtitles", Score: &score})
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("script did not run: %v", err)
+	}
+	if string(data) != "opensubtitles|87" {
+		t.Fatalf("unexpected provider/score vars: %q", data)
+	}
+}
+
+// TestAfterDownloadScoreThreshold verifies the custom script is skipped when the
+// score is below postprocess.score_threshold.
+func TestAfterDownloadScoreThreshold(t *testing.T) {
+	defer viper.Reset()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "movie.en.srt")
+	if err := os.WriteFile(sub, []byte("1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	marker := filepath.Join(dir, "ran.txt")
+	viper.Set("postprocess.custom_script", "touch "+marker)
+	viper.Set("postprocess.score_threshold", 80)
+
+	// Below threshold → skipped.
+	low := 0.50
+	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en", Info{Score: &low})
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatal("script should be skipped below score threshold")
+	}
+
+	// At/above threshold → runs.
+	high := 0.90
+	AfterDownload(context.Background(), sub, filepath.Join(dir, "movie.mkv"), "en", Info{Score: &high})
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("script should run above threshold: %v", err)
 	}
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -236,7 +236,7 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 		_ = store.InsertDownload(&database.DownloadRecord{File: validatedOutputPath, VideoFile: path, Provider: providerName, Language: lang, MatchScore: matchScore})
 	}
 	// Post-processing: chmod, auto-sync, custom script (all opt-in via config).
-	postprocess.AfterDownload(ctx, validatedOutputPath, path, lang)
+	postprocess.AfterDownload(ctx, validatedOutputPath, path, lang, postprocess.Info{Provider: providerName, Score: matchScore})
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Bazarr changelog gap: the custom post-processing script gets **score**, **provider**, and a **score-threshold** gate. Ours passed far fewer variables and had no threshold.

## Changes

- **pkg/postprocess**: `AfterDownload` now takes `Info{Provider, Score}`. `runScript` adds `SM_PROVIDER` and `SM_SCORE` (0-100) alongside the existing `SM_SUBTITLE_PATH`/`SM_MEDIA_PATH`/`SM_LANG`. New `postprocess.score_threshold` (0-100) skips the script when a *known* score is below it (unset threshold or unknown score never gates).
- **pkg/scanner**: passes `Info{Provider, Score}` from the download.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/postprocess/ ./pkg/scanner/` — pass
- New tests: `SM_PROVIDER`/`SM_SCORE` exposed (`opensubtitles|87`); script skipped below threshold, runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)