### PR TITLE
fix(webserver): resolve data race in async library-path scan

### DIFF
--- a/changelog.d/fix-librarypaths-race.md
+++ b/changelog.d/fix-librarypaths-race.md
@@ -1,0 +1,9 @@
+### Fixed
+
+#### Data race in async library-path scan
+
+`scanPathAsync` opened the database store (which reads viper config) inside its
+background goroutine, which could race with a concurrent viper mutation — e.g.
+a test's deferred `viper.Reset()` — and was caught by the `-race` detector in
+`TestLibraryPathsHandler`. The store is now opened synchronously before the
+goroutine starts; only the scan itself runs in the background.

--- a/pkg/webserver/librarypaths.go
+++ b/pkg/webserver/librarypaths.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/librarypaths.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 17206a5a-f1bc-4f44-acfa-aa3d7f72f59c
 
 package webserver
@@ -64,14 +64,17 @@ func writeLibraryPaths(paths []string) error {
 
 // scanPathAsync scans dir into the media library in the background so newly
 // added / rescanned paths populate MediaItems without blocking the request.
+// The store is opened synchronously (which reads viper config) before the
+// goroutine starts, so the background scan never races with a concurrent
+// viper mutation — e.g. a test's deferred viper.Reset().
 func scanPathAsync(dir string) {
+	logger := logging.GetLogger("library-paths")
+	store, err := database.OpenStoreWithConfig()
+	if err != nil {
+		logger.Warnf("scan %s: open store: %v", dir, err)
+		return
+	}
 	go func() {
-		logger := logging.GetLogger("library-paths")
-		store, err := database.OpenStoreWithConfig()
-		if err != nil {
-			logger.Warnf("scan %s: open store: %v", dir, err)
-			return
-		}
 		defer store.Close()
 		if err := metadata.ScanLibraryProgress(context.Background(), dir, store, nil); err != nil {
 			logger.Warnf("scan %s: %v", dir, err)


### PR DESCRIPTION
## Summary

Fixes a real data race (caught by `-race` in `TestLibraryPathsHandler`, intermittently red on CI — it's what failed #2199's run). `scanPathAsync` opened the DB store — which reads viper via `OpenStoreWithConfig`→`GetDatabasePath`→`viper.GetString` — **inside** its background goroutine. That read races with any concurrent viper write, e.g. a test's deferred `viper.Reset()`.

## Fix

Open the store **synchronously** in the request goroutine before launching the background goroutine; only the scan runs async (and `ScanLibraryProgress` touches no viper state). Behavior is otherwise identical.

## Testing

- `go build ./...` — clean
- `go test -race -run TestLibraryPaths -count=5 ./pkg/webserver/` — pass (previously flaky-red under -race)
- `go test -race ./pkg/webserver/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)