### PR TITLE
fix(providers): honor context during FetchFromAll inter-provider delay

### DIFF
--- a/changelog.d/fix-fetchall-context.md
+++ b/changelog.d/fix-fetchall-context.md
@@ -1,0 +1,10 @@
+### Fixed
+
+#### Provider search honors context cancellation during inter-provider delay
+
+`FetchFromAll`'s fallback loop (used when no provider instances are configured)
+waited between provider attempts with a blind `time.Sleep` that ignored context
+cancellation, so a cancelled or bounded context could not abort it mid-wait —
+making automatic monitoring with many stub providers slow to cancel. The delay
+is now context-aware (a `select` on `ctx.Done()`), matching the instance-based
+loops.

--- a/pkg/providers/multi.go
+++ b/pkg/providers/multi.go
@@ -1,3 +1,7 @@
+// file: pkg/providers/multi.go
+// version: 1.1.0
+// guid: 2f8c1a05-6d43-4b79-9e20-3a7c5d8b0164
+
 package providers
 
 import (
@@ -31,7 +35,14 @@ func FetchFromAll(ctx context.Context, mediaPath, lang, key string) ([]byte, str
 			if ctx.Err() != nil {
 				return nil, "", ctx.Err()
 			}
-			time.Sleep(time.Duration(i+1) * delay)
+			// Context-aware inter-provider delay so a cancelled or bounded
+			// context aborts immediately instead of blocking on a blind sleep
+			// (this matches the instance-based loops below).
+			select {
+			case <-time.After(time.Duration(i+1) * delay):
+			case <-ctx.Done():
+				return nil, "", ctx.Err()
+			}
 		}
 		return nil, "", fmt.Errorf("no subtitle found")
 	}

--- a/pkg/providers/multi_test.go
+++ b/pkg/providers/multi_test.go
@@ -1,0 +1,38 @@
+// file: pkg/providers/multi_test.go
+// version: 1.0.0
+// guid: 6b1e9c04-8a37-4d52-9f60-2c5d0a7b3841
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type alwaysFailProvider struct{}
+
+func (alwaysFailProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return nil, fmt.Errorf("fail")
+}
+
+// TestFetchFromAllHonorsCancelledContext verifies FetchFromAll returns promptly
+// with the context error instead of blocking on inter-provider delays when the
+// context is already cancelled.
+func TestFetchFromAllHonorsCancelledContext(t *testing.T) {
+	RegisterFactory("failtest", func() Provider { return alwaysFailProvider{} })
+	RegisterInstance(Instance{ID: "failtest-1", Name: "failtest", Enabled: true})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	start := time.Now()
+	_, _, err := FetchFromAll(ctx, "/media/movie.mkv", "en", "")
+	if err == nil {
+		t.Fatal("expected an error for a cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("FetchFromAll did not abort promptly: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

`FetchFromAll`'s no-instances fallback loop waited between provider attempts with a **blind `time.Sleep`** that ignored context cancellation — unlike the two instance-based loops in the same file, which already `select` on `ctx.Done()`. So a cancelled or bounded context couldn't abort it mid-wait.

This surfaced when routing the monitoring loop through `ProcessFile`: with ~55 stub providers and escalating delays, a bounded context only aborted after the current blind sleep.

## Fix

Make the inter-provider delay context-aware (`select { case <-time.After(...): case <-ctx.Done(): return ctx.Err() }`), matching the adjacent loops. One-line-equivalent alignment; no behavior change for the success path.

## Testing

- `go build ./...`, `go vet` — clean
- `go test ./pkg/providers/` — pass
- New `TestFetchFromAllHonorsCancelledContext`: registers a failing provider instance and asserts a cancelled context returns promptly (<5s) rather than blocking on delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)