### PR TITLE
fix(database): share one store per process so Pebble features work

### DIFF
--- a/changelog.d/fix-shared-store.md
+++ b/changelog.d/fix-shared-store.md
@@ -1,0 +1,38 @@
+<!-- file: changelog.d/fix-shared-store.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b5d38f21-6c04-4a97-9e15-3f7a0c82d146 -->
+<!-- last-edited: 2026-07-25 -->
+
+### Fixed
+
+#### Web server features no longer fail on the Pebble backend
+
+Several parts of the web server opened their own database handle per request.
+On SQLite that is harmless. On Pebble, which takes an **exclusive file lock**,
+it could not work: the server opens a store at startup for the Sonarr/Radarr
+sync tasks and holds it for the process lifetime, so every subsequent open
+failed with `resource temporarily unavailable`.
+
+The result was that entire features worked or did not depending on which
+storage backend the operator had configured, with no message pointing at the
+cause:
+
+- Language profile endpoints returned `500`.
+- Adding a library path returned `200` while the scan behind it never ran —
+  the failure appeared only as one line in the log.
+- The library search sweep and the library scan had the same defect.
+
+`database.GetSharedStore` now returns a process-wide store, opened once and
+reused, keyed by backend and path so that reconfiguring yields a store for the
+new database rather than silently reusing the old one. The web server's startup
+open, the profile handlers, the library scan, the library search sweep and the
+library-path scan all use it. Callers must not `Close` it;
+`database.CloseSharedStores` exists for shutdown and tests.
+
+`OpenStoreWithConfig` still returns a fresh, caller-owned store and remains
+correct for one-shot CLI commands, which own the database for the life of the
+process.
+
+Verified end-to-end against a running server on the Pebble backend: language
+profile listing and creation went from `500` to working, and adding a library
+path went from one logged store-open failure to none.

--- a/pkg/database/shared.go
+++ b/pkg/database/shared.go
@@ -1,0 +1,81 @@
+// file: pkg/database/shared.go
+// version: 1.0.0
+// guid: 3f8a1c05-7d94-4e26-b0af-52c9138e7d64
+// last-edited: 2026-07-25
+
+package database
+
+import "sync"
+
+// Shared stores, keyed by "backend|path".
+var (
+	sharedMu     sync.Mutex
+	sharedStores = map[string]SubtitleStore{}
+)
+
+// GetSharedStore returns a process-wide SubtitleStore for the configured
+// backend, opening it on first use and reusing it thereafter.
+//
+// Callers MUST NOT call Close on the returned store — it is shared with every
+// other caller in the process, and closing it breaks them. Use
+// CloseSharedStores at shutdown, or from a test cleanup.
+//
+// This exists because Pebble takes an *exclusive file lock*. The web server
+// opens a store at startup for the Sonarr/Radarr sync tasks and holds it for
+// the process lifetime, so any handler that opened its own store per request
+// failed with "resource temporarily unavailable" and returned 500 — but only
+// on Pebble. On SQLite, which permits multiple handles, the same code worked
+// fine, so the bug was invisible in tests and depended on the operator's
+// choice of backend.
+//
+// Sharing one handle is safe: SQLStore, PostgresStore and PebbleStore are thin
+// wrappers over *sql.DB / *pebble.DB, both of which are safe for concurrent
+// use, and none of them holds mutable state of its own.
+//
+// The key includes the path and backend so that changing configuration (which
+// tests do routinely, via a temp directory per test) yields a distinct store
+// rather than silently handing back one pointed at the previous database.
+func GetSharedStore() (SubtitleStore, error) {
+	path := GetDatabasePath()
+	backend := GetDatabaseBackend()
+	key := backend + "|" + path
+
+	// The lock is deliberately held across OpenStore rather than released for
+	// the open and re-taken: two goroutines racing here would otherwise both
+	// open a store, and on Pebble the loser's open fails on the lock — exactly
+	// the bug this function exists to prevent.
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+
+	if s, ok := sharedStores[key]; ok {
+		return s, nil
+	}
+	s, err := OpenStore(path, backend)
+	if err != nil {
+		// Not cached: a failed open must not poison later attempts, which may
+		// succeed once the path exists or the config is corrected.
+		return nil, err
+	}
+	sharedStores[key] = s
+	return s, nil
+}
+
+// CloseSharedStores closes every store handed out by GetSharedStore and clears
+// the cache. It returns the first error encountered, after attempting to close
+// all of them.
+//
+// Intended for process shutdown and for tests that need to release a database
+// file (notably on Windows, and for Pebble's lock) before removing it.
+func CloseSharedStores() error {
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+
+	var firstErr error
+	for key, s := range sharedStores {
+		if err := s.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		delete(sharedStores, key)
+	}
+	return firstErr
+}

