### PR TITLE
feat(monitoring): route automatic loop through scanner.ProcessFile

### DIFF
--- a/changelog.d/feat-monitor-processfile.md
+++ b/changelog.d/feat-monitor-processfile.md
@@ -1,0 +1,10 @@
+### Changed
+
+#### Automatic monitoring loop uses the full download pipeline
+
+The scheduled monitoring loop now downloads subtitles through
+`scanner.ProcessFile` instead of a bare fetch-and-write. This means the
+automatic "wanted subtitles" loop gets the same behaviour as manual/CLI
+downloads: score-gating, Whisper fallback, post-processing (UTF-8/chmod/
+auto-sync/custom script), single-language naming, and score-based upgrades —
+previously all bypassed by the monitor's own minimal fetch path.

--- a/pkg/monitoring/monitor.go
+++ b/pkg/monitoring/monitor.go
@@ -1,5 +1,5 @@
 // file: pkg/monitoring/monitor.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12345678-1234-1234-1234-123456789012
 
 package monitoring
@@ -7,17 +7,14 @@ package monitoring
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
-	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/radarr"
+	"github.com/jdfalk/subtitle-manager/pkg/scanner"
 	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
 )
 
@@ -165,16 +162,13 @@ func (m *EpisodeMonitor) processItem(ctx context.Context, item *MonitoredItem) e
 	return m.updateMonitoredItem(item)
 }
 
-// checkLanguage attempts to download subtitles for a specific language.
+// checkLanguage attempts to download subtitles for a specific language via the
+// full download pipeline (scanner.ProcessFile), so the automatic monitoring
+// loop gets the same behaviour as manual downloads: score-gating, Whisper
+// fallback, post-processing, single-language naming and score-based upgrade —
+// instead of the previous bare fetch-and-write.
 func (m *EpisodeMonitor) checkLanguage(ctx context.Context, item *MonitoredItem, lang string) error {
-	// Use the existing provider system to fetch subtitles
-	data, providerID, err := providers.FetchFromAll(ctx, item.Path, lang, "")
-	if err != nil {
-		return err
-	}
-
-	// Store the subtitle and mark as found
-	return m.storeSubtitle(item, lang, data, providerID)
+	return scanner.ProcessFile(ctx, item.Path, lang, "", nil, true, m.store)
 }
 
 // getItemsToCheck retrieves monitored items that need checking.
@@ -233,28 +227,4 @@ func (m *EpisodeMonitor) updateMonitoredItem(item *MonitoredItem) error {
 	}
 
 	return m.store.UpdateMonitoredItem(dbItem)
-}
-
-// storeSubtitle saves the downloaded subtitle to disk and database.
-func (m *EpisodeMonitor) storeSubtitle(item *MonitoredItem, lang string, data []byte, providerID string) error {
-	// Generate subtitle file path
-	ext := filepath.Ext(item.Path)
-	base := strings.TrimSuffix(item.Path, ext)
-	subtitlePath := base + "." + lang + ".srt"
-
-	// Write subtitle to disk
-	if err := os.WriteFile(subtitlePath, data, 0644); err != nil {
-		return err
-	}
-
-	// Record download in database
-	downloadRec := &database.DownloadRecord{
-		File:      subtitlePath,
-		VideoFile: item.Path,
-		Provider:  providerID,
-		Language:  lang,
-		CreatedAt: time.Now(),
-	}
-
-	return m.store.InsertDownload(downloadRec)
 }

--- a/pkg/monitoring/monitor_processfile_test.go
+++ b/pkg/monitoring/monitor_processfile_test.go
@@ -1,0 +1,64 @@
+// file: pkg/monitoring/monitor_processfile_test.go
+// version: 1.0.0
+// guid: 4c8e1b70-2d95-4a38-b6f0-1e7c3a9d0562
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+)
+
+// TestCheckLanguageRoutesThroughProcessFile verifies the monitoring loop now
+// uses scanner.ProcessFile: with all providers failing but Whisper fallback
+// enabled, a subtitle is still written — behaviour the old bare-fetch path
+// (providers.FetchFromAll + storeSubtitle) could not produce.
+func TestCheckLanguageRoutesThroughProcessFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "1\n00:00:00,000 --> 00:00:01,000\ntranscribed\n")
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("whisper.fallback_enabled", true)
+	viper.Set("whisper.transcribe_url", srv.URL)
+	defer viper.Reset()
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("media"), 0o644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	m := &EpisodeMonitor{store: store, logger: logging.GetLogger("test")}
+	item := &MonitoredItem{ID: "1", Path: vid, Languages: []string{"en"}}
+
+	// Bound the context so the provider sweep (which tries every stub) gives up
+	// quickly; the Whisper fallback uses its own context and still writes.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := m.checkLanguage(ctx, item, "en"); err != nil {
+		t.Fatalf("checkLanguage: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "movie.en.srt")); err != nil {
+		t.Fatalf("expected subtitle written via ProcessFile+whisper fallback: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The scheduled monitoring loop (Bazarr's "wanted subtitles" search) downloaded via its own minimal `providers.FetchFromAll` + `storeSubtitle` path, **bypassing every feature in `ProcessFile`**: scoring, Whisper fallback, post-processing, single-language naming, score-based upgrade. This routes it through `scanner.ProcessFile` so the automatic loop behaves like manual/CLI downloads.

## Changes

- **pkg/monitoring**: `checkLanguage` now calls `scanner.ProcessFile(ctx, path, lang, "", nil, true, store)`; removed the redundant `storeSubtitle` helper and now-unused imports. No import cycle (`monitoring → scanner`, and scanner imports neither).

## Note surfaced while testing

`providers.FetchFromAll`'s no-instances fallback iterates all ~55 stub providers with an escalating `time.Sleep(i·1s)`, so with no configured provider *instances* a check is slow. Pre-existing (the old monitor path called `FetchFromAll` too); documented as a follow-up. The new test bounds its context so the sweep gives up fast.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/monitoring/` — pass (~3.7s)
- New `TestCheckLanguageRoutesThroughProcessFile`: with all providers failing but Whisper fallback enabled, a subtitle is written — proving the loop now goes through `ProcessFile` (the old path couldn't produce this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)