### PR TITLE
fix(webserver): mount language profile routes

### DIFF
--- a/changelog.d/fix-mount-profile-routes.md
+++ b/changelog.d/fix-mount-profile-routes.md
@@ -1,0 +1,46 @@
+<!-- file: changelog.d/fix-mount-profile-routes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9c4e1a76-2b8d-4f30-85a1-6e0d7c93b482 -->
+<!-- last-edited: 2026-07-25 -->
+
+### Fixed
+
+#### Language profile endpoints are reachable
+
+`profilesHandler` and `mediaProfilesHandler` were implemented and unit-tested
+but never registered with the router, so the Settings → Languages page and
+every media profile assignment silently did nothing.
+
+The failure was invisible because the router serves the single-page app from a
+catch-all at `/`. An unregistered `/api/...` path did not 404 — it returned
+`200` with `index.html`, so the frontend's `if (res.ok)` check passed, the
+following `res.json()` threw into a `catch` that only logged to the browser
+console, and the page rendered empty with nothing in the server log.
+
+Now mounted: `/api/profiles`, `/api/profiles/{id}`, `/api/media/profile/{id}`,
+and `/api/language-profiles[/{id}]`. The frontend calls the
+`language-profiles` spelling while the handlers parse `/api/profiles`, so the
+former is aliased onto the latter rather than duplicated.
+
+The profile handlers also selected their storage backend by calling
+`OpenSQLStore` directly, ignoring the configured backend. They now use
+`OpenStoreWithConfig`.
+
+**Known limitation:** these endpoints work on the SQLite backend but return
+`500` on Pebble. They open a store per request, and Pebble takes an exclusive
+file lock already held by the server process for its lifetime. This is a
+pre-existing bug shared with `librarypaths.go`, `pipeline.go` and `scan.go`;
+fixing it needs a process-wide shared store and is deliberately left to a
+follow-up rather than mixed into this wiring fix.
+
+#### Regression guard for unmounted API routes
+
+`TestFrontendAPIPathsAreMounted` asserts that paths the web UI calls do not
+match the SPA catch-all. It checks the matched `http.ServeMux` pattern rather
+than the response, because what the catch-all returns depends on the build —
+`200` with `index.html` when `webui/dist` is populated, `404` when it is empty
+in tests — so asserting on the response passes in CI while the route is broken
+in production.
+
+It also runs without the `sqlite` build tag, unlike the rest of this package's
+tests, which call `skipIfNoSQLite` and therefore skip entirely in CI.

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/profiles.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
+// last-edited: 2026-07-25
 
 package webserver
 
@@ -83,7 +84,7 @@ func profilesHandler(db *sql.DB) http.Handler {
 // handleListProfiles returns all language profiles.
 // GET /api/profiles
 func handleListProfiles(w http.ResponseWriter, r *http.Request, db *sql.DB) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -124,7 +125,7 @@ func handleCreateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -144,7 +145,7 @@ func handleCreateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 // handleGetProfile returns a specific language profile.
 // GET /api/profiles/{id}
 func handleGetProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -184,7 +185,7 @@ func handleUpdateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 		return
 	}
 
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -203,7 +204,7 @@ func handleUpdateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 // handleDeleteProfile deletes a language profile.
 // DELETE /api/profiles/{id}
 func handleDeleteProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -228,7 +229,7 @@ func handleDeleteProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 // handleSetDefaultProfile sets a profile as the default.
 // POST /api/profiles/{id}/default
 func handleSetDefaultProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -275,7 +276,7 @@ func mediaProfilesHandler(db *sql.DB) http.Handler {
 // handleGetMediaProfile returns the profile assigned to a media item.
 // GET /api/media/profile/{id}
 func handleGetMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, mediaID string) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -309,7 +310,7 @@ func handleAssignMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB
 		return
 	}
 
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -338,7 +339,7 @@ func handleAssignMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB
 // handleRemoveMediaProfile removes profile assignment from a media item.
 // DELETE /api/media/profile/{id}
 func handleRemoveMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, mediaID string) {
-	store, err := database.OpenSQLStore(database.GetDatabasePath())
+	store, err := database.OpenStoreWithConfig()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -408,42 +409,23 @@ func methodRouter(methods map[string]http.Handler) http.Handler {
 	})
 }
 
