### PR TITLE
feat(providers): implement real keyless Podnapisi provider

### DIFF
--- a/changelog.d/feat-podnapisi-provider.md
+++ b/changelog.d/feat-podnapisi-provider.md
@@ -1,0 +1,20 @@
+<!-- file: changelog.d/feat-podnapisi-provider.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f23258f8-e811-4f3e-b361-b0365bb9b8b0 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Added
+
+#### Real keyless Podnapisi provider (movies and TV)
+
+The `podnapisi` provider now talks to podnapisi.net's public advanced-search
+JSON API instead of the previous stub that hit a fictional
+`api.podnapisi.com/subtitles/{file}/{lang}` endpoint. Podnapisi indexes by
+title/season/episode (TV) or title/year (movies) rather than by file hash, so
+the provider parses the media file name via `pkg/metadata`, queries
+`/subtitles/search/advanced` with the matching `movie_type`, selects the first
+result whose media type matches, and downloads `/{id}/download?container=zip` —
+extracting the subtitle from the returned ZIP archive. Unlike the TV-only
+Gestdown provider, Podnapisi covers both movies and TV episodes. No account or
+API key is required. The request shape and ISO 639-1 language code were verified
+against subliminal's recorded API cassettes.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.6.0 -->
+<!-- version: 1.7.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-23 -->
+<!-- last-edited: 2026-07-24 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -18,7 +18,8 @@ plumbing exists but the behaviour is not wired into the live path.
 GETs a fictional `https://api.<name>.com/subtitles/<file>/<lang>` endpoint
 (`pkg/providers/*/*.go`). Real integrations: **opensubtitles** (hash + REST),
 **napiprojekt** (keyless hash protocol), **gestdown** (keyless Addic7ed REST
-proxy, TV-only), plus **embedded** (ffmpeg track extraction) and the
+proxy, TV-only), **podnapisi** (keyless advanced-search JSON API, movies + TV),
+plus **embedded** (ffmpeg track extraction) and the
 configurable **generic** / **whisper** HTTP pass-throughs. Bazarr's provider
 breadth comes from Python's `subliminal`; porting dozens of real scrapers to Go
 is a large, separate effort.
@@ -35,11 +36,12 @@ is a large, separate effort.
 Porting the remaining stubs splits into three buckets:
 
 - **Keyless / anonymous (implementable & unit-testable now):** hash- or
-  anonymous-search services that need no account. `napiprojekt` (hash protocol)
-  and `gestdown` (Addic7ed REST proxy, filename→episode via `pkg/metadata`) are
-  done as the reference implementations. A handful of others are theoretically keyless but
-  rely on **fragile HTML scraping of live sites** (e.g. `podnapisi`,
-  `yifysubtitles`, `subscene`), which cannot be implemented correctly or tested
+  anonymous-search services that need no account. `napiprojekt` (hash protocol),
+  `gestdown` (Addic7ed REST proxy, filename→episode via `pkg/metadata`), and
+  `podnapisi` (advanced-search JSON API, movies + TV) are done as the reference
+  implementations. A handful of others are theoretically keyless but
+  rely on **fragile HTML scraping of live sites** (e.g. `yifysubtitles`,
+  `subscene`), which cannot be implemented correctly or tested
   offline without replicating each site's exact markup — high effort, brittle.
 - **Credential-gated (BLOCKED — needs the operator):** the majority require an
   account, API key, or paid tier the agent cannot obtain — e.g. `addic7ed`,
@@ -51,7 +53,8 @@ Porting the remaining stubs splits into three buckets:
   be scoped deliberately, provider by provider.
 
 **Net:** automatic search/download works through **opensubtitles**,
-**napiprojekt**, and **gestdown** (TV episodes) today; `embedded` covers muxed
+**napiprojekt**, **gestdown** (TV episodes), and **podnapisi** (movies + TV)
+today; `embedded` covers muxed
 tracks. Going materially further
 requires either operator-supplied credentials or a deliberate, funded scraping
 effort — it is not fully achievable autonomously.

--- a/pkg/providers/podnapisi/podnapisi.go
+++ b/pkg/providers/podnapisi/podnapisi.go
@@ -1,41 +1,241 @@
 // file: pkg/providers/podnapisi/podnapisi.go
+// version: 2.0.0
+// guid: 1dc059b8-703d-4392-9b37-b0fb79f8eabe
+// last-edited: 2026-07-24
+
+// Package podnapisi implements a real, keyless subtitle provider for
+// podnapisi.net using its public advanced-search JSON API.
+//
+// Podnapisi indexes subtitles by title, season, and episode (for TV) or title
+// and year (for movies) rather than by file hash, so Fetch parses the media
+// file name into a (title, type, season, episode, year) tuple via pkg/metadata,
+// queries /subtitles/search/advanced, selects the first result whose media type
+// matches, and downloads it. Downloads arrive as a ZIP archive, so Fetch
+// extracts the subtitle file from the archive before returning it.
+//
+// No account or API key is required: the search endpoint only needs an
+// Accept: application/json header, and the download endpoint is public.
 package podnapisi
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/metadata"
 )
 
+// defaultAPIURL is the public Podnapisi subtitles base URL. Both the search
+// endpoint ("/search/advanced") and download endpoint ("/{id}/download") hang
+// off it.
+const defaultAPIURL = "https://www.podnapisi.net/subtitles"
+
+// subtitleExtensions are the archive entries Fetch treats as subtitle files
+// when no ".srt" entry is present.
+var subtitleExtensions = []string{".srt", ".ass", ".ssa", ".vtt", ".sub", ".txt"}
+
+// Client implements the providers.Provider interface for podnapisi.net.
 type Client struct {
-	APIURL     string
+	// APIURL is the base URL of the Podnapisi subtitles API (overridable for tests).
+	APIURL string
+	// HTTPClient is used to make requests.
 	HTTPClient *http.Client
+	// UserAgent is sent with every request; some Podnapisi edges reject empty agents.
+	UserAgent string
 }
 
+// New returns a Client configured with reasonable defaults.
 func New() *Client {
 	return &Client{
-		APIURL:     "https://api.podnapisi.com",
-		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		APIURL:     defaultAPIURL,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		UserAgent:  "subtitle-manager",
 	}
 }
 
+// searchResponse is the /search/advanced response envelope.
+type searchResponse struct {
+	Data     []result `json:"data"`
+	Page     int      `json:"page"`
+	AllPages int      `json:"all_pages"`
+}
+
+// result mirrors one entry of the search "data" array. Only the fields Fetch
+// needs are decoded.
+type result struct {
+	ID       string      `json:"id"`
+	Language string      `json:"language"`
+	Movie    resultMovie `json:"movie"`
+}
+
+// resultMovie carries the media-type discriminator ("movie", "tv-series", or
+// "mini-series") used to reject entries of the wrong kind.
+type resultMovie struct {
+	Type string `json:"type"`
+}
+
+// Fetch downloads a subtitle for the media described by mediaPath in lang.
+// It returns the subtitle bytes or an error when the file name cannot be
+// parsed, no matching subtitle is found, or the archive holds no subtitle file.
+//
+// lang is forwarded to Podnapisi as-is: the API expects the ISO 639-1 code
+// ("en"), which is exactly what the scanner passes (verified against
+// subliminal's recorded requests), so no code conversion is performed.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	name := filepath.Base(mediaPath)
-	url := fmt.Sprintf("%s/subtitles/%s/%s", c.APIURL, name, lang)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	info, err := metadata.ParseFileName(mediaPath)
+	if err != nil {
+		return nil, fmt.Errorf("podnapisi: parse file name: %w", err)
+	}
+	if strings.TrimSpace(info.Title) == "" {
+		return nil, fmt.Errorf("podnapisi: could not determine title from %q", mediaPath)
+	}
+
+	res, err := c.search(ctx, info, lang)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.HTTPClient.Do(req)
+	if res.ID == "" {
+		return nil, fmt.Errorf("podnapisi: no subtitle found for %q (%s)", mediaPath, lang)
+	}
+	return c.download(ctx, res.ID)
+}
+
+// search queries the advanced-search endpoint and returns the first result
+// whose media type matches the parsed file. The server filters by language,
+// season, and episode, but the type check guards against a movie result being
+// returned for an episode query (and vice versa).
+func (c *Client) search(ctx context.Context, info *metadata.MediaInfo, lang string) (result, error) {
+	q := url.Values{}
+	q.Set("keywords", info.Title)
+	q.Set("language", lang)
+	if info.Type == metadata.TypeEpisode {
+		q.Set("seasons", strconv.Itoa(info.Season))
+		q.Set("episodes", strconv.Itoa(info.Episode))
+		// Podnapisi distinguishes full series from mini-series; request both so
+		// either kind of TV entry matches.
+		q.Add("movie_type", "tv-series")
+		q.Add("movie_type", "mini-series")
+	} else {
+		q.Set("movie_type", "movie")
+		if info.Year > 0 {
+			q.Set("year", strconv.Itoa(info.Year))
+		}
+	}
+
+	resp, err := c.get(ctx, "/search/advanced?"+q.Encode())
+	if err != nil {
+		return result{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return result{}, fmt.Errorf("podnapisi: search: status %d", resp.StatusCode)
+	}
+	var out searchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return result{}, fmt.Errorf("podnapisi: decode search: %w", err)
+	}
+
+	wantMovie := info.Type == metadata.TypeMovie
+	for _, r := range out.Data {
+		if r.ID == "" {
+			continue
+		}
+		if (r.Movie.Type == "movie") != wantMovie {
+			continue
+		}
+		return r, nil
+	}
+	return result{}, nil
+}
+
+// download fetches the subtitle archive for id and returns the extracted
+// subtitle bytes. Podnapisi serves a ZIP even for a single subtitle.
+func (c *Client) download(ctx context.Context, id string) ([]byte, error) {
+	resp, err := c.get(ctx, "/"+url.PathEscape(id)+"/download?container=zip")
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+		return nil, fmt.Errorf("podnapisi: download: status %d", resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	archive, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("podnapisi: read archive: %w", err)
+	}
+	return extractSubtitle(archive)
+}
+
+// extractSubtitle returns the bytes of the first subtitle-looking file in a ZIP
+// archive, preferring a ".srt" entry and falling back to any recognised
+// subtitle extension. It errors when the archive is unreadable or holds none.
+func extractSubtitle(archive []byte) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, fmt.Errorf("podnapisi: open archive: %w", err)
+	}
+	var fallback *zip.File
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		lower := strings.ToLower(f.Name)
+		if strings.HasSuffix(lower, ".srt") {
+			return readZipFile(f)
+		}
+		if fallback == nil && hasSubtitleExtension(lower) {
+			fallback = f
+		}
+	}
+	if fallback != nil {
+		return readZipFile(fallback)
+	}
+	return nil, fmt.Errorf("podnapisi: no subtitle file in archive")
+}
+
+// hasSubtitleExtension reports whether name ends with a known subtitle suffix.
+func hasSubtitleExtension(name string) bool {
+	for _, ext := range subtitleExtensions {
+		if strings.HasSuffix(name, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// readZipFile returns the full decompressed contents of a single archive entry.
+func readZipFile(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, fmt.Errorf("podnapisi: open %q in archive: %w", f.Name, err)
+	}
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("podnapisi: read %q in archive: %w", f.Name, err)
+	}
+	return b, nil
+}
+
+// get issues a GET against the Podnapisi API, joining path onto APIURL and
+// attaching the configured User-Agent and a JSON Accept header (the search
+// endpoint returns HTML unless application/json is requested).
+func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.APIURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return c.HTTPClient.Do(req)
 }

--- a/pkg/providers/podnapisi/podnapisi_test.go
+++ b/pkg/providers/podnapisi/podnapisi_test.go
@@ -1,31 +1,218 @@
+// file: pkg/providers/podnapisi/podnapisi_test.go
+// version: 2.0.0
+// guid: 807c1ff7-3f08-41a0-9fc1-ceb5f3584e3b
+// last-edited: 2026-07-24
+
 package podnapisi
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestClientFetch(t *testing.T) {
-	var gotURL string
+// newTestClient returns a Client pointed at srv with its transport.
+func newTestClient(srv *httptest.Server) *Client {
+	return &Client{
+		APIURL:     srv.URL,
+		HTTPClient: srv.Client(),
+		UserAgent:  "subtitle-manager-test",
+	}
+}
+
+// zipWith builds an in-memory ZIP archive containing the given name→content
+// files, mirroring how Podnapisi serves downloads.
+func zipWith(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestNewDefaults(t *testing.T) {
+	c := New()
+	if c.APIURL != "https://www.podnapisi.net/subtitles" {
+		t.Fatalf("unexpected default APIURL %q", c.APIURL)
+	}
+	if c.HTTPClient == nil {
+		t.Fatal("expected HTTP client")
+	}
+	if c.UserAgent == "" {
+		t.Fatal("expected a non-empty default User-Agent")
+	}
+}
+
+func TestFetchEpisode(t *testing.T) {
+	const srt = "1\n00:00:01,000 --> 00:00:02,000\nhello\n"
+	var gotSearch, gotDownload *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		fmt.Fprint(w, "data")
+		switch {
+		case r.URL.Path == "/search/advanced":
+			gotSearch = r
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"page":1,"all_pages":1,"data":[
+				{"id":"2581","language":"en","movie":{"type":"tv-series"}}
+			]}`))
+		case strings.HasSuffix(r.URL.Path, "/download"):
+			gotDownload = r
+			_, _ = w.Write(zipWith(t, map[string]string{"the.big.bang.theory.s07e05.srt": srt}))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
 	}))
 	defer srv.Close()
 
-	c := New()
-	c.APIURL = srv.URL
-	b, err := c.Fetch(context.Background(), "/path/movie.mkv", "en")
+	c := newTestClient(srv)
+	data, err := c.Fetch(context.Background(), "The.Big.Bang.Theory.S07E05.1080p.BluRay.x264.mkv", "en")
 	if err != nil {
-		t.Fatalf("fetch: %v", err)
+		t.Fatalf("Fetch: %v", err)
 	}
-	if string(b) != "data" {
-		t.Fatalf("unexpected body: %s", b)
+	if string(data) != srt {
+		t.Fatalf("subtitle bytes = %q, want %q", data, srt)
 	}
-	if gotURL != "/subtitles/movie.mkv/en" {
-		t.Fatalf("unexpected url: %s", gotURL)
+
+	// Verify the episode search parameters.
+	q := gotSearch.URL.Query()
+	if !strings.Contains(strings.ToLower(q.Get("keywords")), "big bang") {
+		t.Fatalf("keywords = %q, want the series title", q.Get("keywords"))
+	}
+	if q.Get("language") != "en" {
+		t.Fatalf("language = %q, want en", q.Get("language"))
+	}
+	if q.Get("seasons") != "7" || q.Get("episodes") != "5" {
+		t.Fatalf("seasons/episodes = %q/%q, want 7/5", q.Get("seasons"), q.Get("episodes"))
+	}
+	if types := q["movie_type"]; len(types) != 2 || types[0] != "tv-series" || types[1] != "mini-series" {
+		t.Fatalf("movie_type = %v, want [tv-series mini-series]", types)
+	}
+	if gotSearch.Header.Get("Accept") != "application/json" {
+		t.Fatalf("Accept = %q, want application/json", gotSearch.Header.Get("Accept"))
+	}
+
+	// Verify the download requested a zip container for the selected id.
+	if !strings.Contains(gotDownload.URL.Path, "2581") {
+		t.Fatalf("download path %q missing subtitle id", gotDownload.URL.Path)
+	}
+	if gotDownload.URL.Query().Get("container") != "zip" {
+		t.Fatalf("download container = %q, want zip", gotDownload.URL.Query().Get("container"))
+	}
+}
+
+func TestFetchMovie(t *testing.T) {
+	const srt = "movie subtitle"
+	var gotSearch *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/search/advanced":
+			gotSearch = r
+			_, _ = w.Write([]byte(`{"page":1,"all_pages":1,"data":[
+				{"id":"99","language":"en","movie":{"type":"movie"}}
+			]}`))
+		case strings.HasSuffix(r.URL.Path, "/download"):
+			_, _ = w.Write(zipWith(t, map[string]string{"inception.srt": srt}))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	data, err := c.Fetch(context.Background(), "Inception (2010).mkv", "en")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(data) != srt {
+		t.Fatalf("subtitle bytes = %q, want %q", data, srt)
+	}
+	q := gotSearch.URL.Query()
+	if q.Get("movie_type") != "movie" {
+		t.Fatalf("movie_type = %q, want movie", q.Get("movie_type"))
+	}
+	if q.Get("year") != "2010" {
+		t.Fatalf("year = %q, want 2010", q.Get("year"))
+	}
+	if q.Get("seasons") != "" || q.Get("episodes") != "" {
+		t.Fatal("movie query must not set seasons/episodes")
+	}
+}
+
+func TestFetchNoResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"page":1,"all_pages":1,"data":[]}`))
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).Fetch(context.Background(), "Show.S01E01.mkv", "en")
+	if err == nil || !strings.Contains(err.Error(), "no subtitle found") {
+		t.Fatalf("expected no-subtitle error, got %v", err)
+	}
+}
+
+func TestFetchTypeMismatchSkipped(t *testing.T) {
+	// An episode query that only returns a movie result must find no match
+	// rather than downloading the wrong media type.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/advanced" {
+			t.Fatalf("download must not be attempted; got path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"page":1,"all_pages":1,"data":[
+			{"id":"7","language":"en","movie":{"type":"movie"}}
+		]}`))
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).Fetch(context.Background(), "Show.S01E01.mkv", "en")
+	if err == nil || !strings.Contains(err.Error(), "no subtitle found") {
+		t.Fatalf("expected no-subtitle error for type mismatch, got %v", err)
+	}
+}
+
+func TestFetchSearchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).Fetch(context.Background(), "Show.S01E01.mkv", "en")
+	if err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("expected status 500 error, got %v", err)
+	}
+}
+
+func TestExtractSubtitlePrefersSrt(t *testing.T) {
+	archive := zipWith(t, map[string]string{
+		"readme.txt": "ignore me",
+		"movie.srt":  "the real subtitle",
+		"movie.nfo":  "not a subtitle",
+	})
+	data, err := extractSubtitle(archive)
+	if err != nil {
+		t.Fatalf("extractSubtitle: %v", err)
+	}
+	if string(data) != "the real subtitle" {
+		t.Fatalf("got %q, want the .srt content", data)
+	}
+}
+
+func TestExtractSubtitleNone(t *testing.T) {
+	archive := zipWith(t, map[string]string{"cover.jpg": "binary"})
+	if _, err := extractSubtitle(archive); err == nil {
+		t.Fatal("expected error when archive holds no subtitle file")
 	}
 }


### PR DESCRIPTION
## Summary

Replaces the fictional-endpoint `podnapisi` **stub** with a real, keyless subtitle provider backed by podnapisi.net's public advanced-search JSON API. Continues the provider build-out phase (`docs/PROVIDER_BUILDOUT_PROMPT.md`) after Gestdown (#2201).

Unlike the TV-only Gestdown provider, **Podnapisi covers both movies and TV episodes**, and no account or API key is required.

## How it works

- Parse the media file name via `pkg/metadata` → `(title, type, season, episode, year)`.
- `GET /subtitles/search/advanced` with `Accept: application/json` and the matching `movie_type` (`tv-series` + `mini-series` for episodes, `movie` for films).
- Select the first `data[]` result whose `movie.type` matches the requested media kind (guards against a movie result for an episode query).
- `GET /{id}/download?container=zip` → the subtitle arrives as a **ZIP**, so the provider extracts the subtitle file (preferring `.srt`) from the archive.

## Verification, not guessing

The request shape (repeated `movie_type` params, **ISO 639-1** `language=en`) and the response schema were confirmed against subliminal's recorded VCR cassettes and its provider source — not inferred from the stub. This corrected two things a naïve port would have gotten wrong: the language code format (alpha-2, not alpha-3) and the zip-wrapped download.

## Docs

`docs/BAZARR_PARITY_STATUS.md` previously listed `podnapisi` under *fragile HTML scraping* — that was wrong; its JSON API is keyless. Moved it into the implemented-keyless bucket alongside `napiprojekt` and `gestdown`.

## Tests

httptest-mocked (`go test ./pkg/providers/podnapisi/` — 8 tests, all pass): episode search + param assertions, movie search (`movie_type=movie` + `year`), zip download/extract, no-result, episode/movie type-mismatch skip, search error, and `.srt` preference in the archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
