### PR TITLE
docs: track provider build-out prompt, replace stale CI fix plan

### DIFF
--- a/changelog.d/docs-buildout-and-ci-plan.md
+++ b/changelog.d/docs-buildout-and-ci-plan.md
@@ -1,0 +1,21 @@
+<!-- file: changelog.d/docs-buildout-and-ci-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 074e7e52-ecb4-4fc2-bd85-7c6fc3c0af8f -->
+<!-- last-edited: 2026-07-25 -->
+
+### Changed
+
+#### Provider build-out prompt and CI fix plan are now tracked docs
+
+`docs/PROVIDER_BUILDOUT_PROMPT.md`, the governing document for the provider
+build-out, was previously untracked. It is now committed and corrected: Phase 1
+(keyless providers) is marked complete and exhausted, and its claim that
+opensubtitles.com was "already implemented" is flagged as **wrong** — the
+`opensubtitlescom` package is still a fictional stub, and the real integration
+is the separate classic `opensubtitles` package.
+
+The untracked `SUBTITLE_MANAGER_FIX_PLAN.md` scratch file is replaced by
+`docs/CI_FIX_PLAN.md`, trimmed to the items re-verified as still live: the
+protobuf generator's dead gcommon import path, and untriaged Dependabot alerts.
+Items that had since been fixed (the CI Go-version pin, the Python gcommon pin)
+are recorded as resolved so they are not re-opened.

--- a/docs/CI_FIX_PLAN.md
+++ b/docs/CI_FIX_PLAN.md
@@ -1,0 +1,74 @@
+<!-- file: docs/CI_FIX_PLAN.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 38d9f2af-a14a-4e72-8dea-6f0d885f8680 -->
+<!-- last-edited: 2026-07-25 -->
+
+# CI / release pipeline — known issues
+
+Successor to the untracked `SUBTITLE_MANAGER_FIX_PLAN.md` scratch file, trimmed
+to the items that are **still live as of 2026-07-25**. Each claim below was
+re-verified against the repository at that date rather than carried forward on
+faith — the original file had drifted, listing several failures that were
+already fixed.
+
+## Working rules for this repo
+
+- Work in a git worktree; **rebase-merge only** (branch protection).
+- Every PR needs a `changelog.d/` fragment (a `changelog-check` CI job enforces
+  it), or `[skip changelog]` in the PR title / the `skip-changelog` label.
+- A `guid-index` pre-commit hook regenerates `.github/guid-index.json` and
+  **aborts the first commit**; `git add -A` and re-commit. **Do not blind
+  `--amend`** after a failed hook — it rewrites the wrong commit.
+- Module path is `github.com/jdfalk/subtitle-manager`; the remote is
+  `falkcorp/subtitle-manager`.
+- The real CI gate is **`Go CI (1.25)`** + **`Analyze (go)`**. One-second
+  `Code Quality Check` / `Intelligent AI Labeling` failures are stale
+  concurrency-cancelled `pr-automation` jobs — the latest run's conclusion is
+  authoritative.
+
+## Still open
+
+### 1. Protobuf generator references a dead gcommon path
+
+`scripts/generate_protobuf_services.py:549` still imports the legacy
+`github.com/jdfalk/gcommon/sdks/go/v1/common`. That module path no longer
+exists: gcommon became protos-only, published to the Buf Schema Registry, and
+`go.mod` now consumes `buf.build/gen/go/falkcorp/gcommon/...` (commit
+`233be382`).
+
+This does not currently break `Continuous Integration` or the `Release`
+workflow — release-time protobuf generation was disabled for this repo (PR
+#2204) precisely because the generated `.pb.go` files are committed. So the
+script is dead weight rather than an active failure. Decide between:
+
+- updating it to the BSR/`buf generate` layout, if regeneration is still wanted
+  as a developer tool; or
+- deleting it, if committed `.pb.go` files are the intended workflow.
+
+### 2. Dependabot alerts (9 open on the default branch)
+
+As of 2026-07-25: **5 high, 3 medium, 1 low**. Not yet triaged. Only open PR
+addressing any of them is #2166 (dompurify bump). Re-read the current list
+before acting — this count goes stale quickly:
+
+```bash
+gh api repos/falkcorp/subtitle-manager/dependabot/alerts \
+  --jq '[.[] | select(.state=="open")] | group_by(.security_advisory.severity)
+        | map({sev: .[0].security_advisory.severity, n: length})'
+```
+
+## Resolved since the original plan
+
+Recorded so nobody re-opens them:
+
+- **CI Go version.** `ci.yml` now pins `go-version: '1.25'`, matching
+  `go.mod`'s `go 1.25.0`. The old `1.24` pin is gone.
+- **Python gcommon pin.** `requirements.txt` no longer carries the dead
+  `git+https://github.com/jdfalk/gcommon.git@df100011…` editable install, nor
+  the missing-`selenium` / unterminated-string-literal failures.
+- **Release workflow red on every push to `main`** (protobuf generator needing
+  Go ≥ 1.25 on a Go 1.23 runner; goreleaser aborting on an untracked
+  `proto-generated/`). Fixed in PR #2204 by disabling release-time protobuf
+  generation for this repo and gitignoring the output directory.
+- **"14-way broken / ambiguous imports" diagnosis.** Stale. `go build ./...`
+  and `go vet ./...` pass clean.

--- a/docs/PROVIDER_BUILDOUT_PROMPT.md
+++ b/docs/PROVIDER_BUILDOUT_PROMPT.md
@@ -1,0 +1,86 @@
+<!-- file: docs/PROVIDER_BUILDOUT_PROMPT.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 0d3f8b21-5c47-4e90-a2b6-9f1c0e7d4a38 -->
+<!-- last-edited: 2026-07-25 -->
+
+# Next-session prompt: provider build-out
+
+Paste the block below into a fresh Claude Code session (in the
+`falkcorp/subtitle-manager` repo). Check the boxes for providers you have
+accounts/keys for, and put the **actual secrets in your local
+`~/.subtitle-manager.yaml`** (never in the repo or chat) before you run it.
+
+---
+
+Continue the subtitle-manager **Bazarr backend feature-parity** work. Everything
+tractable without external accounts is already merged (see
+`docs/BAZARR_PARITY_STATUS.md` and the `project_subtitle_manager_bazarr_parity`
+auto-memory). The one big remaining gap is the **provider ecosystem**: ~50 of
+~55 registered providers are non-functional stubs (they GET a fictional
+`api.<name>.com`). Real ones today: `opensubtitles`, `napiprojekt`, `gestdown`,
+`podnapisi`, `embedded`.
+
+> **Read this before trusting any "already implemented" note below.** This
+> document is a prompt, not an audit — at least one of its original claims was
+> wrong (it said opensubtitles.com was done; the `opensubtitlescom` package is
+> still a fictional stub). **Verify each line against the code before acting on
+> it.** The same rule applies to provider protocols: confirm against the
+> provider's live docs *and* subliminal's source and VCR cassettes before
+> writing any client. The stubs' plausible-looking URLs are fiction.
+
+**Work the phases below, one focused PR per provider, using the established
+workflow** (worktree off `origin/main`; `changelog.d/` fragment; mandatory file
+version headers; httptest-mocked tests — you never need my real secrets, only
+the config-key wiring; `gh pr merge <N> --rebase --admin`). For each provider,
+**confirm the real API/protocol from its current docs before implementing — do
+not guess** — and skip pure-HTML-scraping providers unless I say otherwise
+(note any you skip and why).
+
+## Phase 1 — keyless providers — **COMPLETE / EXHAUSTED**
+- [x] **Gestdown** (`gestdown.info`) — done, PR #2201. Keyless REST proxy for
+      Addic7ed, **TV only**. Indexes by show/season/episode rather than by hash,
+      so it fits the filename-only `Fetch` interface via `metadata.ParseFileName`.
+      Verified live: it treats `en`, `eng` and `English` as equivalent, but
+      regional variants are distinct (`pt` ≠ `pt-BR`).
+- [x] **Podnapisi** — done, PR #2202. Covers **movies and TV**. The parity doc's
+      old "fragile HTML scraping" label was wrong: it has a real advanced-search
+      JSON API. Language is **alpha-2**, and downloads are **zip-wrapped** — both
+      facts came from subliminal's VCR cassette, not from guessing.
+- [x] No keyless candidates remain. `yifysubtitles` and `subscene` were assessed
+      and **skipped**: they are genuine HTML scraping with no stable API, which
+      cannot be implemented correctly or tested offline. Revisit only if you
+      explicitly want to take on scraping.
+
+## Phase 2 — credential-gated providers (I've put secrets in my local config)
+Implement + wire config for the ones I check. Config lives under the provider's
+namespace in `~/.subtitle-manager.yaml`; you only wire the key names + protocol.
+- [ ] **opensubtitles.com** — ⚠️ **NOT implemented**, despite this line's original
+      claim. The `opensubtitlescom` package is still a fictional stub hitting
+      `api.opensubtitlescom.com`. The real, working integration is the *classic*
+      `opensubtitles` package — a different provider. Treat this as a
+      from-scratch REST v1 implementation
+      (`opensubtitles.api_key` / `.username` / `.password`).
+- [ ] **subdl.com** — free API key (`subdl.api_key`).
+- [ ] **addic7ed** — username/password (+ cookies/anti-captcha caveats; note if blocked).
+- [ ] **titlovi** — username/password.
+- [ ] **betaseries** — API key.
+- [ ] **assrt** — API token.
+- [ ] _(add any others you want and have creds for)_
+
+Providers requiring private-tracker accounts (`avistaz`, `hdbits`, `karagarga`)
+or that are scraping-only stay stubs unless I explicitly ask — keep the
+provider-boundary section of `docs/BAZARR_PARITY_STATUS.md` accurate as you go.
+
+## Phase 3 — optional infra gaps (from the changelog cross-reference)
+- [x] Notify Sonarr/Radarr to rescan after a download — done, PR #2205. The
+      "media→*arr-item-id mapping" was **not** the blocker it looked like: the id
+      is resolved from the media path at event time against the *arr's own folder
+      listing, so no schema change was needed. See the design note in
+      `docs/BAZARR_PARITY_STATUS.md`.
+- [ ] Split Whisper connection vs read timeouts; provider-throttling depth.
+- [ ] Real-time SignalR sync with Sonarr/Radarr — still open, still large.
+
+**Security:** put real secrets only in the local (uncommitted) config file. Just
+tell me which providers you configured — I don't need the secret values.
+
+---


### PR DESCRIPTION
Housekeeping for the two untracked files sitting in the working tree.

## `docs/PROVIDER_BUILDOUT_PROMPT.md` — now tracked, and corrected

This is the governing document for the provider build-out, but it was untracked
and had drifted from reality. Committed with these corrections:

- **Phase 1 marked complete and exhausted.** Gestdown (#2201) and Podnapisi
  (#2202) are done; `yifysubtitles` and `subscene` were assessed and skipped as
  genuine HTML scraping with no stable API.
- **The opensubtitles.com line was wrong.** It said "already implemented". The
  `opensubtitlescom` package is still a fictional stub hitting
  `api.opensubtitlescom.com`; the real integration is the *separate, classic*
  `opensubtitles` package. Now flagged as a from-scratch implementation.
- **Phase 3's *arr rescan is done** (#2205), and its stated blocker — needing a
  media→*arr-id mapping — turned out not to be one.
- Added a standing warning at the top: this file is a prompt, not an audit;
  verify each line against the code before acting on it.

## `SUBTITLE_MANAGER_FIX_PLAN.md` → `docs/CI_FIX_PLAN.md`

The scratch file self-described as "delete when done", but it turned out **not**
to be fully stale — so rather than delete it, I re-verified every item against
the repo and kept only what's live.

**Still open:**
- `scripts/generate_protobuf_services.py:549` still imports the dead
  `github.com/jdfalk/gcommon/sdks/go/v1/common`. Not currently breaking anything
  (release-time generation is disabled by #2204), so it is dead weight rather
  than an active failure — the doc frames it as an update-or-delete decision.
- 9 open Dependabot alerts (5 high / 3 medium / 1 low), untriaged, with the
  query to re-check since the count goes stale.

**Recorded as resolved** so they don't get re-opened: the CI Go-version pin
(`ci.yml` is on 1.25 now), the Python gcommon editable-install pin (gone from
`requirements.txt`), the Release-workflow breakage (#2204), and the old
"14-way broken" diagnosis (`go build`/`go vet` are clean).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH