### PR TITLE
feat(providers): implement real keyless Gestdown provider

### DIFF
--- a/changelog.d/feat-gestdown-provider.md
+++ b/changelog.d/feat-gestdown-provider.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/feat-gestdown-provider.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f1c6a48-2b90-4d7e-8c15-a4e29d0b7f62 -->
+<!-- last-edited: 2026-07-23 -->
+
+### Added
+
+#### Real keyless Gestdown provider (Addic7ed TV subtitles)
+
+The `gestdown` provider now talks to the real gestdown.info REST API — a free,
+keyless proxy over Addic7ed's TV-subtitle catalogue — instead of the previous
+stub that hit a fictional `api.gestdown.com/subtitles/{file}/{lang}` endpoint.
+Because Addic7ed indexes by show/season/episode rather than by file hash, the
+provider parses the media file name into `(series, season, episode)` via
+`pkg/metadata`, resolves the show through `/shows/search/{name}` (preferring a
+candidate whose season list covers the target season), lists completed
+subtitles for the requested language via `/subtitles/get/{showId}/{season}/{episode}/{lang}`,
+and downloads the first match. It is TV-only: movie files are rejected, matching
+Gestdown/Addic7ed's scope. No account or API key is required.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,5 +1,5 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.5.0 -->
+<!-- version: 1.6.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
 <!-- last-edited: 2026-07-23 -->
 
@@ -14,21 +14,30 @@ plumbing exists but the behaviour is not wired into the live path.
 
 ## The load-bearing caveat: the provider layer
 
-**~50 of ~55 registered subtitle providers are non-functional stubs** — each
+**~49 of ~55 registered subtitle providers are non-functional stubs** — each
 GETs a fictional `https://api.<name>.com/subtitles/<file>/<lang>` endpoint
 (`pkg/providers/*/*.go`). Real integrations: **opensubtitles** (hash + REST),
-**napiprojekt** (keyless hash protocol), plus **embedded** (ffmpeg track
-extraction) and the configurable **generic** / **whisper** HTTP pass-throughs.
-Bazarr's provider breadth comes from Python's `subliminal`; porting dozens of
-real scrapers to Go is a large, separate effort.
+**napiprojekt** (keyless hash protocol), **gestdown** (keyless Addic7ed REST
+proxy, TV-only), plus **embedded** (ffmpeg track extraction) and the
+configurable **generic** / **whisper** HTTP pass-throughs. Bazarr's provider
+breadth comes from Python's `subliminal`; porting dozens of real scrapers to Go
+is a large, separate effort.
+
+> **Note for the Phase 2 credential work:** the `opensubtitlescom` package
+> (the `.com` REST v1 provider) is still a *stub* hitting a fictional
+> `api.opensubtitlescom.com` host — despite the build-out prompt calling it
+> "already implemented". The real, working OpenSubtitles integration is the
+> classic `opensubtitles` package. Trust the code, not the prompt's
+> "already implemented" claims, for each Phase 2 provider.
 
 ### The provider boundary (what can be done autonomously vs. what needs you)
 
 Porting the remaining stubs splits into three buckets:
 
 - **Keyless / anonymous (implementable & unit-testable now):** hash- or
-  anonymous-search services that need no account. `napiprojekt` is done as the
-  reference implementation. A handful of others are theoretically keyless but
+  anonymous-search services that need no account. `napiprojekt` (hash protocol)
+  and `gestdown` (Addic7ed REST proxy, filename→episode via `pkg/metadata`) are
+  done as the reference implementations. A handful of others are theoretically keyless but
   rely on **fragile HTML scraping of live sites** (e.g. `podnapisi`,
   `yifysubtitles`, `subscene`), which cannot be implemented correctly or tested
   offline without replicating each site's exact markup — high effort, brittle.
@@ -41,8 +50,9 @@ Porting the remaining stubs splits into three buckets:
   no stable API; porting them is the bulk of the `subliminal` effort and should
   be scoped deliberately, provider by provider.
 
-**Net:** automatic search/download works through **opensubtitles** and
-**napiprojekt** today; `embedded` covers muxed tracks. Going materially further
+**Net:** automatic search/download works through **opensubtitles**,
+**napiprojekt**, and **gestdown** (TV episodes) today; `embedded` covers muxed
+tracks. Going materially further
 requires either operator-supplied credentials or a deliberate, funded scraping
 effort — it is not fully achievable autonomously.
 
@@ -64,7 +74,7 @@ effort — it is not fully achievable autonomously.
 ### Search / download / upgrade engine
 | Capability | Status | Notes |
 | --- | --- | --- |
-| Provider registry breadth | 🔴 | ~50 stubs; 2 real (opensubtitles, napiprojekt) + embedded |
+| Provider registry breadth | 🔴 | ~49 stubs; 3 real (opensubtitles, napiprojekt, gestdown) + embedded |
 | Whisper fallback (transcribe when no provider match) | ✅ | `whisper.fallback_enabled` (`pkg/scanner.whisperFallback`) |
 | Automatic "wanted" search loop (scheduled) | 🟡 | monitor skeleton; score gate now available |
 | Manual search (ranked candidates) | 🟡 | `/api/search`; only opensubtitles implements `Searcher` |

--- a/pkg/providers/gestdown/gestdown.go
+++ b/pkg/providers/gestdown/gestdown.go
@@ -1,48 +1,228 @@
 // file: pkg/providers/gestdown/gestdown.go
+// version: 2.0.0
+// guid: 898074d8-d1d4-4681-936c-e4c2ed0ddaa3
+// last-edited: 2026-07-23
+
+// Package gestdown implements a real, keyless subtitle provider for
+// gestdown.info, a free REST proxy over Addic7ed's TV-subtitle catalogue.
+//
+// Addic7ed indexes subtitles by show name, season, and episode rather than by
+// file hash, so Fetch parses the media file name into a (series, season,
+// episode) tuple via pkg/metadata, resolves the show through Gestdown's search
+// endpoint, lists the completed subtitles for the requested language, and
+// downloads the first match. No account or API key is required.
+//
+// Movies are unsupported: Gestdown/Addic7ed is TV-only, and Fetch returns an
+// error for anything that does not parse as an episode.
 package gestdown
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"net/url"
+	"strings"
 	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/metadata"
 )
 
-// Client implements the providers.Provider interface for Gestdown.
-// It performs a simple HTTP GET to download subtitles.
+// defaultAPIURL is the public Gestdown API base URL.
+const defaultAPIURL = "https://api.gestdown.info"
+
+// Client implements the providers.Provider interface for gestdown.info.
 type Client struct {
-	// APIURL is the base URL of the Gestdown API.
+	// APIURL is the base URL of the Gestdown API (overridable for tests).
 	APIURL string
 	// HTTPClient is used to make requests.
 	HTTPClient *http.Client
+	// UserAgent is sent with every request; Gestdown rejects empty agents.
+	UserAgent string
 }
 
 // New returns a Client configured with reasonable defaults.
 func New() *Client {
 	return &Client{
-		APIURL:     "https://api.gestdown.com",
-		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		APIURL:     defaultAPIURL,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		UserAgent:  "subtitle-manager",
 	}
 }
 
-// Fetch downloads the subtitle for mediaPath in lang.
-// It returns the subtitle bytes or an error.
+// show mirrors one entry of the /shows/search response.
+type show struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Seasons []int  `json:"seasons"`
+}
+
+// showSearchResponse is the /shows/search/{name} response envelope.
+type showSearchResponse struct {
+	Shows []show `json:"shows"`
+}
+
+// subtitle mirrors one entry of the matchingSubtitles array.
+type subtitle struct {
+	SubtitleID  string `json:"subtitleId"`
+	Version     string `json:"version"`
+	Completed   bool   `json:"completed"`
+	DownloadURI string `json:"downloadUri"`
+	Language    string `json:"language"`
+}
+
+// subtitlesResponse is the /subtitles/get/... response envelope.
+type subtitlesResponse struct {
+	MatchingSubtitles []subtitle `json:"matchingSubtitles"`
+}
+
+// Fetch downloads a subtitle for the episode described by mediaPath in lang.
+// It returns the subtitle bytes or an error when the file is not a TV episode,
+// the show cannot be resolved, or no completed subtitle exists.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	name := filepath.Base(mediaPath)
-	url := fmt.Sprintf("%s/subtitles/%s/%s", c.APIURL, name, lang)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	info, err := metadata.ParseFileName(mediaPath)
+	if err != nil {
+		return nil, fmt.Errorf("gestdown: parse file name: %w", err)
+	}
+	if info.Type != metadata.TypeEpisode {
+		return nil, fmt.Errorf("gestdown: only TV episodes are supported (got %q)", mediaPath)
+	}
+	if strings.TrimSpace(info.Title) == "" {
+		return nil, fmt.Errorf("gestdown: could not determine series name from %q", mediaPath)
+	}
+
+	shows, err := c.searchShows(ctx, info.Title)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.HTTPClient.Do(req)
+	if len(shows) == 0 {
+		return nil, fmt.Errorf("gestdown: show %q not found", info.Title)
+	}
+
+	sub, err := c.findSubtitle(ctx, shows, info.Season, info.Episode, lang)
+	if err != nil {
+		return nil, err
+	}
+	return c.download(ctx, sub.DownloadURI)
+}
+
+// searchShows resolves a series name to candidate shows.
+func (c *Client) searchShows(ctx context.Context, title string) ([]show, error) {
+	resp, err := c.get(ctx, "/shows/search/"+url.PathEscape(title))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gestdown: show search: status %d", resp.StatusCode)
+	}
+	var out showSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("gestdown: decode show search: %w", err)
+	}
+	return out.Shows, nil
+}
+
+// findSubtitle walks the candidate shows in relevance order and returns the
+// first completed subtitle for the requested episode and language.
+func (c *Client) findSubtitle(ctx context.Context, shows []show, season, episode int, lang string) (subtitle, error) {
+	for _, sh := range orderShows(shows, season) {
+		subs, err := c.listSubtitles(ctx, sh.ID, season, episode, lang)
+		if err != nil {
+			return subtitle{}, err
+		}
+		for _, s := range subs {
+			if s.Completed && s.DownloadURI != "" {
+				return s, nil
+			}
+		}
+	}
+	return subtitle{}, fmt.Errorf("gestdown: no completed subtitle for S%02dE%02d (%s)", season, episode, lang)
+}
+
+// orderShows ranks candidate shows so those whose season list covers the target
+// season are tried first, preserving the API's original order within each group.
+func orderShows(shows []show, season int) []show {
+	preferred := make([]show, 0, len(shows))
+	rest := make([]show, 0, len(shows))
+	for _, sh := range shows {
+		if containsInt(sh.Seasons, season) {
+			preferred = append(preferred, sh)
+		} else {
+			rest = append(rest, sh)
+		}
+	}
+	return append(preferred, rest...)
+}
+
+// containsInt reports whether v appears in xs.
+func containsInt(xs []int, v int) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// listSubtitles returns the matching subtitles for a show/episode/language.
+// A 404 (show or episode not indexed) yields an empty slice rather than an error
+// so the caller can try the next candidate show.
+//
+// lang is forwarded to Gestdown as-is: the API treats ISO 639-1 ("en"),
+// ISO 639-2 ("eng"), and the English language name ("English") as equivalent
+// (verified live), and the scanner passes 2-letter profile codes, so no
+// code→name conversion is needed. Regional variants are distinct, however —
+// "pt-BR" and "pt" resolve to different Addic7ed catalogues.
+func (c *Client) listSubtitles(ctx context.Context, showID string, season, episode int, lang string) ([]subtitle, error) {
+	path := fmt.Sprintf("/subtitles/get/%s/%d/%d/%s", url.PathEscape(showID), season, episode, url.PathEscape(lang))
+	resp, err := c.get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gestdown: list subtitles: status %d", resp.StatusCode)
+	}
+	var out subtitlesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("gestdown: decode subtitles: %w", err)
+	}
+	return out.MatchingSubtitles, nil
+}
+
+// download fetches the subtitle bytes from a relative downloadUri.
+func (c *Client) download(ctx context.Context, downloadURI string) ([]byte, error) {
+	if downloadURI == "" {
+		return nil, fmt.Errorf("gestdown: empty download URI")
+	}
+	resp, err := c.get(ctx, downloadURI)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+		return nil, fmt.Errorf("gestdown: download: status %d", resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
+}
+
+// get issues a GET against the Gestdown API, joining path onto APIURL and
+// attaching the configured User-Agent.
+func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.APIURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return c.HTTPClient.Do(req)
 }

--- a/pkg/providers/gestdown/gestdown_test.go
+++ b/pkg/providers/gestdown/gestdown_test.go
@@ -1,15 +1,16 @@
 // file: pkg/providers/gestdown/gestdown_test.go
-// version: 1.0.0
-// guid: 16f526e0-ae08-40c4-bc7e-d4dfc47f7c60
+// version: 2.0.0
+// guid: bfe9a67e-a423-4db3-a78d-1d298b8507c5
+// last-edited: 2026-07-23
 
 package gestdown
 
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -19,98 +20,190 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
-func TestNewClientDefaults(t *testing.T) {
-	client := New()
-
-	if client == nil {
-		t.Fatal("expected client")
-	}
-
-	if client.APIURL != "https://api.gestdown.com" {
-		t.Fatalf("expected default APIURL, got %q", client.APIURL)
-	}
-
-	if client.HTTPClient == nil {
-		t.Fatal("expected HTTP client")
+// newTestClient returns a Client pointed at srv with its transport.
+func newTestClient(srv *httptest.Server) *Client {
+	return &Client{
+		APIURL:     srv.URL,
+		HTTPClient: srv.Client(),
+		UserAgent:  "subtitle-manager-test",
 	}
 }
 
-func TestClientFetch(t *testing.T) {
-	ctx := context.Background()
+func TestNewDefaults(t *testing.T) {
+	c := New()
+	if c.APIURL != "https://api.gestdown.info" {
+		t.Fatalf("expected default gestdown.info APIURL, got %q", c.APIURL)
+	}
+	if c.HTTPClient == nil {
+		t.Fatal("expected HTTP client")
+	}
+	if c.UserAgent == "" {
+		t.Fatal("expected a non-empty default User-Agent")
+	}
+}
 
-	t.Run("success", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			if req.URL.Path != "/subtitles/movie.mkv/en" {
-				t.Fatalf("expected request path to include filename and language, got %q", req.URL.Path)
+// router dispatches on the decoded request path. A plain handler is used
+// instead of http.ServeMux because Gestdown paths contain spaces (e.g.
+// "/shows/search/Breaking Bad"), which the Go 1.22+ ServeMux pattern parser
+// rejects.
+func router(t *testing.T, routes map[string]http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		h, ok := routes[r.URL.Path]
+		if !ok {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+			return
+		}
+		h(w, r)
+	}
+}
+
+func TestFetchEpisodeSuccess(t *testing.T) {
+	sawUA := false
+	srv := httptest.NewServer(router(t, map[string]http.HandlerFunc{
+		"/shows/search/Breaking Bad": func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("User-Agent") != "" {
+				sawUA = true
 			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("subtitle-data"))
-		}))
-		defer server.Close()
+			_, _ = w.Write([]byte(`{"shows":[{"id":"show-uuid","name":"Breaking Bad","seasons":[1,2,3,4,5]}]}`))
+		},
+		"/subtitles/get/show-uuid/1/1/en": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"matchingSubtitles":[
+				{"subtitleId":"a","version":"draft","completed":false,"downloadUri":"/subtitles/download/a","language":"English"},
+				{"subtitleId":"b","version":"0tv","completed":true,"downloadUri":"/subtitles/download/b","language":"English"}
+			]}`))
+		},
+		"/subtitles/download/b": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/srt")
+			_, _ = w.Write([]byte("1\n00:00:01,000 --> 00:00:02,000\nHello\n"))
+		},
+	}))
+	defer srv.Close()
 
-		client := &Client{
-			APIURL: server.URL,
-			HTTPClient: &http.Client{
-				Transport: server.Client().Transport,
-			},
-		}
+	c := newTestClient(srv)
+	data, err := c.Fetch(context.Background(), "/media/Breaking.Bad.S01E01.1080p.WEB.mkv", "en")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if !strings.Contains(string(data), "Hello") {
+		t.Fatalf("expected subtitle body, got %q", string(data))
+	}
+	if !sawUA {
+		t.Fatal("expected a User-Agent header to be sent")
+	}
+}
 
-		data, err := client.Fetch(ctx, "/media/movie.mkv", "en")
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+func TestFetchSkipsIncompleteSubtitle(t *testing.T) {
+	// Only an incomplete subtitle is offered; Fetch must not return it.
+	srv := httptest.NewServer(router(t, map[string]http.HandlerFunc{
+		"/shows/search/Breaking Bad": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"shows":[{"id":"show-uuid","name":"Breaking Bad","seasons":[1]}]}`))
+		},
+		"/subtitles/get/show-uuid/1/1/en": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"matchingSubtitles":[{"subtitleId":"a","completed":false,"downloadUri":"/subtitles/download/a"}]}`))
+		},
+	}))
+	defer srv.Close()
 
-		if string(data) != "subtitle-data" {
-			t.Fatalf("expected subtitle data, got %q", string(data))
-		}
-	})
+	c := newTestClient(srv)
+	if _, err := c.Fetch(context.Background(), "/media/Breaking.Bad.S01E01.mkv", "en"); err == nil {
+		t.Fatal("expected error when only incomplete subtitles are available")
+	}
+}
 
-	t.Run("invalid base url", func(t *testing.T) {
-		client := &Client{
-			APIURL:     "http://[::1",
-			HTTPClient: &http.Client{},
-		}
+func TestFetchMovieUnsupported(t *testing.T) {
+	// A movie file must be rejected without any HTTP call.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no request expected for a movie, got %s", r.URL.Path)
+	}))
+	defer srv.Close()
 
-		_, err := client.Fetch(ctx, "/media/movie.mkv", "en")
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
+	c := newTestClient(srv)
+	_, err := c.Fetch(context.Background(), "/media/Inception (2010).mkv", "en")
+	if err == nil {
+		t.Fatal("expected error for a movie file")
+	}
+	if !strings.Contains(err.Error(), "only TV episodes") {
+		t.Fatalf("expected TV-only error, got %v", err)
+	}
+}
 
-	t.Run("transport error", func(t *testing.T) {
-		transportErr := errors.New("transport failure")
-		client := &Client{
-			APIURL: "https://example.invalid",
-			HTTPClient: &http.Client{
-				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-					return nil, transportErr
-				}),
-			},
-		}
-
-		_, err := client.Fetch(ctx, "/media/movie.mkv", "en")
-		if !errors.Is(err, transportErr) {
-			t.Fatalf("expected transport error, got %v", err)
-		}
-	})
-
-	t.Run("non-200 status", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+func TestFetchShowNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/shows/search/") {
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = io.WriteString(w, "not found")
-		}))
-		defer server.Close()
-
-		client := &Client{
-			APIURL: server.URL,
-			HTTPClient: &http.Client{
-				Transport: server.Client().Transport,
-			},
+			return
 		}
+		t.Fatalf("unexpected path %q after show 404", r.URL.Path)
+	}))
+	defer srv.Close()
 
-		_, err := client.Fetch(ctx, "/media/movie.mkv", "en")
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
+	c := newTestClient(srv)
+	if _, err := c.Fetch(context.Background(), "/media/No.Such.Show.S01E01.mkv", "en"); err == nil {
+		t.Fatal("expected error when the show is not found")
+	}
+}
+
+func TestFetchPrefersSeasonMatchingShow(t *testing.T) {
+	// Two shows share a name; only the second lists season 3. The
+	// season-matching show is ordered first, so the other is never queried.
+	srv := httptest.NewServer(router(t, map[string]http.HandlerFunc{
+		"/shows/search/The Office": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"shows":[
+				{"id":"uk","name":"The Office","seasons":[1,2]},
+				{"id":"us","name":"The Office","seasons":[1,2,3,4,5]}
+			]}`))
+		},
+		"/subtitles/get/us/3/2/en": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"matchingSubtitles":[{"subtitleId":"z","completed":true,"downloadUri":"/subtitles/download/z"}]}`))
+		},
+		"/subtitles/download/z": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("SRT"))
+		},
+		"/subtitles/get/uk/3/2/en": func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("season-matching show should be tried first; uk should not be queried")
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	data, err := c.Fetch(context.Background(), "/media/The.Office.S03E02.mkv", "en")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if string(data) != "SRT" {
+		t.Fatalf("expected SRT body, got %q", string(data))
+	}
+}
+
+func TestFetchTransportError(t *testing.T) {
+	transportErr := errors.New("transport failure")
+	c := &Client{
+		APIURL: "https://example.invalid",
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, transportErr
+			}),
+		},
+	}
+	_, err := c.Fetch(context.Background(), "/media/Breaking.Bad.S01E01.mkv", "en")
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+func TestListSubtitles404IsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	subs, err := c.listSubtitles(context.Background(), "show-uuid", 1, 1, "en")
+	if err != nil {
+		t.Fatalf("expected 404 to be treated as empty, got error %v", err)
+	}
+	if len(subs) != 0 {
+		t.Fatalf("expected no subtitles, got %d", len(subs))
+	}
 }


### PR DESCRIPTION
## Summary

Replaces the `gestdown` **stub** (which GET a fictional `api.gestdown.com/subtitles/{file}/{lang}`) with a **real, keyless integration** against the [gestdown.info](https://www.gestdown.info) REST API — a free proxy over Addic7ed's TV-subtitle catalogue. First provider of the Phase 1 provider build-out (`docs/PROVIDER_BUILDOUT_PROMPT.md`).

## How it works

Addic7ed indexes by **show / season / episode**, not by file hash, so the provider works within the filename-only `Fetch(ctx, mediaPath, lang)` interface by:

1. Parsing the file name into `(series, season, episode)` via `pkg/metadata.ParseFileName` (pure regex — no network, no keys).
2. Resolving the show via `GET /shows/search/{name}`, preferring a candidate whose season list covers the target season.
3. Listing completed subtitles via `GET /subtitles/get/{showId}/{season}/{episode}/{lang}`.
4. Downloading the first completed match via the returned `downloadUri`.

Movies are rejected — Gestdown/Addic7ed is TV-only.

## API contract

Confirmed **end-to-end against the live API** and cross-checked against the subliminal reference implementation:
- `GET /shows/search/{name}` → `{"shows":[{id,name,seasons,...}]}`
- `GET /subtitles/get/{id}/{season}/{episode}/{lang}` → `{"matchingSubtitles":[{subtitleId,completed,downloadUri,...}]}` (lang accepts `en`/`eng`/`English`)
- `GET {downloadUri}` → raw SRT bytes

## Tests

httptest-mocked (no live network, no secrets): happy path, incomplete-subtitle skip, movie rejection, show-not-found, season-preference ordering, transport error, and 404→empty listing.

## Also

Records in `docs/BAZARR_PARITY_STATUS.md` that the `opensubtitlescom` package is still a **fictional stub** despite the build-out prompt calling it "already implemented" — so the Phase 2 credential work trusts the code over the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)