--- a/pkg/database/shared_test.go
+++ b/pkg/database/shared_test.go
@@ -1,0 +1,158 @@
+// file: pkg/database/shared_test.go
+// version: 1.0.0
+// guid: 5e71b4c8-9a02-4d3f-81b6-c47f0e29a1d3
+// last-edited: 2026-07-25
+
+package database
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// usePebbleAt points the database configuration at a throwaway Pebble
+// directory and releases every shared store afterwards.
+//
+// Pebble is used rather than SQLite because it is the backend that exhibits the
+// bug: it takes an exclusive file lock, so a second concurrent open fails. It
+// also needs no cgo and no build tag, so these tests run in CI — unlike the
+// webserver suite, which skips without `-tags sqlite`.
+func usePebbleAt(t *testing.T, dir string) {
+	t.Helper()
+	prevBackend := viper.GetString("db_backend")
+	prevPath := viper.GetString("db_path")
+	viper.Set("db_backend", "pebble")
+	viper.Set("db_path", dir)
+	t.Cleanup(func() {
+		if err := CloseSharedStores(); err != nil {
+			t.Errorf("CloseSharedStores: %v", err)
+		}
+		viper.Set("db_backend", prevBackend)
+		viper.Set("db_path", prevPath)
+	})
+}
+
+// TestGetSharedStoreSurvivesSecondOpen is the regression test for the bug this
+// package-level cache exists to fix.
+//
+// The web server opened a store at startup and held it for the process
+// lifetime, then each request handler opened another. On Pebble the second open
+// failed with "resource temporarily unavailable" and the handler returned 500 —
+// while on SQLite, which permits multiple handles, the identical code worked.
+// Whole pages were broken or not depending on the operator's backend choice.
+func TestGetSharedStoreSurvivesSecondOpen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "pebble")
+	usePebbleAt(t, dir)
+
+	// Stands in for the web server's startup open, held for the process
+	// lifetime.
+	first, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("first GetSharedStore: %v", err)
+	}
+
+	// Stands in for a request handler needing a store while the above is held.
+	second, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("second GetSharedStore while the first is held: %v "+
+			"(this is the 500-on-Pebble bug)", err)
+	}
+	if first != second {
+		t.Error("GetSharedStore returned a distinct store for the same config; " +
+			"a second Pebble handle cannot be opened while the first is held")
+	}
+
+	// Demonstrates that the old approach genuinely fails here, so the test
+	// above is not passing vacuously.
+	if extra, err := OpenStoreWithConfig(); err == nil {
+		extra.Close()
+		t.Error("OpenStoreWithConfig unexpectedly succeeded while a shared " +
+			"Pebble store was open; if Pebble no longer takes an exclusive " +
+			"lock, GetSharedStore may no longer be necessary")
+	}
+}
+
+// TestGetSharedStoreSeparatesConfigs verifies the cache is keyed by backend and
+// path, so reconfiguring yields a store for the new database rather than
+// silently reusing the previous one.
+func TestGetSharedStoreSeparatesConfigs(t *testing.T) {
+	root := t.TempDir()
+
+	usePebbleAt(t, filepath.Join(root, "one"))
+	first, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("open first: %v", err)
+	}
+
+	viper.Set("db_path", filepath.Join(root, "two"))
+	second, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("open second: %v", err)
+	}
+
+	if first == second {
+		t.Error("changing db_path returned the same store; callers would " +
+			"silently read and write the previous database")
+	}
+}
+
+// TestGetSharedStoreConcurrent verifies concurrent callers all receive the same
+// store and none observes a lock failure. Run under -race.
+//
+// The lock in GetSharedStore is held across OpenStore precisely for this case:
+// releasing it around the open would let two goroutines both attempt one, and
+// on Pebble the loser fails on the file lock.
+func TestGetSharedStoreConcurrent(t *testing.T) {
+	usePebbleAt(t, filepath.Join(t.TempDir(), "pebble"))
+
+	const n = 20
+	var wg sync.WaitGroup
+	stores := make([]SubtitleStore, n)
+	errs := make([]error, n)
+
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			stores[i], errs[i] = GetSharedStore()
+		}()
+	}
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		if stores[i] != stores[0] {
+			t.Fatalf("goroutine %d got a different store instance", i)
+		}
+	}
+}
+
+// TestCloseSharedStoresAllowsReopen verifies the cache is cleared, so a
+// subsequent GetSharedStore opens a fresh handle rather than returning a closed
+// one.
+func TestCloseSharedStoresAllowsReopen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "pebble")
+	usePebbleAt(t, dir)
+
+	first, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := CloseSharedStores(); err != nil {
+		t.Fatalf("CloseSharedStores: %v", err)
+	}
+
+	second, err := GetSharedStore()
+	if err != nil {
+		t.Fatalf("reopen after close: %v", err)
+	}
+	if first == second {
+		t.Error("GetSharedStore returned the closed store after " +
+			"CloseSharedStores; every subsequent query would fail")
+	}
+}

--- a/pkg/database/store_factory.go
+++ b/pkg/database/store_factory.go
@@ -1,3 +1,8 @@
+// file: pkg/database/store_factory.go
+// version: 1.1.0
+// guid: e84ac7c7-7e79-4715-b815-2a759bf96277
+// last-edited: 2026-07-25
+
 package database
 
 // OpenStore selects a storage backend and returns a SubtitleStore.
@@ -13,7 +18,14 @@ func OpenStore(path, backend string) (SubtitleStore, error) {
 	}
 }
 
-// OpenStoreWithConfig opens a store using the current configuration.
+// OpenStoreWithConfig opens a *new* store using the current configuration. The
+// caller owns it and must Close it.
+//
+// Long-lived processes that open a store more than once — the web server, and
+// anything running inside it — must use GetSharedStore instead. Pebble takes an
+// exclusive file lock, so a second concurrent open fails outright. This
+// function is appropriate for one-shot CLI commands, which own the database for
+// the duration of the process.
 func OpenStoreWithConfig() (SubtitleStore, error) {
 	path := GetDatabasePath()
 	backend := GetDatabaseBackend()

--- a/pkg/webserver/librarypaths.go
+++ b/pkg/webserver/librarypaths.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/librarypaths.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 17206a5a-f1bc-4f44-acfa-aa3d7f72f59c
+// last-edited: 2026-07-25
 
 package webserver
 
@@ -69,13 +70,13 @@ func writeLibraryPaths(paths []string) error {
 // viper mutation — e.g. a test's deferred viper.Reset().
 func scanPathAsync(dir string) {
 	logger := logging.GetLogger("library-paths")
-	store, err := database.OpenStoreWithConfig()
+	// Shared, so not closed by the goroutine: see database.GetSharedStore.
+	store, err := database.GetSharedStore()
 	if err != nil {
 		logger.Warnf("scan %s: open store: %v", dir, err)
 		return
 	}
 	go func() {
-		defer store.Close()
 		if err := metadata.ScanLibraryProgress(context.Background(), dir, store, nil); err != nil {
 			logger.Warnf("scan %s: %v", dir, err)
 		}

--- a/pkg/webserver/pipeline.go
+++ b/pkg/webserver/pipeline.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/pipeline.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e57ab8d-480a-41c5-8d2f-3eab3a966511
+// last-edited: 2026-07-25
 
 package webserver
 
@@ -72,12 +73,12 @@ func librarySearchHandler() http.Handler {
 
 		go func() {
 			logger := logging.GetLogger("library-search")
-			store, err := database.OpenStoreWithConfig()
+			// Shared, so not closed here: see database.GetSharedStore.
+			store, err := database.GetSharedStore()
 			if err != nil {
 				finishLibrarySearch(err)
 				return
 			}
-			defer store.Close()
 			workers := viper.GetInt("scan_workers")
 			if workers < 1 {
 				workers = 4

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/profiles.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
 // last-edited: 2026-07-25
 
@@ -84,12 +84,11 @@ func profilesHandler(db *sql.DB) http.Handler {
 // handleListProfiles returns all language profiles.
 // GET /api/profiles
 func handleListProfiles(w http.ResponseWriter, r *http.Request, db *sql.DB) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	profiles, err := store.ListLanguageProfiles()
 	if err != nil {
@@ -125,12 +124,11 @@ func handleCreateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	if err := store.CreateLanguageProfile(ConvertProfilesToDatabase(&profile)); err != nil {
 		http.Error(w, "Failed to create profile", http.StatusInternalServerError)
@@ -145,12 +143,11 @@ func handleCreateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 // handleGetProfile returns a specific language profile.
 // GET /api/profiles/{id}
 func handleGetProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	profile, err := store.GetLanguageProfile(profileID)
 	if err != nil {
@@ -185,12 +182,11 @@ func handleUpdateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 		return
 	}
 
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	if err := store.UpdateLanguageProfile(ConvertProfilesToDatabase(&profile)); err != nil {
 		http.Error(w, "Failed to update profile", http.StatusInternalServerError)
@@ -204,12 +200,11 @@ func handleUpdateProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 // handleDeleteProfile deletes a language profile.
 // DELETE /api/profiles/{id}
 func handleDeleteProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	// Check if this is the default profile
 	defaultProfile, err := store.GetDefaultLanguageProfile()
@@ -229,12 +224,11 @@ func handleDeleteProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 // handleSetDefaultProfile sets a profile as the default.
 // POST /api/profiles/{id}/default
 func handleSetDefaultProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profileID string) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	if err := store.SetDefaultLanguageProfile(profileID); err != nil {
 		http.Error(w, "Failed to set default profile", http.StatusInternalServerError)
@@ -276,12 +270,11 @@ func mediaProfilesHandler(db *sql.DB) http.Handler {
 // handleGetMediaProfile returns the profile assigned to a media item.
 // GET /api/media/profile/{id}
 func handleGetMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, mediaID string) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	profile, err := store.GetMediaProfile(mediaID)
 	if err != nil {
@@ -310,12 +303,11 @@ func handleAssignMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB
 		return
 	}
 
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	// Verify profile exists
 	_, err = store.GetLanguageProfile(request.ProfileID)
@@ -339,12 +331,11 @@ func handleAssignMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB
 // handleRemoveMediaProfile removes profile assignment from a media item.
 // DELETE /api/media/profile/{id}
 func handleRemoveMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, mediaID string) {
-	store, err := database.OpenStoreWithConfig()
+	store, err := database.GetSharedStore()
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
-	defer store.Close()
 
 	if err := store.RemoveProfileFromMedia(mediaID); err != nil {
 		http.Error(w, "Failed to remove profile assignment", http.StatusInternalServerError)
@@ -428,4 +419,3 @@ func rewritePrefix(from, to string, h http.Handler) http.Handler {
 		h.ServeHTTP(w, r2)
 	})
 }
-

--- a/pkg/webserver/scan.go
+++ b/pkg/webserver/scan.go
@@ -1,4 +1,8 @@
 // file: pkg/webserver/scan.go
+// version: 1.1.0
+// guid: c025a40c-894d-401d-a68d-a27b7f66c3b6
+// last-edited: 2026-07-25
+
 package webserver
 
 import (
@@ -216,14 +220,14 @@ func libraryScanHandler(db *sql.DB) http.Handler {
 		libStatus = libScanStatus{Running: true, Files: []string{}}
 		libMu.Unlock()
 		go func() {
-			store, err := database.OpenStoreWithConfig()
+			// Shared, so not closed here: see database.GetSharedStore.
+			store, err := database.GetSharedStore()
 			if err != nil {
 				libMu.Lock()
 				libStatus.Running = false
 				libMu.Unlock()
 				return
 			}
-			defer store.Close()
 			cb := func(f string) {
 				libMu.Lock()
 				libStatus.Completed++

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/server.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
 // last-edited: 2026-07-25
 
@@ -402,7 +402,11 @@ func StartServer(addr string) error {
 		viper.GetString("db_cleanup_frequency"))
 
 	// Start Sonarr/Radarr sync tasks when configured
-	if store, err := database.OpenStoreWithConfig(); err == nil {
+	// The shared store, not a private one: this handle lives for the process
+	// lifetime, and on Pebble it holds an exclusive file lock. Opening it
+	// privately here is what made every per-request store open in the handlers
+	// fail with a 500 on Pebble while working on SQLite.
+	if store, err := database.GetSharedStore(); err == nil {
 		// Prune download history older than the configured retention (Bazarr's
 		// history-retention). No-op when history.retention_days is unset/<=0.
 		maintenance.StartHistoryPruning(context.Background(), store,


### PR DESCRIPTION
Follows #2207 (now merged).

## The bug

Pebble takes an **exclusive file lock**. The web server opens a store at startup for the Sonarr/Radarr sync tasks and holds it for the process lifetime — so every handler that opened its own store per request failed with `resource temporarily unavailable`.

On SQLite, which permits multiple handles, the identical code works. **Whole features therefore worked or didn't depending on which backend the operator picked**, with nothing in the response pointing at the cause.

Confirmed directly against a running server:

```
pebble.Open(<running server's db dir>) -> "resource temporarily unavailable"
```

## What was broken

| | Symptom |
|---|---|
| Language profile endpoints | `500` |
| Add library path | `200` — but the scan behind it **never ran**, visible only as one log line |
| Library search sweep | same defect |
| Library scan | same defect |

The library-path case is the nastier one: a success response for work that silently didn't happen.

## The fix

`database.GetSharedStore()` — a process-wide store, opened once and reused, keyed by `backend|path` so reconfiguring yields a store for the *new* database rather than silently handing back one pointed at the old.

Converted: the **startup open** (essential — it's the actual lock holder, so converting only the handlers would fix nothing), the profile handlers, the library scan, the library search sweep, and the library-path scan.

`OpenStoreWithConfig` is unchanged and still returns a fresh caller-owned store. That remains correct for one-shot CLI commands, which own the database for the life of the process; its doc comment now says so and points long-lived callers at `GetSharedStore`.

Sharing one handle is safe: `SQLStore`, `PostgresStore` and `PebbleStore` are thin wrappers over `*sql.DB` / `*pebble.DB`, both safe for concurrent use, with no mutable state of their own. I checked this rather than assumed it.

The mutex is held **across** `OpenStore` rather than released around it — two goroutines racing there would both attempt an open, putting the loser straight back on the Pebble lock. Covered by a 20-goroutine test under `-race`.

## Tests

Written against **Pebble, not SQLite**, for two reasons: it's the backend that actually exhibits the bug, and it needs no cgo and no build tag — so these run in CI, unlike the webserver suite, which skips entirely without `-tags sqlite`.

`TestGetSharedStoreSurvivesSecondOpen` also asserts that `OpenStoreWithConfig` **still fails** under the same conditions. Without that, the test would pass vacuously if Pebble's locking ever changed, and would stop being evidence of anything.

Also covered: distinct configs yield distinct stores; `CloseSharedStores` clears the cache so a reopen doesn't hand back a closed handle; concurrent access.

## End-to-end verification

A/B against two servers on identical Pebble configs — pre-fix binary vs post-fix:

| pebble | pre-fix | post-fix |
|---|---|---|
| `GET /api/language-profiles` | **500** | **200**, full CRUD verified |
| add library path | 200, **1 logged store-open failure** | 200, **0 failures** |

## Note on a pre-existing failure

`TestLanguageProfileSQLiteIntegration` fails under `-tags sqlite` (`UNIQUE constraint failed: language_profiles.id`). It fails identically on `main` — **not caused by this PR**. It's another instance of the CI blind spot flagged on #2207: CI never builds the sqlite path, so these never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH