### PR TITLE
feat(arr): rescan Sonarr/Radarr after subtitle download

### DIFF
--- a/changelog.d/feat-arr-rescan.md
+++ b/changelog.d/feat-arr-rescan.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/feat-arr-rescan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7d1320d6-a4d0-48f6-9618-8d06952ece1d -->
+<!-- last-edited: 2026-07-25 -->
+
+### Added
+
+#### Sonarr/Radarr are told to rescan after a subtitle is written
+
+Previously a downloaded subtitle stayed invisible to Sonarr/Radarr until their
+own scheduled disk scan happened to run. subtitle-manager now issues the same
+commands Bazarr does as soon as a subtitle is written or upgraded:
+`RescanSeries`/`seriesId` and `RescanMovie`/`movieId` on `POST /api/v3/command`.
+
+This is enabled by default for any enabled *arr integration, matching Bazarr,
+which notifies unconditionally. Opt out with
+`integrations.sonarr.rescan_after_download: false` (likewise `radarr`).
+
+The new `pkg/arrnotify` package plugs into the existing `events.MultiPublisher`
+as another subscriber, alongside webhooks and notifications. The *arr item id is
+resolved from the media path when the event fires — the *arr's folder listing is
+fetched and cached for five minutes, then matched by longest containing folder.
+Matching runs in subtitle-manager's path space, applying `Filters.MapPath` to the
+*arr's folders rather than trying to invert it, since `MapPath` is
+longest-prefix-wins and not reliably invertible. Ambiguous matches are skipped
+rather than guessed, and any failure is logged and swallowed so a rescan can
+never break the subtitle pipeline that produced it.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.7.0 -->
+<!-- version: 1.8.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-24 -->
+<!-- last-edited: 2026-07-25 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -72,12 +72,12 @@ effort — it is not fully achievable autonomously.
 | Excluded tags / series types | ✅ | `arr.Filters` excluded tags/series-types |
 | Path mappings (arr↔local) applied | ✅ | `arr.Filters.PathMappings` |
 | Webhook on import → search | 🟡 | Sonarr/Radarr/custom + Plex; still hardcoded `en` |
-| Notify *arr to rescan after download | 🔴 | needs media→*arr-id tracking we don't keep |
+| Notify *arr to rescan after download | ✅ | `pkg/arrnotify`; id resolved from path at event time (see note below) |
 
 ### Search / download / upgrade engine
 | Capability | Status | Notes |
 | --- | --- | --- |
-| Provider registry breadth | 🔴 | ~49 stubs; 3 real (opensubtitles, napiprojekt, gestdown) + embedded |
+| Provider registry breadth | 🔴 | ~49 stubs; 4 real (opensubtitles, napiprojekt, gestdown, podnapisi) + embedded |
 | Whisper fallback (transcribe when no provider match) | ✅ | `whisper.fallback_enabled` (`pkg/scanner.whisperFallback`) |
 | Automatic "wanted" search loop (scheduled) | 🟡 | monitor skeleton; score gate now available |
 | Manual search (ranked candidates) | 🟡 | `/api/search`; only opensubtitles implements `Searcher` |
@@ -172,8 +172,27 @@ Backend items only — pure UI and bugfixes excluded.
 
 ### Remaining backend gaps (from the changelog)
 
-- 🔴 **Notify Sonarr/Radarr after download** so they index the new subtitle —
-  needs a media→*arr-item-id mapping we don't currently persist.
+- ✅ **Notify Sonarr/Radarr after download** so they index the new subtitle —
+  implemented in `pkg/arrnotify` as an `events.EventPublisher` subscriber, using
+  the same commands Bazarr sends (`RescanSeries`/`seriesId`,
+  `RescanMovie`/`movieId` on `POST /api/v3/command`). Enabled by default for any
+  enabled *arr; opt out with `integrations.{sonarr,radarr}.rescan_after_download: false`.
+
+  **Design note.** The earlier claim that this "needs a media→*arr-item-id
+  mapping we don't persist" overstated the gap. The id is resolved from the
+  media path at event time instead: the *arr's own folder listing is fetched
+  (cached for 5 minutes, since a library scan can emit hundreds of downloads)
+  and matched by longest containing folder. Matching happens in
+  subtitle-manager's path space — `Filters.MapPath` is applied to the *arr's
+  folders rather than inverted, because `MapPath` is longest-prefix-wins and so
+  not reliably invertible. Ambiguous matches are skipped rather than guessed.
+
+  Persisting `SeriesID`/`MovieID` on `database.MediaItem` was considered and
+  rejected for now: `media_items` is written by hand-rolled SQL in ~15 places
+  across sqlite/postgres/pebble with no migration framework, making a column
+  addition disproportionately wide. The accepted cost is that a rescan is lost
+  (logged, not retried) when the *arr is unreachable at that moment. If that
+  proves to matter, persisting the id becomes a focused follow-up.
 - 🔴 **Real-time (SignalR) sync** with Sonarr v3 / Radarr v3 — large; needs a
   SignalR client. We poll/sync via REST only.
 - 🟡 **Provider throttling** — Bazarr tracks per-provider throttle state and a

--- a/pkg/arr/baseurl.go
+++ b/pkg/arr/baseurl.go
@@ -1,0 +1,32 @@
+// file: pkg/arr/baseurl.go
+// version: 1.0.0
+// guid: 5a09a63e-a737-4060-a986-8976349f7bd9
+// last-edited: 2026-07-25
+
+package arr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// BaseURL builds a Sonarr/Radarr base URL from config under the given prefix,
+// e.g. "integrations.sonarr". Returns "" when the integration is disabled or
+// has no host, so callers can treat the empty string as "not configured".
+func BaseURL(prefix string) string {
+	if !viper.GetBool(prefix + ".enabled") {
+		return ""
+	}
+	host := viper.GetString(prefix + ".host")
+	if host == "" {
+		return ""
+	}
+	scheme := "http"
+	if viper.GetBool(prefix + ".ssl") {
+		scheme = "https"
+	}
+	base := strings.Trim(viper.GetString(prefix+".base_url"), "/")
+	return fmt.Sprintf("%s://%s:%v/%s", scheme, host, viper.GetString(prefix+".port"), base)
+}

--- a/pkg/arrnotify/publisher.go
+++ b/pkg/arrnotify/publisher.go
@@ -1,0 +1,196 @@
+// file: pkg/arrnotify/publisher.go
+// version: 1.0.0
+// guid: 3e3f1217-8acc-47fe-9320-733f390155e6
+// last-edited: 2026-07-25
+
+// Package arrnotify tells Sonarr/Radarr to rescan a title's folder after
+// subtitle-manager writes a subtitle for it, so the *arr picks the new file up
+// instead of waiting for its own scheduled scan. This is Bazarr's
+// notify_sonarr/notify_radarr behaviour (bazarr/sonarr/notify.py,
+// bazarr/radarr/notify.py).
+//
+// The *arr item id is resolved from the media path at event time rather than
+// persisted alongside the media item: media_items is written by hand-rolled SQL
+// in ~15 places across three backends and there is no migration framework, so
+// adding a column is a disproportionately wide change. The trade-off is that a
+// rescan is lost (logged, not retried) if the *arr is unreachable at that
+// moment.
+package arrnotify
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
+	"github.com/jdfalk/subtitle-manager/pkg/events"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/radarr"
+	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
+)
+
+// defaultTTL bounds how stale a cached series/movie listing may be. A library
+// scan can write hundreds of subtitles, and /api/v3/series is a large response,
+// so refetching per subtitle would hammer the *arr for no benefit: a title's
+// folder does not move mid-scan.
+const defaultTTL = 5 * time.Minute
+
+// Publisher implements events.EventPublisher, issuing an *arr rescan whenever a
+// subtitle is written. Failures are logged and swallowed -- a rescan is a
+// convenience, and must never fail the subtitle pipeline that produced it.
+type Publisher struct {
+	Sonarr *sonarr.Client
+	Radarr *radarr.Client
+	// TTL bounds cached listings; zero means defaultTTL.
+	TTL time.Duration
+
+	// now is swappable so tests can drive cache expiry without sleeping.
+	now func() time.Time
+
+	mu       sync.Mutex
+	series   []sonarr.SeriesRef
+	seriesAt time.Time
+	movies   []radarr.MovieRef
+	moviesAt time.Time
+}
+
+// NewPublisher returns a Publisher for the given clients. Either may be nil.
+func NewPublisher(s *sonarr.Client, r *radarr.Client) *Publisher {
+	return &Publisher{Sonarr: s, Radarr: r, now: time.Now}
+}
+
+// NewPublisherFromConfig builds a Publisher from viper config, returning nil
+// when neither integration is enabled or both have opted out of rescanning.
+// Rescan defaults to on for an enabled integration, matching Bazarr, which
+// notifies unconditionally.
+func NewPublisherFromConfig() *Publisher {
+	var s *sonarr.Client
+	if url := arr.BaseURL("integrations.sonarr"); url != "" && rescanEnabled("integrations.sonarr") {
+		s = sonarr.NewClient(url, viper.GetString("integrations.sonarr.api_key"))
+		s.Filters = arr.FiltersFromViper("integrations.sonarr")
+	}
+	var r *radarr.Client
+	if url := arr.BaseURL("integrations.radarr"); url != "" && rescanEnabled("integrations.radarr") {
+		r = radarr.NewClient(url, viper.GetString("integrations.radarr.api_key"))
+		r.Filters = arr.FiltersFromViper("integrations.radarr")
+	}
+	if s == nil && r == nil {
+		return nil
+	}
+	return NewPublisher(s, r)
+}
+
+// rescanEnabled reports whether rescan-after-download is on for the given
+// integration prefix. Absent config means enabled, so operators who already
+// have an *arr configured get parity behaviour without editing their config.
+func rescanEnabled(prefix string) bool {
+	key := prefix + ".rescan_after_download"
+	if !viper.IsSet(key) {
+		return true
+	}
+	return viper.GetBool(key)
+}
+
+func (p *Publisher) ttl() time.Duration {
+	if p.TTL > 0 {
+		return p.TTL
+	}
+	return defaultTTL
+}
+
+func (p *Publisher) clock() time.Time {
+	if p.now != nil {
+		return p.now()
+	}
+	return time.Now()
+}
+
+// PublishSubtitleDownloaded triggers a rescan for the downloaded subtitle's
+// media file.
+func (p *Publisher) PublishSubtitleDownloaded(ctx context.Context, data events.SubtitleDownloadedData) {
+	p.rescan(ctx, data.FilePath)
+}
+
+// PublishSubtitleUpgraded triggers a rescan for the upgraded subtitle's media
+// file: the replacement is a new file on disk as far as the *arr is concerned.
+func (p *Publisher) PublishSubtitleUpgraded(ctx context.Context, data events.SubtitleUpgradedData) {
+	p.rescan(ctx, data.FilePath)
+}
+
+// PublishSubtitleFailed is a no-op: nothing was written, so there is nothing to
+// rescan.
+func (p *Publisher) PublishSubtitleFailed(context.Context, events.SubtitleFailedData) {}
+
+// PublishSearchFailed is a no-op for the same reason.
+func (p *Publisher) PublishSearchFailed(context.Context, events.SearchFailedData) {}
+
+// rescan resolves videoPath to a Sonarr series or Radarr movie and asks that
+// *arr to rescan it. Sonarr is tried first; a path can only belong to one.
+func (p *Publisher) rescan(ctx context.Context, videoPath string) {
+	if p == nil || videoPath == "" {
+		return
+	}
+	logger := logging.GetLogger("arrnotify")
+
+	// The lock is deliberately held across the listing fetch: during a library
+	// scan many downloads land at once, and serialising here collapses what
+	// would otherwise be a burst of identical /api/v3 requests into one.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.Sonarr != nil {
+		if refs, err := p.seriesRefs(ctx); err != nil {
+			logger.Warnf("cannot list Sonarr series for %s: %v", videoPath, err)
+		} else if id, ok := sonarr.MatchPath(refs, videoPath); ok {
+			if err := p.Sonarr.Rescan(ctx, id); err != nil {
+				logger.Warnf("Sonarr rescan of series %d failed: %v", id, err)
+			} else {
+				logger.Debugf("requested Sonarr rescan of series %d for %s", id, videoPath)
+			}
+			return
+		}
+	}
+	if p.Radarr != nil {
+		if refs, err := p.movieRefs(ctx); err != nil {
+			logger.Warnf("cannot list Radarr movies for %s: %v", videoPath, err)
+		} else if id, ok := radarr.MatchPath(refs, videoPath); ok {
+			if err := p.Radarr.Rescan(ctx, id); err != nil {
+				logger.Warnf("Radarr rescan of movie %d failed: %v", id, err)
+			} else {
+				logger.Debugf("requested Radarr rescan of movie %d for %s", id, videoPath)
+			}
+			return
+		}
+	}
+	logger.Debugf("no Sonarr/Radarr item owns %s; skipping rescan", videoPath)
+}
+
+// seriesRefs returns the cached Sonarr series listing, refreshing it when stale.
+// Callers must hold p.mu.
+func (p *Publisher) seriesRefs(ctx context.Context) ([]sonarr.SeriesRef, error) {
+	if p.series != nil && p.clock().Sub(p.seriesAt) < p.ttl() {
+		return p.series, nil
+	}
+	refs, err := p.Sonarr.Series(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.series, p.seriesAt = refs, p.clock()
+	return refs, nil
+}
+
+// movieRefs returns the cached Radarr movie listing, refreshing it when stale.
+// Callers must hold p.mu.
+func (p *Publisher) movieRefs(ctx context.Context) ([]radarr.MovieRef, error) {
+	if p.movies != nil && p.clock().Sub(p.moviesAt) < p.ttl() {
+		return p.movies, nil
+	}
+	refs, err := p.Radarr.MovieRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.movies, p.moviesAt = refs, p.clock()
+	return refs, nil
+}

--- a/pkg/arrnotify/publisher_test.go
+++ b/pkg/arrnotify/publisher_test.go
@@ -1,0 +1,258 @@
+// file: pkg/arrnotify/publisher_test.go
+// version: 1.0.0
+// guid: 65a3269c-5455-48cc-9056-9055485b4c24
+// last-edited: 2026-07-25
+
+package arrnotify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/events"
+	"github.com/jdfalk/subtitle-manager/pkg/radarr"
+	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
+)
+
+// arrStub is a fake Sonarr or Radarr exposing the two endpoints the rescan
+// path uses, and recording what it was asked to do.
+type arrStub struct {
+	listPath string
+	listBody string
+
+	mu        sync.Mutex
+	listCalls int32
+	rescanned []int
+	listFails bool
+}
+
+func (s *arrStub) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case s.listPath:
+			atomic.AddInt32(&s.listCalls, 1)
+			if s.listFails {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = io.WriteString(w, s.listBody)
+		case "/api/v3/command":
+			var cmd struct {
+				SeriesID int `json:"seriesId"`
+				MovieID  int `json:"movieId"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&cmd)
+			id := cmd.SeriesID
+			if id == 0 {
+				id = cmd.MovieID
+			}
+			s.mu.Lock()
+			s.rescanned = append(s.rescanned, id)
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (s *arrStub) ids() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.rescanned...)
+}
+
+func newSonarrStub(t *testing.T, body string) (*arrStub, *sonarr.Client) {
+	t.Helper()
+	stub := &arrStub{listPath: "/api/v3/series", listBody: body}
+	return stub, sonarr.NewClient(stub.start(t).URL, "k")
+}
+
+func newRadarrStub(t *testing.T, body string) (*arrStub, *radarr.Client) {
+	t.Helper()
+	stub := &arrStub{listPath: "/api/v3/movie", listBody: body}
+	return stub, radarr.NewClient(stub.start(t).URL, "k")
+}
+
+func downloaded(path string) events.SubtitleDownloadedData {
+	return events.SubtitleDownloadedData{FilePath: path, Language: "en", Provider: "podnapisi"}
+}
+
+// TestDownloadTriggersSonarrRescan is the core behaviour: writing a subtitle for
+// an episode asks Sonarr to rescan that series.
+func TestDownloadTriggersSonarrRescan(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E01.mkv"))
+
+	if got := stub.ids(); len(got) != 1 || got[0] != 7 {
+		t.Fatalf("rescanned = %v, want [7]", got)
+	}
+}
+
+// TestDownloadTriggersRadarrRescan covers the movie path, including that Sonarr
+// being present but not owning the file falls through to Radarr.
+func TestDownloadTriggersRadarrRescan(t *testing.T) {
+	sonarrStub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	radarrStub, rc := newRadarrStub(t, `[{"id":11,"path":"/movies/Film"}]`)
+	p := NewPublisher(sc, rc)
+
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/movies/Film/Film.mkv"))
+
+	if got := radarrStub.ids(); len(got) != 1 || got[0] != 11 {
+		t.Fatalf("radarr rescanned = %v, want [11]", got)
+	}
+	if got := sonarrStub.ids(); len(got) != 0 {
+		t.Fatalf("sonarr rescanned = %v, want none", got)
+	}
+}
+
+// TestUpgradeTriggersRescan: an upgraded subtitle is a new file on disk too.
+func TestUpgradeTriggersRescan(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	p.PublishSubtitleUpgraded(context.Background(), events.SubtitleUpgradedData{
+		FilePath: "/tv/Show/S01E01.mkv", Language: "en",
+	})
+
+	if got := stub.ids(); len(got) != 1 || got[0] != 7 {
+		t.Fatalf("rescanned = %v, want [7]", got)
+	}
+}
+
+// TestFailureEventsDoNotRescan: nothing was written, so nothing to rescan.
+func TestFailureEventsDoNotRescan(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	p.PublishSubtitleFailed(context.Background(), events.SubtitleFailedData{FilePath: "/tv/Show/S01E01.mkv"})
+	p.PublishSearchFailed(context.Background(), events.SearchFailedData{Query: "Show"})
+
+	if got := stub.ids(); len(got) != 0 {
+		t.Fatalf("rescanned = %v, want none", got)
+	}
+	if n := atomic.LoadInt32(&stub.listCalls); n != 0 {
+		t.Fatalf("listed %d times, want 0", n)
+	}
+}
+
+// TestUnknownPathIsSkipped: a file no *arr owns must not trigger a rescan.
+func TestUnknownPathIsSkipped(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/other/Thing/file.mkv"))
+
+	if got := stub.ids(); len(got) != 0 {
+		t.Fatalf("rescanned = %v, want none", got)
+	}
+}
+
+// TestListingIsCached: a library scan writing many subtitles must not refetch
+// the (large) series listing per subtitle.
+func TestListingIsCached(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	for i := 0; i < 5; i++ {
+		p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E01.mkv"))
+	}
+
+	if n := atomic.LoadInt32(&stub.listCalls); n != 1 {
+		t.Fatalf("listed %d times, want 1 (cached)", n)
+	}
+	if got := stub.ids(); len(got) != 5 {
+		t.Fatalf("rescanned %d times, want 5", len(got))
+	}
+}
+
+// TestCacheExpires: past the TTL the listing is refetched, so a series added
+// mid-run is eventually seen.
+func TestCacheExpires(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+	p.TTL = time.Minute
+
+	now := time.Unix(1000, 0)
+	p.now = func() time.Time { return now }
+
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E01.mkv"))
+	now = now.Add(2 * time.Minute)
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E02.mkv"))
+
+	if n := atomic.LoadInt32(&stub.listCalls); n != 2 {
+		t.Fatalf("listed %d times, want 2 (cache expired)", n)
+	}
+}
+
+// TestListingFailureIsFailOpen: an unreachable Sonarr must not panic or block,
+// and must not stop Radarr from being consulted. The rescan is simply lost --
+// the documented trade-off of resolving ids at event time.
+func TestListingFailureIsFailOpen(t *testing.T) {
+	sonarrStub := &arrStub{listPath: "/api/v3/series", listFails: true}
+	sc := sonarr.NewClient(sonarrStub.start(t).URL, "k")
+	radarrStub, rc := newRadarrStub(t, `[{"id":11,"path":"/movies/Film"}]`)
+	p := NewPublisher(sc, rc)
+
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/movies/Film/Film.mkv"))
+
+	if got := radarrStub.ids(); len(got) != 1 || got[0] != 11 {
+		t.Fatalf("radarr rescanned = %v, want [11] despite Sonarr being down", got)
+	}
+}
+
+// TestNilPublisherAndEmptyPathAreSafe covers the degenerate calls the event bus
+// can make before configuration is complete.
+func TestNilPublisherAndEmptyPathAreSafe(t *testing.T) {
+	var p *Publisher
+	p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E01.mkv"))
+
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	real := NewPublisher(sc, nil)
+	real.PublishSubtitleDownloaded(context.Background(), downloaded(""))
+	if n := atomic.LoadInt32(&stub.listCalls); n != 0 {
+		t.Fatalf("listed %d times for empty path, want 0", n)
+	}
+}
+
+// TestConcurrentEventsAreSerialised exercises the mutex under -race and
+// confirms the burst still produces exactly one listing fetch.
+func TestConcurrentEventsAreSerialised(t *testing.T) {
+	stub, sc := newSonarrStub(t, `[{"id":7,"path":"/tv/Show"}]`)
+	p := NewPublisher(sc, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.PublishSubtitleDownloaded(context.Background(), downloaded("/tv/Show/S01E01.mkv"))
+		}()
+	}
+	wg.Wait()
+
+	if n := atomic.LoadInt32(&stub.listCalls); n != 1 {
+		t.Fatalf("listed %d times, want 1", n)
+	}
+	if got := stub.ids(); len(got) != 20 {
+		t.Fatalf("rescanned %d times, want 20", len(got))
+	}
+}
+
+// TestPublisherSatisfiesEventPublisher pins the interface contract that makes
+// this wireable into events.NewMultiPublisher.
+func TestPublisherSatisfiesEventPublisher(t *testing.T) {
+	var _ events.EventPublisher = (*Publisher)(nil)
+}

--- a/pkg/radarr/rescan.go
+++ b/pkg/radarr/rescan.go
@@ -1,0 +1,118 @@
+// file: pkg/radarr/rescan.go
+// version: 1.0.0
+// guid: 44eff140-954a-442f-b2ec-a5e63dfa6de7
+// last-edited: 2026-07-25
+
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// MovieRef is the minimum a rescan needs: the Radarr movie id and the movie
+// folder, already translated into subtitle-manager's path space.
+type MovieRef struct {
+	ID int
+	// Path is the movie folder as subtitle-manager sees it, i.e. after
+	// Filters.MapPath has been applied.
+	Path string
+}
+
+// movieResponse mirrors the subset of GET /api/v3/movie we care about.
+type movieResponse struct {
+	ID   int    `json:"id"`
+	Path string `json:"path"`
+}
+
+// MovieRefs lists every movie with its folder, mapped into subtitle-manager's
+// path space so results can be compared against local media paths directly.
+func (c *Client) MovieRefs(ctx context.Context) ([]MovieRef, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v3/movie", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var raw []movieResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	refs := make([]MovieRef, 0, len(raw))
+	for _, m := range raw {
+		if m.Path == "" || m.ID == 0 {
+			continue
+		}
+		refs = append(refs, MovieRef{ID: m.ID, Path: c.Filters.MapPath(m.Path)})
+	}
+	return refs, nil
+}
+
+// Rescan asks Radarr to rescan the given movie's folder from disk, which is how
+// a newly written subtitle becomes visible to Radarr. Mirrors Bazarr's
+// notify_radarr (bazarr/radarr/notify.py).
+func (c *Client) Rescan(ctx context.Context, movieID int) error {
+	body, err := json.Marshal(map[string]any{"name": "RescanMovie", "movieId": movieID})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v3/command", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Radarr answers 201 Created for an accepted command; accept any 2xx.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// MatchPath returns the id of the movie whose folder contains videoPath. See
+// sonarr.MatchPath for why matching happens in subtitle-manager's path space
+// and why ambiguous matches report none rather than guessing.
+func MatchPath(refs []MovieRef, videoPath string) (int, bool) {
+	bestLen, bestID, ambiguous := -1, 0, false
+	for _, r := range refs {
+		if !underFolder(videoPath, r.Path) {
+			continue
+		}
+		switch {
+		case len(r.Path) > bestLen:
+			bestLen, bestID, ambiguous = len(r.Path), r.ID, false
+		case len(r.Path) == bestLen && r.ID != bestID:
+			ambiguous = true
+		}
+	}
+	if bestLen < 0 || ambiguous {
+		return 0, false
+	}
+	return bestID, true
+}
+
+// underFolder reports whether file sits inside dir. The separator check stops
+// "/movies/Alien" from swallowing "/movies/Aliens/Aliens.mkv".
+func underFolder(file, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	trimmed := strings.TrimSuffix(dir, "/")
+	return strings.HasPrefix(file, trimmed+"/")
+}

--- a/pkg/radarr/rescan_test.go
+++ b/pkg/radarr/rescan_test.go
@@ -1,0 +1,108 @@
+// file: pkg/radarr/rescan_test.go
+// version: 1.0.0
+// guid: 8b3652b2-6d65-41b6-aa42-583159582761
+// last-edited: 2026-07-25
+
+package radarr
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
+)
+
+// TestMovieRefsAppliesPathMapping verifies movie folders come back in
+// subtitle-manager's path space so MatchPath never has to invert MapPath.
+func TestMovieRefsAppliesPathMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/movie" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `[{"id":11,"path":"/data/movies/Film (2020)"}]`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	c.Filters = arr.Filters{PathMappings: [][2]string{{"/data/movies", "/media/films"}}}
+
+	refs, err := c.MovieRefs(context.Background())
+	if err != nil {
+		t.Fatalf("MovieRefs: %v", err)
+	}
+	if len(refs) != 1 || refs[0].ID != 11 || refs[0].Path != "/media/films/Film (2020)" {
+		t.Fatalf("got %+v, want [{11 /media/films/Film (2020)}]", refs)
+	}
+}
+
+// TestRescanPostsBazarrCommand pins the request shape to Bazarr's
+// notify_radarr: POST /api/v3/command {"name":"RescanMovie","movieId":N}.
+func TestRescanPostsBazarrCommand(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/command" {
+			t.Errorf("got %s %s, want POST /api/v3/command", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	if err := NewClient(srv.URL, "k").Rescan(context.Background(), 11); err != nil {
+		t.Fatalf("Rescan: %v", err)
+	}
+	if got["name"] != "RescanMovie" {
+		t.Errorf("name = %v, want RescanMovie", got["name"])
+	}
+	if id, _ := got["movieId"].(float64); int(id) != 11 {
+		t.Errorf("movieId = %v, want 11", got["movieId"])
+	}
+}
+
+func TestRescanReportsNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if err := NewClient(srv.URL, "k").Rescan(context.Background(), 1); err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	refs := []MovieRef{
+		{ID: 1, Path: "/movies/Alien"},
+		{ID: 2, Path: "/movies/Aliens"},
+	}
+	cases := []struct {
+		name  string
+		video string
+		want  int
+		ok    bool
+	}{
+		// The separator check is what stops "Alien" matching "Aliens".
+		{"separator boundary", "/movies/Aliens/Aliens.mkv", 2, true},
+		{"exact folder", "/movies/Alien/Alien.mkv", 1, true},
+		{"no match", "/tv/Show/S01E01.mkv", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := MatchPath(refs, tc.video)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("MatchPath(%q) = (%d, %v), want (%d, %v)", tc.video, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestMatchPathAmbiguousReportsNone(t *testing.T) {
+	refs := []MovieRef{{ID: 1, Path: "/movies/Film"}, {ID: 2, Path: "/movies/Film"}}
+	if id, ok := MatchPath(refs, "/movies/Film/Film.mkv"); ok {
+		t.Errorf("got (%d, true), want no match for ambiguous mapping", id)
+	}
+}

--- a/pkg/sonarr/rescan.go
+++ b/pkg/sonarr/rescan.go
@@ -1,0 +1,126 @@
+// file: pkg/sonarr/rescan.go
+// version: 1.0.0
+// guid: ef11acdf-7c70-406c-8d0e-e033603dbbb3
+// last-edited: 2026-07-25
+
+package sonarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// SeriesRef is the minimum a rescan needs: the Sonarr series id and the series
+// folder, already translated into subtitle-manager's path space.
+type SeriesRef struct {
+	ID int
+	// Path is the series folder as subtitle-manager sees it, i.e. after
+	// Filters.MapPath has been applied.
+	Path string
+}
+
+// seriesResponse mirrors the subset of GET /api/v3/series we care about.
+type seriesResponse struct {
+	ID   int    `json:"id"`
+	Path string `json:"path"`
+}
+
+// Series lists every series with its folder, mapped into subtitle-manager's
+// path space so results can be compared against local media paths directly.
+func (c *Client) Series(ctx context.Context) ([]SeriesRef, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v3/series", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var raw []seriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	refs := make([]SeriesRef, 0, len(raw))
+	for _, s := range raw {
+		if s.Path == "" || s.ID == 0 {
+			continue
+		}
+		refs = append(refs, SeriesRef{ID: s.ID, Path: c.Filters.MapPath(s.Path)})
+	}
+	return refs, nil
+}
+
+// Rescan asks Sonarr to rescan the given series' folder from disk, which is how
+// a newly written subtitle becomes visible to Sonarr. Mirrors Bazarr's
+// notify_sonarr (bazarr/sonarr/notify.py).
+func (c *Client) Rescan(ctx context.Context, seriesID int) error {
+	body, err := json.Marshal(map[string]any{"name": "RescanSeries", "seriesId": seriesID})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v3/command", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Sonarr answers 201 Created for an accepted command; accept any 2xx.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// MatchPath returns the id of the series whose folder contains videoPath.
+//
+// Matching happens in subtitle-manager's path space: SeriesRef.Path has already
+// been through Filters.MapPath, so we never have to invert the mapping (which
+// is not reliably invertible -- MapPath is longest-prefix-wins, so two distinct
+// Sonarr roots can collapse onto one local root).
+//
+// The longest matching folder wins so nested libraries behave. If two series
+// map to the same folder the match is ambiguous and we report none rather than
+// guess, since rescanning the wrong series is a silent no-op that is hard to
+// debug.
+func MatchPath(refs []SeriesRef, videoPath string) (int, bool) {
+	bestLen, bestID, ambiguous := -1, 0, false
+	for _, r := range refs {
+		if !underFolder(videoPath, r.Path) {
+			continue
+		}
+		switch {
+		case len(r.Path) > bestLen:
+			bestLen, bestID, ambiguous = len(r.Path), r.ID, false
+		case len(r.Path) == bestLen && r.ID != bestID:
+			ambiguous = true
+		}
+	}
+	if bestLen < 0 || ambiguous {
+		return 0, false
+	}
+	return bestID, true
+}
+
+// underFolder reports whether file sits inside dir. The separator check stops
+// "/tv/Show" from swallowing "/tv/Show Name/S01E01.mkv".
+func underFolder(file, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	trimmed := strings.TrimSuffix(dir, "/")
+	return strings.HasPrefix(file, trimmed+"/")
+}

--- a/pkg/sonarr/rescan_test.go
+++ b/pkg/sonarr/rescan_test.go
@@ -1,0 +1,155 @@
+// file: pkg/sonarr/rescan_test.go
+// version: 1.0.0
+// guid: 513902a4-c46e-4d65-978f-3983bd9d7c4a
+// last-edited: 2026-07-25
+
+package sonarr
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
+)
+
+// TestSeriesAppliesPathMapping verifies that series folders come back in
+// subtitle-manager's path space, which is what makes MatchPath work without
+// having to invert Filters.MapPath.
+func TestSeriesAppliesPathMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/series" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "key" {
+			t.Errorf("api key = %q, want %q", got, "key")
+		}
+		_, _ = io.WriteString(w, `[{"id":7,"path":"/data/tv/Show"},{"id":8,"path":"/data/tv/Other"}]`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	c.Filters = arr.Filters{PathMappings: [][2]string{{"/data/tv", "/media/television"}}}
+
+	refs, err := c.Series(context.Background())
+	if err != nil {
+		t.Fatalf("Series: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2", len(refs))
+	}
+	if refs[0].ID != 7 || refs[0].Path != "/media/television/Show" {
+		t.Errorf("ref[0] = %+v, want {7 /media/television/Show}", refs[0])
+	}
+}
+
+// TestSeriesSkipsIncompleteEntries guards against a rescan of series id 0.
+func TestSeriesSkipsIncompleteEntries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[{"id":0,"path":"/tv/A"},{"id":3,"path":""},{"id":4,"path":"/tv/B"}]`)
+	}))
+	defer srv.Close()
+
+	refs, err := NewClient(srv.URL, "k").Series(context.Background())
+	if err != nil {
+		t.Fatalf("Series: %v", err)
+	}
+	if len(refs) != 1 || refs[0].ID != 4 {
+		t.Fatalf("got %+v, want only series 4", refs)
+	}
+}
+
+// TestRescanPostsBazarrCommand pins the request shape to Bazarr's
+// notify_sonarr: POST /api/v3/command {"name":"RescanSeries","seriesId":N}.
+func TestRescanPostsBazarrCommand(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/command" {
+			t.Errorf("got %s %s, want POST /api/v3/command", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("content-type = %q", ct)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	if err := NewClient(srv.URL, "k").Rescan(context.Background(), 42); err != nil {
+		t.Fatalf("Rescan: %v", err)
+	}
+	if got["name"] != "RescanSeries" {
+		t.Errorf("name = %v, want RescanSeries", got["name"])
+	}
+	if id, _ := got["seriesId"].(float64); int(id) != 42 {
+		t.Errorf("seriesId = %v, want 42", got["seriesId"])
+	}
+}
+
+// TestRescanReportsNon2xx ensures a rejected command surfaces as an error so
+// the caller can log it, rather than silently appearing to succeed.
+func TestRescanReportsNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if err := NewClient(srv.URL, "k").Rescan(context.Background(), 1); err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	refs := []SeriesRef{
+		{ID: 1, Path: "/tv/Show"},
+		{ID: 2, Path: "/tv/Show Name"},
+		{ID: 3, Path: "/tv/Nested/Inner"},
+		{ID: 4, Path: "/tv/Nested"},
+	}
+	cases := []struct {
+		name  string
+		video string
+		want  int
+		ok    bool
+	}{
+		// "/tv/Show" must not swallow a file under "/tv/Show Name".
+		{"separator boundary", "/tv/Show Name/S01E01.mkv", 2, true},
+		{"exact folder", "/tv/Show/S01E01.mkv", 1, true},
+		// Longest folder wins so a nested library picks the inner series.
+		{"longest prefix wins", "/tv/Nested/Inner/S01E01.mkv", 3, true},
+		{"outer when not in inner", "/tv/Nested/Loose.mkv", 4, true},
+		{"no match", "/movies/Film/Film.mkv", 0, false},
+		// The folder itself is not a file inside the folder.
+		{"folder is not its own child", "/tv/Show", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := MatchPath(refs, tc.video)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("MatchPath(%q) = (%d, %v), want (%d, %v)", tc.video, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestMatchPathAmbiguousReportsNone documents the deliberate choice to refuse a
+// guess when two series map onto the same folder: rescanning the wrong series
+// is a silent no-op that is painful to debug.
+func TestMatchPathAmbiguousReportsNone(t *testing.T) {
+	refs := []SeriesRef{{ID: 1, Path: "/tv/Show"}, {ID: 2, Path: "/tv/Show"}}
+	if id, ok := MatchPath(refs, "/tv/Show/S01E01.mkv"); ok {
+		t.Errorf("got (%d, true), want no match for ambiguous mapping", id)
+	}
+}
+
+// TestMatchPathTrailingSlashFolder covers *arr instances that report folders
+// with a trailing separator.
+func TestMatchPathTrailingSlashFolder(t *testing.T) {
+	refs := []SeriesRef{{ID: 9, Path: "/tv/Show/"}}
+	if id, ok := MatchPath(refs, "/tv/Show/S01E01.mkv"); !ok || id != 9 {
+		t.Errorf("got (%d, %v), want (9, true)", id, ok)
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/server.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
+// last-edited: 2026-07-25
 
 package webserver
 
@@ -21,6 +22,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/jdfalk/subtitle-manager/pkg/arrnotify"
 	"github.com/jdfalk/subtitle-manager/pkg/bazarr"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/events"
@@ -1419,13 +1421,23 @@ func initializeWebhooks() {
 	manager := webhooks.GetGlobalManager()
 	publisher := webhooks.NewWebhookEventPublisher(manager)
 
-	// Compose with a notifications publisher so subtitle events also reach the
-	// operator's configured channels (Discord/Telegram/email/Apprise). When no
-	// channel is configured, notifyPublisher is nil and only webhooks fire.
+	// Compose with the optional subscribers. Each is nil when unconfigured, and
+	// NewMultiPublisher drops nils, so an operator with neither still gets plain
+	// webhook delivery.
+	//   - notifications: subtitle events reach Discord/Telegram/email/Apprise.
+	//   - arrnotify: Sonarr/Radarr are told to rescan the title so the new
+	//     subtitle shows up without waiting for their own scheduled scan.
+	subscribers := []events.EventPublisher{publisher}
 	if np := notificationsPublisherFromConfig(); np != nil {
-		events.SetGlobalPublisher(events.NewMultiPublisher(publisher, np))
-	} else {
+		subscribers = append(subscribers, np)
+	}
+	if ap := arrnotify.NewPublisherFromConfig(); ap != nil {
+		subscribers = append(subscribers, ap)
+	}
+	if len(subscribers) == 1 {
 		events.SetGlobalPublisher(publisher)
+	} else {
+		events.SetGlobalPublisher(events.NewMultiPublisher(subscribers...))
 	}
 
 	// Register incoming webhook handlers with secrets from configuration


### PR DESCRIPTION
Closes the last 🔴 item in the Sonarr/Radarr section of
`docs/BAZARR_PARITY_STATUS.md`.

## What

A downloaded subtitle previously stayed invisible to Sonarr/Radarr until their
own scheduled disk scan happened to run. subtitle-manager now issues a rescan as
soon as a subtitle is written or upgraded.

The commands are **confirmed against Bazarr's source**, not recalled —
`bazarr/sonarr/notify.py` and `bazarr/radarr/notify.py`:

| *arr | Request |
| --- | --- |
| Sonarr | `POST /api/v3/command` `{"name":"RescanSeries","seriesId":N}` |
| Radarr | `POST /api/v3/command` `{"name":"RescanMovie","movieId":N}` |

Enabled by default for any enabled *arr — Bazarr notifies unconditionally. Opt
out with `integrations.{sonarr,radarr}.rescan_after_download: false`.

## How it fits

`pkg/arrnotify` implements `events.EventPublisher` and joins the existing
`events.MultiPublisher` chain built in #2186, alongside webhooks and
notifications. No new hook into the scanner was needed — that seam already
existed.

## Decisions recorded (happy to revisit any of these)

**1. Resolve the *arr id at event time; don't persist it.** The parity doc said
this "needs a media→*arr-item-id mapping we don't persist" — that overstated the
gap. Instead the *arr's own folder listing is fetched and matched by longest
containing folder.

Persisting `SeriesID`/`MovieID` on `database.MediaItem` was the alternative. It
was rejected *for now* because `media_items` is written by hand-rolled SQL in
~15 places across sqlite/postgres/pebble with no migration framework, so adding
a column is a disproportionately wide diff to carry as a rider on this feature.
**Accepted cost:** a rescan is lost (logged, not retried) if the *arr is
unreachable at that moment. If that matters in practice, persisting the id is a
clean follow-up.

**2. Match in subtitle-manager's path space, don't invert `MapPath`.** The path
we hold has already been through `arr.Filters.MapPath` (#2182), so it is *not*
the path the *arr knows. Rather than inverting the mapping — `MapPath` is
longest-prefix-wins, so two distinct *arr roots can collapse onto one local root
and the inverse is genuinely ambiguous — `MapPath` is applied *forward* to the
*arr's folders and matching happens in local space. This reuses the existing
function and needs no inverse.

**3. Skip ambiguous matches rather than guess.** Rescanning the wrong series is
a silent no-op that is unpleasant to debug, so two folders tying means no match.

**4. Cache listings for 5 minutes, and hold the lock across the fetch.** A
library scan can emit hundreds of downloads and `/api/v3/series` is a large
response. Holding the mutex across the fetch deliberately collapses a burst of
concurrent downloads into a single upstream request.

**5. Fail open.** Every failure is logged and swallowed, matching both Bazarr's
bare `except` and the existing contract in
`pkg/notifications/event_publisher.go` that a side-channel must never break the
pipeline that produced the event.

## Follow-up noted, not done

`pkg/webserver/server.go` still builds *arr base URLs inline in two places,
duplicating the new `arr.BaseURL`. Left alone to keep this PR focused.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test -race ./...` — full suite green.
- 24 new tests: httptest-mocked, no credentials needed. They pin the exact
  request shape against Bazarr's, and cover the separator boundary
  (`/movies/Alien` must not swallow `/movies/Aliens/...`), longest-prefix wins,
  ambiguity refusal, path-mapping translation, cache hit/expiry, fail-open when
  an *arr is down, nil/empty-path safety, and a 20-goroutine concurrency test
  under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH