### PR TITLE
chore(deps): migrate gcommon consumption to BSR-generated SDK

### DIFF
--- a/changelog.d/chore-gcommon-bsr-sdk.md
+++ b/changelog.d/chore-gcommon-bsr-sdk.md
@@ -1,0 +1,17 @@
+<!-- file: changelog.d/chore-gcommon-bsr-sdk.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 40ded265-0b30-4305-94f6-3971174427d8 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Changed
+
+#### gcommon protobuf consumption moved to the Buf Schema Registry SDK
+
+subtitle-manager now pulls the generated gcommon protobuf/gRPC code from the
+Buf Schema Registry (`buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go` and
+`.../grpc/go`) instead of the hand-maintained `github.com/falkcorp/gcommon/v2`
+Go module. This is the intended distribution model now that gcommon is a
+protos-only repository published to `buf.build/falkcorp/gcommon`. Message and
+service types are unchanged; the only difference is that BSR splits messages and
+gRPC service stubs into separate packages. No configuration is required — the
+BSR modules verify against the public Go checksum database.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/jdfalk/subtitle-manager
 go 1.25.0
 
 require (
+	buf.build/gen/go/falkcorp/gcommon/grpc/go v1.6.2-20260724201220-436a1c85f680.1
+	buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go v1.36.11-20260724201220-436a1c85f680.1
 	cloud.google.com/go/storage v1.60.0
 	cloud.google.com/go/translate v1.12.7
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
@@ -11,7 +13,6 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
-	github.com/falkcorp/gcommon/v2 v2.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/lib/pq v1.11.1
@@ -86,6 +87,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260709200747-435963d16310.1 h1:fXh8CsdNpjRr8R5vFdqtIxPt/Lno2IIJlYOdZBIZn0w=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260709200747-435963d16310.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
+buf.build/gen/go/falkcorp/gcommon/grpc/go v1.6.2-20260724201220-436a1c85f680.1 h1:E9vOWFKEGcXyW/Yu8A3Gq1EqlYY/GZvABCfSH9co00A=
+buf.build/gen/go/falkcorp/gcommon/grpc/go v1.6.2-20260724201220-436a1c85f680.1/go.mod h1:nvBXUUm68exBwtYaie7LA6tQ7nVDKXN9R8aiit7PAiA=
+buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go v1.36.11-20260724201220-436a1c85f680.1 h1:lAE0Iw/BvAX7HaGEc4YcCgZdxMKfYLDlBjQr02eebrw=
+buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go v1.36.11-20260724201220-436a1c85f680.1/go.mod h1:dtDgw7/U0x0zlqnHmzIZxPSFrriuxqHEdeD0sYJUpWc=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
@@ -119,8 +123,6 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/falkcorp/gcommon/v2 v2.2.0 h1:JA2M4TjrzLGKDiE0t4Zi4bQ2pF4Q32BkfnuqaLRUU0w=
-github.com/falkcorp/gcommon/v2 v2.2.0/go.mod h1:wcMCkqihnHMbpQ2lDDk1UqLbk/k8lySxTUxS5QyZ+FA=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/authserver/oauth_flow_test.go
+++ b/pkg/authserver/oauth_flow_test.go
@@ -1,5 +1,5 @@
 // file: pkg/authserver/oauth_flow_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: e8f7d6c5-b4a3-9281-7f6e-5d4c3b2a1908
 
 package authserver
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
-	authpb "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	authpb "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	gauth "github.com/jdfalk/subtitle-manager/pkg/gcommonauth"
 	"github.com/jdfalk/subtitle-manager/pkg/testutil"
 )

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -1,5 +1,5 @@
 // file: pkg/authserver/server.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: d14bd9a1-4b55-4b57-bffc-4adc165ebd1a
 
 package authserver
@@ -10,16 +10,17 @@ import (
 	"strconv"
 	"time"
 
-	authpb "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	commongrpc "buf.build/gen/go/falkcorp/gcommon/grpc/go/commonpb/v2/commonv2grpc"
+	authpb "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	gauth "github.com/jdfalk/subtitle-manager/pkg/gcommonauth"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Server implements authpb.AuthServiceServer using the local database
+// Server implements commongrpc.AuthServiceServer using the local database
 // and gcommonauth helpers.
 type Server struct {
 	DB *sql.DB
-	authpb.UnimplementedAuthServiceServer
+	commongrpc.UnimplementedAuthServiceServer
 }
 
 // NewServer creates a new Server instance.

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -1,5 +1,5 @@
 // file: pkg/authserver/server_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: c5c8d260-2641-45dc-80d2-4dbb941bdb7e
 
 package authserver
@@ -8,7 +8,7 @@ import (
 	"context"
 	"testing"
 
-	authpb "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	authpb "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	gauth "github.com/jdfalk/subtitle-manager/pkg/gcommonauth"
 	"github.com/jdfalk/subtitle-manager/pkg/testutil"
 )

--- a/pkg/backups/service_test.go
+++ b/pkg/backups/service_test.go
@@ -1,5 +1,5 @@
 // file: pkg/backups/service_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 123e4567-e89b-12d3-a456-426614174012
 
 package backups
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
 )

--- a/pkg/cache/proto.go
+++ b/pkg/cache/proto.go
@@ -1,11 +1,11 @@
 // file: pkg/cache/proto.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 94a9a33b-5e6e-4b6c-9c34-24e2f5a1e3a1
 
 package cache
 
 import (
-	commonpb "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	commonpb "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,5 +1,5 @@
 // file: pkg/config/config_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: b1c2d3e4-f5g6-h7i8-j9k0-l1m2n3o4p5q6
 
 package config
@@ -7,7 +7,7 @@ package config
 import (
 	"testing"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 )
 
 func TestLogLevelMigration(t *testing.T) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,5 +1,5 @@
 // file: pkg/config/types.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6
 
 package config
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 )
 
 // LogLevel is now an alias for gcommon LogLevel to maintain compatibility

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -52,7 +52,7 @@ import (
 	"strconv"
 	"time"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/database/migration_test.go
+++ b/pkg/database/migration_test.go
@@ -1,5 +1,5 @@
 // file: pkg/database/migration_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 7b4d4003-442f-4395-b208-c375162f6fea
 
 package database
@@ -7,7 +7,7 @@ package database
 import (
 	"testing"
 
-	database "github.com/falkcorp/gcommon/v2/pkg/databasepb/v2"
+	database "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/databasepb/v2"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/pkg/database/mocks/subtitlestore_mock.go
+++ b/pkg/database/mocks/subtitlestore_mock.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	"time"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	mock "github.com/stretchr/testify/mock"
 )

--- a/pkg/database/pb_conversions.go
+++ b/pkg/database/pb_conversions.go
@@ -1,5 +1,5 @@
 // file: pkg/database/pb_conversions.go
-// version: 4.0.0
+// version: 4.0.1
 // guid: c9cf2d1a-c284-46f4-90d1-70925cbe8b27
 
 package database
@@ -7,7 +7,7 @@ package database
 import (
 	"time"
 
-	database "github.com/falkcorp/gcommon/v2/pkg/databasepb/v2"
+	database "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/databasepb/v2"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/cockroachdb/pebble"
 	"github.com/google/uuid"
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
 	profilesPkg "github.com/jdfalk/subtitle-manager/pkg/profiles"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -1,5 +1,5 @@
 // file: pkg/database/postgres.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 29e61686-4676-4b4a-b4be-b0cb294239a3
 // last-edited: 2026-07-23
 
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	_ "github.com/lib/pq"
 )
 

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -3,7 +3,7 @@ package database
 import (
 	"time"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/jdfalk/subtitle-manager/pkg/profiles"
 )
 

--- a/pkg/gcommon/config/config.go
+++ b/pkg/gcommon/config/config.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommon/config/config.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: af6f4b9b-3c1b-4c2e-99f5-d45e6b7c8d9e
 
 package config
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/pkg/gcommon/config/config_test.go
+++ b/pkg/gcommon/config/config_test.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommon/config/config_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: af6f4b9b-3c1b-4c2e-99f5-d45e6b7c8d9f
 
 package config
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"

--- a/pkg/gcommon/subtitle_format.go
+++ b/pkg/gcommon/subtitle_format.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommon/subtitle_format.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package gcommon
@@ -7,7 +7,7 @@ package gcommon
 import (
 	"strings"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 )
 
 // SubtitleFormatHelper provides utilities for working with gcommon subtitle format enums

--- a/pkg/gcommon/subtitle_format_test.go
+++ b/pkg/gcommon/subtitle_format_test.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommon/subtitle_format_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6e
 
 package gcommon
@@ -7,7 +7,7 @@ package gcommon
 import (
 	"testing"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/gcommonauth/auth.go
+++ b/pkg/gcommonauth/auth.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommonauth/auth.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: ec8f6814-42cc-41ab-956a-a0ee798664a4
 package gcommonauth
 
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/google/uuid"
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/pkg/gcommonlog/logrus_provider.go
+++ b/pkg/gcommonlog/logrus_provider.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommonlog/logrus_provider.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: a1e4bca3-27a2-4e4a-9d4c-1c2f3b4d5e6f
 
 package gcommonlog
@@ -8,7 +8,7 @@ import (
 	"context"
 	"io"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/gcommonlog/logrus_provider_test.go
+++ b/pkg/gcommonlog/logrus_provider_test.go
@@ -1,5 +1,5 @@
 // file: pkg/gcommonlog/logrus_provider_test.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: 3456b7c8-9d0e-4f12-8b34-5a6c7d8e9f01
 package gcommonlog
 
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	common "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 )
 
 // TestLogrusProvider verifies that the provider writes log messages and fields.

--- a/pkg/media/client.go
+++ b/pkg/media/client.go
@@ -1,5 +1,5 @@
 // file: pkg/media/client.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 789e4567-e89b-12d3-a456-426614174111
 
 // Package media provides client implementations for media processing services
@@ -13,15 +13,16 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	mediapb "github.com/falkcorp/gcommon/v2/pkg/mediapb/v2"
+	mediagrpc "buf.build/gen/go/falkcorp/gcommon/grpc/go/mediapb/v2/mediav2grpc"
+	mediapb "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/mediapb/v2"
 )
 
 // Client wraps gRPC clients for media services
 type Client struct {
-	mediaService      mediapb.MediaServiceClient
-	subtitleService   mediapb.SubtitleServiceClient
-	processingService mediapb.MediaProcessingServiceClient
-	audioService      mediapb.AudioServiceClient
+	mediaService      mediagrpc.MediaServiceClient
+	subtitleService   mediagrpc.SubtitleServiceClient
+	processingService mediagrpc.MediaProcessingServiceClient
+	audioService      mediagrpc.AudioServiceClient
 	conn              *grpc.ClientConn
 }
 
@@ -33,10 +34,10 @@ func NewClient(serverAddr string) (*Client, error) {
 	}
 
 	return &Client{
-		mediaService:      mediapb.NewMediaServiceClient(conn),
-		subtitleService:   mediapb.NewSubtitleServiceClient(conn),
-		processingService: mediapb.NewMediaProcessingServiceClient(conn),
-		audioService:      mediapb.NewAudioServiceClient(conn),
+		mediaService:      mediagrpc.NewMediaServiceClient(conn),
+		subtitleService:   mediagrpc.NewSubtitleServiceClient(conn),
+		processingService: mediagrpc.NewMediaProcessingServiceClient(conn),
+		audioService:      mediagrpc.NewAudioServiceClient(conn),
 		conn:              conn,
 	}, nil
 }

--- a/pkg/media/server.go
+++ b/pkg/media/server.go
@@ -1,5 +1,5 @@
 // file: pkg/media/server.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d
 
 package media
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"time"
 
+	mediagrpc "buf.build/gen/go/falkcorp/gcommon/grpc/go/mediapb/v2/mediav2grpc"
+	media "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/mediapb/v2"
 	"github.com/asticode/go-astisub"
 	"github.com/google/uuid"
-	media "github.com/falkcorp/gcommon/v2/pkg/mediapb/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -28,13 +29,13 @@ import (
 
 // MediaServiceServer implements the media service gRPC server
 type MediaServiceServer struct {
-	media.UnimplementedMediaServiceServer
+	mediagrpc.UnimplementedMediaServiceServer
 	fileStorage *FileStorage
 }
 
 // SubtitleServiceServer implements the subtitle service gRPC server
 type SubtitleServiceServer struct {
-	media.UnimplementedSubtitleServiceServer
+	mediagrpc.UnimplementedSubtitleServiceServer
 	fileStorage *FileStorage
 }
 
@@ -589,10 +590,10 @@ func (s *MediaServiceServer) UploadMedia(ctx context.Context, req *media.UploadM
 
 // NewServer creates a new server instance
 type Server struct {
-	media.UnimplementedMediaServiceServer
-	media.UnimplementedSubtitleServiceServer
-	media.UnimplementedMediaProcessingServiceServer
-	media.UnimplementedAudioServiceServer
+	mediagrpc.UnimplementedMediaServiceServer
+	mediagrpc.UnimplementedSubtitleServiceServer
+	mediagrpc.UnimplementedMediaProcessingServiceServer
+	mediagrpc.UnimplementedAudioServiceServer
 
 	// Configuration
 	mediaRoot    string

--- a/pkg/metrics/metrics_gcommon.go
+++ b/pkg/metrics/metrics_gcommon.go
@@ -1,7 +1,7 @@
 //go:build gcommonmetrics
 
 // file: pkg/metrics/metrics_gcommon.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5g
 
 package metrics
@@ -9,7 +9,7 @@ package metrics
 import (
 	"context"
 
-	gmetrics "github.com/falkcorp/gcommon/v2/pkg/metricspb/v2"
+	gmetrics "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/metricspb/v2"
 )
 
 var (

--- a/pkg/monitoring/monitor_test.go
+++ b/pkg/monitoring/monitor_test.go
@@ -1,5 +1,5 @@
 // file: pkg/monitoring/monitor_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 12345678-1234-1234-1234-123456789015
 
 package monitoring
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	gcommon "github.com/falkcorp/gcommon/v2/pkg/commonpb/v2"
+	gcommon "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 )
 

--- a/pkg/queue/jobs.go
+++ b/pkg/queue/jobs.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/jobs.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 123e4567-e89b-12d3-a456-426614174001
 package queue
 
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	queue "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2"
+	queue "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/queuepb/v2"
 	jobpb "github.com/jdfalk/subtitle-manager/pkg/jobpb"
 	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
 	"google.golang.org/protobuf/types/known/anypb"

--- a/pkg/queue/mocks/job_mock.go
+++ b/pkg/queue/mocks/job_mock.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	"context"
 
-	queue "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2"
+	queue "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/queuepb/v2"
 	queue0 "github.com/jdfalk/subtitle-manager/pkg/queue"
 	mock "github.com/stretchr/testify/mock"
 )

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/queue_test.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: 123e4567-e89b-12d3-a456-426614174003
 package queue
 
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	gqueue "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2"
+	gqueue "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/queuepb/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Migrates subtitle-manager off the hand-maintained `github.com/falkcorp/gcommon/v2` Go SDK module onto the **BSR-generated SDKs** — the intended distribution model now that gcommon is a protos-only repo published to `buf.build/falkcorp/gcommon`. This is the final step of the gcommon Phase C pivot; once merged, the `gcommon-go` repo can be retired.

## What changed
| | from | to |
|---|---|---|
| messages | `github.com/falkcorp/gcommon/v2/pkg/<pkg>pb/v2` | `buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/<pkg>pb/v2` |
| services | (same package as messages) | `buf.build/gen/go/falkcorp/gcommon/grpc/go/<pkg>pb/v2/<pkg>v2grpc` |

- **25 files** were a pure import-path swap — the generated package names are identical (`commonv2`, `mediav2`, …) and every gcommon import was already aliased, so no identifier churn.
- **3 files** (`pkg/media/client.go`, `pkg/media/server.go`, `pkg/authserver/server.go`) use gRPC service types. BSR splits messages and services into separate modules/packages, so these gained a second `…grpc` import; the 16 service-symbol references were repointed. No behavior change.
- `go.mod`: dropped `github.com/falkcorp/gcommon/v2`, added the two `buf.build/gen/go/...` modules.

## Notes
- BSR modules **verify against the public Go checksum database** — no `GOSUMDB`/`GONOSUMDB` config needed in dev or CI. (An initial 500 from sum.golang.org was transient indexing lag on the freshly-pushed module.)

## Verification
- `go build ./...` ✅
- `go vet` ✅ on all affected packages
- `go test -race` ✅ — `ok` for pkg/media, pkg/authserver, pkg/database, pkg/gcommon(+/config), pkg/queue, pkg/cache, pkg/config, pkg/gcommonlog, pkg/gcommonauth
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)