-// languageProfilesRouter handles language profile sub-routes.
-func languageProfilesRouter(db *sql.DB) http.Handler {
+// rewritePrefix returns a handler that replaces the leading from segment of
+// the request path with to before delegating to h.
+//
+// It exists so /api/language-profiles (what the frontend calls) and
+// /api/profiles (what the handlers parse) can share one implementation
+// instead of being kept in sync by hand. The request is cloned rather than
+// mutated: the original *http.Request is visible to middleware up the chain,
+// and rewriting its URL in place would corrupt their view of the path.
+func rewritePrefix(from, to string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "GET":
-			handleGetLanguageProfile(db).ServeHTTP(w, r)
-		case "PUT":
-			handleUpdateLanguageProfile(db).ServeHTTP(w, r)
-		case "DELETE":
-			handleDeleteLanguageProfile(db).ServeHTTP(w, r)
-		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		if !strings.HasPrefix(r.URL.Path, from) {
+			h.ServeHTTP(w, r)
+			return
 		}
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = to + strings.TrimPrefix(r.URL.Path, from)
+		h.ServeHTTP(w, r2)
 	})
 }
 
-// handleGetLanguageProfile wraps handleGetProfile for compatibility.
-func handleGetLanguageProfile(db *sql.DB) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := extractIDFromPath(r.URL.Path, "/api/profiles/")
-		handleGetProfile(w, r, db, id)
-	})
-}
-
-// handleUpdateLanguageProfile wraps handleUpdateProfile for compatibility.
-func handleUpdateLanguageProfile(db *sql.DB) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := extractIDFromPath(r.URL.Path, "/api/profiles/")
-		handleUpdateProfile(w, r, db, id)
-	})
-}
-
-// handleDeleteLanguageProfile wraps handleDeleteProfile for compatibility.
-func handleDeleteLanguageProfile(db *sql.DB) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := extractIDFromPath(r.URL.Path, "/api/profiles/")
-		handleDeleteProfile(w, r, db, id)
-	})
-}

--- a/pkg/webserver/profiles_test.go
+++ b/pkg/webserver/profiles_test.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/profiles_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1b0c9d8e-7f6e-2a3b-5c4d-8f7e9a0b1c2d
+// last-edited: 2026-07-25
 
 package webserver
 
@@ -9,28 +10,55 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/jdfalk/subtitle-manager/pkg/profiles"
+	"github.com/spf13/viper"
 )
 
+// useTempProfileStore points the profile handlers at a throwaway SQLite
+// database for the duration of the test.
+//
+// The handlers open their own store via database.OpenStoreWithConfig rather
+// than using the *sql.DB passed to them, so the backend has to be configured
+// through viper. The previous tests worked around this by asserting the 500
+// that a missing store produced — locking in a failure rather than testing
+// behaviour, which is why they inverted and started failing once the store
+// opened successfully.
+func useTempProfileStore(t *testing.T) {
+	t.Helper()
+	prevBackend := viper.GetString("db_backend")
+	prevPath := viper.GetString("db_path")
+	t.Cleanup(func() {
+		viper.Set("db_backend", prevBackend)
+		viper.Set("db_path", prevPath)
+	})
+	viper.Set("db_backend", "sqlite")
+	viper.Set("db_path", filepath.Join(t.TempDir(), "profiles.db"))
+}
+
 func TestProfilesHandlerList(t *testing.T) {
-	// This test would require SQLite support which is not available in the test environment
-	// We'll create a basic structure test instead
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
 	handler := profilesHandler(nil)
 
-	req, err := http.NewRequest("GET", "/api/profiles", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	req := httptest.NewRequest(http.MethodGet, "/api/profiles", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Expect internal server error due to no SQLite support, but handler should not panic
-	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d (body: %s)",
+			http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	// An empty store must still yield valid JSON the UI can iterate over.
+	var got []profiles.LanguageProfile
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not a JSON profile array: %v (body: %s)",
+			err, rr.Body.String())
 	}
 }
 
@@ -50,20 +78,36 @@ func TestProfilesHandlerCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
 	handler := profilesHandler(nil)
 
-	req, err := http.NewRequest("POST", "/api/profiles", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	req := httptest.NewRequest(http.MethodPost, "/api/profiles", bytes.NewBuffer(body))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Expect internal server error due to no SQLite support, but handler should not panic
-	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("Expected 200 or 201, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
+
+	// The created profile must come back from a subsequent list, otherwise the
+	// write silently went nowhere.
+	listReq := httptest.NewRequest(http.MethodGet, "/api/profiles", nil)
+	listRR := httptest.NewRecorder()
+	handler.ServeHTTP(listRR, listReq)
+
+	var got []profiles.LanguageProfile
+	if err := json.Unmarshal(listRR.Body.Bytes(), &got); err != nil {
+		t.Fatalf("list response is not a JSON profile array: %v", err)
+	}
+	for _, p := range got {
+		if p.Name == "Test Profile" {
+			return
+		}
+	}
+	t.Errorf("created profile %q not present in list (got %d profiles)",
+		"Test Profile", len(got))
 }
 
 func TestProfilesHandlerInvalidJSON(t *testing.T) {
@@ -130,19 +174,22 @@ func TestProfilesHandlerValidation(t *testing.T) {
 }
 
 func TestMediaProfilesHandler(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
 	handler := mediaProfilesHandler(nil)
 
-	req, err := http.NewRequest("GET", "/api/media/profile/123", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	req := httptest.NewRequest(http.MethodGet, "/api/media/profile/123", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Expect internal server error due to no SQLite support, but handler should not panic
-	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	// Media 123 has no assignment. Any answer is acceptable except a 5xx: the
+	// handler must resolve the store and report "no assignment" rather than
+	// fall over. Asserting the exact code would pin down an unspecified
+	// not-found representation.
+	if rr.Code >= 500 {
+		t.Errorf("unassigned media returned server error %d (body: %s)",
+			rr.Code, rr.Body.String())
 	}
 }
 

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -38,6 +38,21 @@ var frontendAPIPaths = []string{
 	"/api/providers/status",
 }
 
+// knownMissingAPIPaths are paths the web UI calls that have no backend handler
+// at all — not merely unmounted, unwritten.
+//
+// They are listed rather than omitted so this file records the real state of
+// the contract: frontendAPIPaths above is a curated list of routes that should
+// pass, and without this second list a green run would read as "the frontend's
+// API surface is covered" when it means "these ten are". Each entry is skipped
+// with its caller; delete the entry when the handler lands.
+var knownMissingAPIPaths = map[string]string{
+	"/api/wanted":             "Wanted.jsx — Bazarr's wanted list; needs a handler over monitored_items",
+	"/api/bulk-operation":     "MediaLibrary.jsx — bulk media operations",
+	"/api/library/rescan-all": "App.jsx — rescan every library path",
+	"/api/notifications/test": "NotificationSettings.jsx — send a test notification",
+}
+
 // TestFrontendAPIPathsAreMounted verifies no frontend-called API path falls
 // through to the SPA catch-all.
 //
@@ -57,15 +72,23 @@ func TestFrontendAPIPathsAreMounted(t *testing.T) {
 	}
 	catchAll := prefix + "/"
 
+	assertMounted := func(t *testing.T, p string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, prefix+p, nil)
+		if _, pattern := mux.Handler(req); pattern == catchAll {
+			t.Errorf("%s matched the SPA catch-all %q instead of an API route; "+
+				"the web UI calls this path, so it returns index.html with a 200 "+
+				"and the page silently renders empty", p, catchAll)
+		}
+	}
+
 	for _, p := range frontendAPIPaths {
-		t.Run(p, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, prefix+p, nil)
-			_, pattern := mux.Handler(req)
-			if pattern == catchAll {
-				t.Errorf("%s matched the SPA catch-all %q instead of an API route; "+
-					"the web UI calls this path, so it returns index.html with a 200 "+
-					"and the page silently renders empty", p, catchAll)
-			}
+		t.Run(p, func(t *testing.T) { assertMounted(t, p) })
+	}
+
+	for p, why := range knownMissingAPIPaths {
+		t.Run("missing"+p, func(t *testing.T) {
+			t.Skipf("no handler exists: %s", why)
 		})
 	}
 }

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -1,0 +1,102 @@
+// file: pkg/webserver/route_coverage_test.go
+// version: 1.0.0
+// guid: 6b2c9d41-8f37-4a52-9c60-1d4e7a8b3f05
+// last-edited: 2026-07-25
+
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// frontendAPIPaths lists API paths the web UI calls. Each must be served by a
+// real handler.
+//
+// This guards a whole class of bug rather than one endpoint. The mux registers
+// a catch-all at "/" that serves the SPA's index.html, so an unmounted API
+// route does not 404 — it returns 200 with an HTML body. The frontend's
+// `if (res.ok)` check passes, the following res.json() throws into a catch
+// block that only console.errors, and the page renders empty with no
+// server-side trace. Language profiles shipped that way: profilesHandler was
+// written and unit-tested, but never mounted, so the entire Languages settings
+// page was inert.
+//
+// Unit-testing a handler in isolation cannot catch this. The assertion has to
+// run through the real mux.
+var frontendAPIPaths = []string{
+	"/api/profiles",
+	"/api/profiles/some-id",
+	"/api/language-profiles",
+	"/api/language-profiles/some-id",
+	"/api/media/profile/some-id",
+	"/api/config",
+	"/api/history",
+	"/api/system",
+	"/api/library/browse",
+	"/api/providers/status",
+}
+
+// TestFrontendAPIPathsAreMounted verifies no frontend-called API path falls
+// through to the SPA catch-all.
+//
+// The assertion is on the mux pattern rather than the response. A mounted
+// handler may legitimately answer 400/404/405/500 depending on the ID and
+// storage backend, so no status code distinguishes "missing route" from
+// "handler said no" — but the matched pattern does, exactly.
+// A nil *sql.DB is deliberate, and load-bearing: route registration does not
+// touch the database, so the test runs without the sqlite build tag. The rest
+// of this package's tests call skipIfNoSQLite and therefore skip entirely in
+// CI, which builds without that tag — a guard that skips where it is needed
+// most is not a guard.
+func TestFrontendAPIPathsAreMounted(t *testing.T) {
+	mux, prefix, err := newMux(nil)
+	if err != nil {
+		t.Fatalf("newMux: %v", err)
+	}
+	catchAll := prefix + "/"
+
+	for _, p := range frontendAPIPaths {
+		t.Run(p, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, prefix+p, nil)
+			_, pattern := mux.Handler(req)
+			if pattern == catchAll {
+				t.Errorf("%s matched the SPA catch-all %q instead of an API route; "+
+					"the web UI calls this path, so it returns index.html with a 200 "+
+					"and the page silently renders empty", p, catchAll)
+			}
+		})
+	}
+}
+
+// TestRewritePrefix verifies the language-profiles alias maps onto the
+// /api/profiles paths the handlers parse, and leaves other paths untouched.
+func TestRewritePrefix(t *testing.T) {
+	var got string
+	h := rewritePrefix("/api/language-profiles", "/api/profiles",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.URL.Path
+		}))
+
+	for _, tc := range []struct{ in, want string }{
+		{"/api/language-profiles", "/api/profiles"},
+		{"/api/language-profiles/", "/api/profiles/"},
+		{"/api/language-profiles/abc", "/api/profiles/abc"},
+		{"/api/language-profiles/abc/default", "/api/profiles/abc/default"},
+		// Non-matching paths pass through unchanged.
+		{"/api/profiles/abc", "/api/profiles/abc"},
+	} {
+		req := httptest.NewRequest(http.MethodGet, tc.in, nil)
+		h.ServeHTTP(httptest.NewRecorder(), req)
+		if got != tc.want {
+			t.Errorf("rewritePrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		// The original request must not be mutated; middleware up the chain
+		// still sees the path the client actually requested.
+		if req.URL.Path != tc.in {
+			t.Errorf("rewritePrefix mutated the original request: %q became %q",
+				tc.in, req.URL.Path)
+		}
+	}
+}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -138,12 +138,30 @@ func setupHandler(db *sql.DB) http.Handler {
 
 // Handler returns an http.Handler that serves the embedded web UI.
 func Handler(db *sql.DB) (http.Handler, error) {
+	mux, _, err := newMux(db)
+	if err != nil {
+		return nil, err
+	}
+	return securityHeadersMiddleware(mux), nil
+}
+
+// newMux builds the route table and returns it with the configured base-URL
+// prefix.
+//
+// It is split out from Handler so tests can ask http.ServeMux.Handler which
+// pattern a given path matches. That is the only reliable way to assert an API
+// route is mounted: an unmounted /api/... path is absorbed by the SPA
+// catch-all, and what that returns depends on the build — 200 with index.html
+// when webui/dist is populated, 404 when it is empty in tests. Asserting on the
+// response therefore silently passes in CI while the route is broken in
+// production.
+func newMux(db *sql.DB) (*http.ServeMux, string, error) {
 	// Initialize webhook system
 	initializeWebhooks()
 
 	f, err := fs.Sub(webui.FS, "dist")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	prefix := strings.Trim(viper.GetString("base_url"), "/")
 	if prefix != "" {
@@ -256,7 +274,27 @@ func Handler(db *sql.DB) (http.Handler, error) {
 	mux.Handle(prefix+"/api/series/", authMiddleware(db, "basic", universalTagsHandler(db)))
 	mux.Handle(prefix+"/api/languages/", authMiddleware(db, "admin", universalTagsHandler(db)))
 
-	// Language profiles management
+	// Language profiles management.
+	//
+	// These handlers existed and were unit-tested but were never mounted, so
+	// every request fell through to the SPA catch-all below and returned
+	// index.html with a 200. The frontend's `res.ok` check passed, the
+	// subsequent res.json() threw, and the Languages settings page silently
+	// rendered as empty. Permission is "basic" to match /api/config rather
+	// than the "admin" used for tags: language profiles are settings the
+	// media pages also read to render profile dropdowns.
+	mux.Handle(prefix+"/api/profiles", authMiddleware(db, "basic", profilesHandler(db)))
+	mux.Handle(prefix+"/api/profiles/", authMiddleware(db, "basic", profilesHandler(db)))
+	mux.Handle(prefix+"/api/media/profile/", authMiddleware(db, "basic", mediaProfilesHandler(db)))
+
+	// The frontend calls /api/language-profiles; the handler and its ID
+	// extraction are written against /api/profiles. Alias rather than
+	// duplicate, so a single implementation serves both spellings.
+	mux.Handle(prefix+"/api/language-profiles", authMiddleware(db, "basic",
+		rewritePrefix("/api/language-profiles", "/api/profiles", profilesHandler(db))))
+	mux.Handle(prefix+"/api/language-profiles/", authMiddleware(db, "basic",
+		rewritePrefix("/api/language-profiles", "/api/profiles", profilesHandler(db))))
+
 	// Prometheus metrics endpoint (no authentication required for monitoring)
 	mux.Handle(prefix+"/metrics", promhttp.Handler())
 
@@ -266,7 +304,7 @@ func Handler(db *sql.DB) (http.Handler, error) {
 
 	fsHandler := spaFileServer(f)
 	mux.Handle(prefix+"/", staticFileMiddleware(http.StripPrefix(prefix+"/", fsHandler)))
-	return securityHeadersMiddleware(mux), nil
+	return mux, prefix, nil
 }
 
 // StartServer starts an HTTP server on the given address serving the embedded UI.

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/server.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
 // last-edited: 2026-07-25
 


### PR DESCRIPTION
## What

`profilesHandler` and `mediaProfilesHandler` were fully implemented and unit-tested, but **never registered with the router**. `server.go` even had a `// Language profiles management` comment with nothing under it. The Settings → Languages page and all media profile assignment were inert.

Mounts:

- `/api/profiles`, `/api/profiles/{id}`
- `/api/media/profile/{id}`
- `/api/language-profiles`, `/api/language-profiles/{id}`

## Why it was invisible

The mux serves the SPA from a catch-all at `/`. An unregistered `/api/...` path did **not** 404 — it returned `200` with `index.html`. So the frontend's `if (res.ok)` passed, the following `res.json()` threw into a `catch` that only `console.error`s, and the page rendered empty with **nothing in the server log**.

Verified against the running app before and after:

```
before:  GET /api/language-profiles -> 200 text/html   (index.html)
after:   GET /api/language-profiles -> 500 text/plain  (real handler; see limitation)
```

## Decisions

- **Alias, not duplicate.** The frontend calls `/api/language-profiles`; the handlers parse `/api/profiles`. A `rewritePrefix` helper maps one onto the other so a single implementation serves both. It clones the request rather than mutating it, so middleware up the chain still sees the path the client sent.
- **Permission `basic`**, matching `/api/config` rather than the `admin` used for tags — media pages read profiles to render dropdowns, and language profiles are settings-shaped.
- **`OpenSQLStore` → `OpenStoreWithConfig`** in the profile handlers (9 sites). They hardcoded the SQL backend, ignoring configuration.
- **Deleted `languageProfilesRouter`** and its three wrappers — referenced only by each other, and their `extractIDFromPath(path, "/api/profiles/")` prefix never matched any live route. Dead code written against a route that never existed.

## Known limitation — please read

These endpoints **work on SQLite but return `500` on Pebble.** They open a store per request, and Pebble takes an exclusive file lock already held by the server process for its lifetime. Confirmed directly:

```
pebble.Open(<running server's db>) -> "resource temporarily unavailable"
```

This is **pre-existing and not caused by this PR** — the same per-request open exists in `librarypaths.go:72`, `pipeline.go:75`, and `scan.go:219`. Reverting the store change would not help: the old code called `OpenSQLStore` on a Pebble path, which also fails.

Fixing it needs a process-wide shared store (keyed by backend+path; handlers must not `Close`), which is a cross-cutting `pkg/database` lifecycle change. Deliberately **not** mixed into this wiring fix. Follow-up will convert all four call sites.

## Tests

`TestFrontendAPIPathsAreMounted` guards the whole class, not just this endpoint. Two deliberate choices:

1. **Asserts the matched `ServeMux` pattern, not the response.** What the catch-all returns depends on the build — `200`/`index.html` when `webui/dist` is populated, `404` when empty in tests. A response-based assertion passes in CI while the route is broken in production. I wrote that version first and it passed against the unfixed code; the pattern-based one fails on exactly the 4 missing routes.
2. **Runs without the `sqlite` build tag.** The rest of this package calls `skipIfNoSQLite` and so skips entirely in CI. A guard that skips where it is needed most is not a guard. Route registration doesn't touch the DB, so `newMux(nil)` suffices.

To make that possible, `Handler` is split into `newMux(db) (*http.ServeMux, string, error)` plus a thin wrapper.

Three profile tests asserted `500` "due to no SQLite support" — pinning an environment failure rather than behaviour, which inverted once the store opened successfully. Rewritten to assert real behaviour (list returns a JSON array; a created profile appears in a subsequent list).

**Net test effect: 3 pre-existing failures fixed, 0 added.** Verified `go test -race -shuffle=on` stable across repeat runs.

## Separate finding, not addressed here

`go test -tags sqlite -race ./pkg/webserver/` fails on unmodified `main`: 5 tests plus a data race. Without the tag it passes, because everything skips — which is how CI runs it. The authenticated webserver surface is effectively unexercised in CI. Reported separately; does not block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH