### PR TITLE
fix(ci): stop regenerating protobuf during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/release.yml
-# version: 2.0.1
+# version: 2.1.0
 # guid: 8b4d6c2a-1f5e-4a8b-9c3d-7e2f5a8b1c4d
+# last-edited: 2026-07-25
 
 name: Release
 
@@ -69,4 +70,10 @@ jobs:
       draft: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.draft == 'true' || false }}
       prerelease: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.prerelease == 'true' }}
       stable: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stable == 'true' || false }}
+      # This repository commits its generated .pb.go files (25 of them, under
+      # pkg/), and `go build ./...` succeeds from a clean checkout. Regenerating
+      # protobuf at release time is therefore redundant, and it broke releases
+      # two ways: the generator needs Go >= 1.25 while the action runs 1.23, and
+      # its output directory left the tree dirty so goreleaser refused to build.
+      protobuf-disabled: true
     secrets: inherit

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.5
+# version: 2.15.0
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
+# last-edited: 2026-07-25
 
 name: Reusable Release Coordinator
 
@@ -59,6 +60,14 @@ on:
         default: false
       protobuf-enabled:
         description: 'Force enable Protobuf builds'
+        required: false
+        type: boolean
+        default: false
+      protobuf-disabled:
+        description: >-
+          Force disable protobuf generation during release. Set this when the
+          repository commits its generated .pb.go files, so regenerating at
+          release time is redundant work that can only introduce skew.
         required: false
         type: boolean
         default: false
@@ -302,12 +311,14 @@ jobs:
           echo "tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
           echo "full-version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
 
-  # Protocol Buffer Generation (if needed)
+  # Protocol Buffer Generation (if needed). Language detection turns this on for
+  # any repo containing .proto files, which is wrong for repos that commit their
+  # generated code — protobuf-disabled opts those out.
   build-protobuf:
     name: Generate Protocol Buffers
     runs-on: ubuntu-latest
     needs: [detect-languages]
-    if: ${{ needs.detect-languages.outputs.protobuf-needed == 'true' }}
+    if: ${{ !inputs.protobuf-disabled && needs.detect-languages.outputs.protobuf-needed == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -321,6 +332,12 @@ jobs:
     name: Build Go Components
     runs-on: ubuntu-latest
     needs: [detect-languages, build-protobuf]
+    # always() is deliberate and must stay: build-protobuf is *skipped* (not
+    # successful) whenever protobuf-disabled is set or no .proto files exist,
+    # and a skipped dependency would otherwise block this job. It is fail-open
+    # with respect to a *failed* build-protobuf, which is safe because the
+    # create-release job below gates on !failure() -- a failed generation can
+    # waste a build here but can never publish a release built on stale protos.
     if: |
       always() &&
       needs.detect-languages.outputs.has-go == 'true' &&
@@ -362,7 +379,7 @@ jobs:
       - name: Build Go
         uses: falkcorp/gha-release-go@e6b2fa793ea1f43d6baee44c77c6047b5abe7f15 # v2.0.1 (GORELEASER_CURRENT_TAG pin)
         with:
-          protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
+          protobuf-artifacts: ${{ !inputs.protobuf-disabled && needs.detect-languages.outputs.protobuf-needed == 'true' }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
           system-packages: ${{ inputs.system-packages }}
           pre-build-script: ${{ inputs.pre-build-script }}
@@ -387,7 +404,7 @@ jobs:
       - name: Build Python
         uses: falkcorp/gha-release-python@f3105cab8ecca34051c16c989cc809b19ae5a297 # v2.0.0
         with:
-          protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
+          protobuf-artifacts: ${{ !inputs.protobuf-disabled && needs.detect-languages.outputs.protobuf-needed == 'true' }}
 
   # Rust Build
   build-rust:
@@ -406,7 +423,7 @@ jobs:
       - name: Build Rust
         uses: falkcorp/gha-release-rust@fcee6b67fc61c0da24d890d850793ccae981ccbf # v2.0.0
         with:
-          protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
+          protobuf-artifacts: ${{ !inputs.protobuf-disabled && needs.detect-languages.outputs.protobuf-needed == 'true' }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
 
   # Frontend Build

--- a/.gitignore
+++ b/.gitignore
@@ -368,6 +368,11 @@ cookies.txt
 # Task logs
 logs/
 
+# Protobuf output staged by release tooling. The generated .pb.go files are
+# committed under pkg/, so anything dropped here is transient; leaving it
+# untracked made goreleaser abort with "git is in a dirty state".
+proto-generated/
+
 # >>> jdfalk managed ignore block (sync-gitignore.py) >>>
 # AI agent scratch / state (may contain PII, machine paths, secrets)
 .claude/notes/

--- a/changelog.d/fix-release-protobuf.md
+++ b/changelog.d/fix-release-protobuf.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/fix-release-protobuf.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 39b3f7ac-f9c8-4b56-b211-f83b7f06bf78 -->
+<!-- last-edited: 2026-07-25 -->
+
+### Fixed
+
+#### Release workflow no longer regenerates protobuf, unbreaking releases
+
+The `Release` workflow had been failing on every push to `main`, so no release
+artifacts were published. Two failures shared one stale assumption — that this
+repository generates its protobuf code at release time:
+
+- `Generate Protocol Buffers` failed with
+  `protoc-gen-go-grpc@v1.6.2 requires go >= 1.25.0 (running go 1.23.12;
+  GOTOOLCHAIN=local)`.
+- `Build Go Components` failed with `git is in a dirty state` because the
+  generator left an untracked `proto-generated/` directory behind, which
+  goreleaser refuses to build over.
+
+Neither step was doing anything useful: the 25 generated `.pb.go` files are
+committed under `pkg/`, and `go build ./...` succeeds from a clean checkout with
+no generation step. The reusable release coordinator gained a
+`protobuf-disabled` input (language detection enables protobuf builds for any
+repository containing `.proto` files, which is wrong when the generated code is
+committed), and `release.yml` now sets it. `proto-generated/` is also gitignored
+so stray generator output can never dirty the tree again.


### PR DESCRIPTION
## Problem

The `Release` workflow has failed on **every** push to `main` for at least the
last three commits (`2e74653d`, `52b8c3a2`, `1416df78`), so no release artifacts
have shipped. `Continuous Integration` is green, which is why this went
unnoticed.

Two jobs failed, from one shared stale assumption — that this repository
generates its protobuf code at release time:

- **`Generate Protocol Buffers`** —
  `protoc-gen-go-grpc@v1.6.2 requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)`
- **`Build Go Components`** — goreleaser aborted with `git is in a dirty state`,
  listing `?? proto-generated/`, output the generator left behind.

## Why the fix is "delete the assumption"

Neither step does anything this repo consumes:

- 25 generated `.pb.go` files are **committed** under `pkg/`.
- `go build ./...` succeeds from a clean checkout with no generation step.
- Since `233be382`, gcommon arrives pre-generated via the Buf Schema Registry.

`detect-languages` infers `protobuf-needed` from the mere presence of `.proto`
files, and that heuristic cannot distinguish "generates at build time" from
"commits generated code". So the fix is an explicit opt-out rather than a
cleverer heuristic.

## Changes

- `reusable-release.yml`: new `protobuf-disabled` workflow input; gates the
  `build-protobuf` job and the `protobuf-artifacts` passed to the Go/Python/Rust
  builds.
- `release.yml`: sets `protobuf-disabled: true`, with a comment recording why.
- `.gitignore`: ignore `proto-generated/` so stray generator output can never
  dirty the tree again. Placed **above** the `sync-gitignore.py` managed block so
  it survives regeneration.

## Decision recorded: `always()` on `build-go` stays

`build-go`/`build-python`/`build-rust` guard on `always()`, which is fail-open
with respect to a *failed* `build-protobuf`. I considered tightening it to
`!cancelled() && needs.build-protobuf.result != 'failure'` and decided against
it: `always()` is **required** for the skip case (a skipped dependency would
otherwise block the job), and the create-release job already gates on
`!failure()` — so a failed generation can waste a build but can never publish a
release built on stale protos. Tightening would only surface the failure earlier
while diverging further from the org-standard workflow shape. Rationale is now a
comment in the file.

## Verification

- `actionlint` passes clean on all workflows.
- `go build ./...` passes from a clean checkout (this is the claim the fix rests on).
- **This PR's CI cannot verify the fix** — `Release` only triggers on push to
  `main`, never on PRs. Confirmation comes from the next push to `main` after
  merge. If it is still red afterward, the residual cause is inside
  `falkcorp/gha-release-go`, a separate repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH