### PR TITLE
feat(webserver): add the wanted list and opt-in monitoring loop

### DIFF
--- a/changelog.d/feat-wanted-list.md
+++ b/changelog.d/feat-wanted-list.md
@@ -1,0 +1,54 @@
+<!-- file: changelog.d/feat-wanted-list.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c1f6b830-9d47-4e52-8a06-3b52e7d914af -->
+<!-- last-edited: 2026-07-25 -->
+
+### Added
+
+#### Wanted list
+
+`/api/wanted` now exists. The web UI has always called it, but no handler was
+ever registered, so the Wanted page silently rendered empty — the request fell
+through to the single-page-app catch-all and came back as `index.html` with a
+`200`, which the frontend accepted before failing to parse it.
+
+The endpoint is backed by the existing `monitored_items` table, which already
+carried status, retry count and blacklist integration, so no schema change was
+needed.
+
+    GET    /api/wanted                     list monitored media
+    POST   /api/wanted {path, languages}   start monitoring a file
+    DELETE /api/wanted {path}              stop monitoring a file
+
+The Wanted page now lists **media files missing subtitles**, which is what
+Bazarr means by "wanted", showing each file with its requested languages,
+status and retry count. It previously kept a list of subtitle *download URLs*
+bookmarked from search results — a different concept that Bazarr has no
+equivalent of, and that no backend ever implemented. "Add to Wanted" on a
+search result is replaced by "Monitor this file", which acts on the media path.
+
+#### Automatic subtitle monitoring in the web server, off by default
+
+The monitoring loop that acts on the wanted list previously existed only in the
+`monitor` CLI command, so `subtitle-manager web` never searched for missing
+subtitles on its own. It can now run inside the web server.
+
+**It is disabled by default and must be turned on explicitly** with
+`monitor.enabled: true`. This differs from Bazarr, which monitors by default,
+and the reason is deliberate: the loop runs the full download pipeline, which
+contacts subtitle providers and **writes subtitle files into the operator's
+media directories**, unattended, on a timer. Verified in testing — with
+monitoring enabled the server wrote a `.srt` next to a media file without
+further input. Bazarr asks about this during setup; there is no equivalent
+prompt here yet, so enabling it by default would mean an upgrade silently
+starts modifying a media library.
+
+Other keys: `monitor.interval` (minutes, default 60), `monitor.languages`
+(default `["en"]`), `monitor.max_retries` (default 3),
+`monitor.quality_check`.
+
+When Sonarr or Radarr is configured, the wanted list is populated from them on
+startup. It is deliberately **not** derived from the local media library: that
+would enrol every scanned file at once and turn a single opt-in into a
+library-wide download. Individual files can always be added through
+`POST /api/wanted`.

--- a/pkg/monitoring/sync.go
+++ b/pkg/monitoring/sync.go
@@ -1,6 +1,7 @@
 // file: pkg/monitoring/sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12345678-1234-1234-1234-123456789013
+// last-edited: 2026-07-25
 
 package monitoring
 
@@ -70,6 +71,17 @@ func (m *EpisodeMonitor) SyncFromRadarr(ctx context.Context, opts SyncOptions) e
 	}
 
 	return nil
+}
+
+// AddToMonitoring adds a single media item to the monitoring ("wanted") list,
+// merging languages if the path is already monitored.
+//
+// Exported for callers outside this package — the web server's /api/wanted
+// handler, which adds a path the operator picked by hand rather than one
+// discovered by a Sonarr/Radarr sync. For a manual add, only Path need be set;
+// MediaID stays empty, as there is no media_items row to link to.
+func (m *EpisodeMonitor) AddToMonitoring(mediaItem database.MediaItem, opts SyncOptions) error {
+	return m.addToMonitoring(mediaItem, opts)
 }
 
 // addToMonitoring adds a media item to the monitoring system.

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/route_coverage_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6b2c9d41-8f37-4a52-9c60-1d4e7a8b3f05
 // last-edited: 2026-07-25
 
@@ -36,6 +36,7 @@ var frontendAPIPaths = []string{
 	"/api/system",
 	"/api/library/browse",
 	"/api/providers/status",
+	"/api/wanted",
 }
 
 // knownMissingAPIPaths are paths the web UI calls that have no backend handler
@@ -47,7 +48,6 @@ var frontendAPIPaths = []string{
 // API surface is covered" when it means "these ten are". Each entry is skipped
 // with its caller; delete the entry when the handler lands.
 var knownMissingAPIPaths = map[string]string{
-	"/api/wanted":             "Wanted.jsx — Bazarr's wanted list; needs a handler over monitored_items",
 	"/api/bulk-operation":     "MediaLibrary.jsx — bulk media operations",
 	"/api/library/rescan-all": "App.jsx — rescan every library path",
 	"/api/notifications/test": "NotificationSettings.jsx — send a test notification",

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/server.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
 // last-edited: 2026-07-25
 
@@ -283,6 +283,7 @@ func newMux(db *sql.DB) (*http.ServeMux, string, error) {
 	// rendered as empty. Permission is "basic" to match /api/config rather
 	// than the "admin" used for tags: language profiles are settings the
 	// media pages also read to render profile dropdowns.
+	mux.Handle(prefix+"/api/wanted", authMiddleware(db, "basic", wantedHandler()))
 	mux.Handle(prefix+"/api/profiles", authMiddleware(db, "basic", profilesHandler(db)))
 	mux.Handle(prefix+"/api/profiles/", authMiddleware(db, "basic", profilesHandler(db)))
 	mux.Handle(prefix+"/api/media/profile/", authMiddleware(db, "basic", mediaProfilesHandler(db)))
@@ -481,6 +482,8 @@ func StartServer(addr string) error {
 	logger.Info("starting self test task")
 	selftest.StartPeriodic(context.Background(), db,
 		viper.GetString("selftest_frequency"))
+
+	startMonitoring(context.Background())
 
 	logger.Infof("listening on %s", addr)
 	return http.ListenAndServe(addr, h)

--- a/pkg/webserver/wanted.go
+++ b/pkg/webserver/wanted.go
@@ -1,0 +1,273 @@
+// file: pkg/webserver/wanted.go
+// version: 1.0.0
+// guid: 7a3c5e19-4b28-4d06-9f71-2c8e0a45b3d7
+// last-edited: 2026-07-25
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/arr"
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/monitoring"
+	"github.com/jdfalk/subtitle-manager/pkg/radarr"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+	"github.com/jdfalk/subtitle-manager/pkg/sonarr"
+)
+
+// Defaults for the monitor configuration. Interval is in minutes.
+const (
+	defaultMonitorInterval   = 60
+	defaultMonitorMaxRetries = 3
+)
+
+// monitorInterval returns the configured monitoring interval.
+//
+// The floor is not cosmetic: time.NewTicker panics on a non-positive duration,
+// so an unset or zero monitor.interval would crash the web server at startup
+// rather than fall back to a default.
+func monitorInterval() time.Duration {
+	minutes := viper.GetInt("monitor.interval")
+	if minutes < 1 {
+		minutes = defaultMonitorInterval
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
+// monitorLanguages returns the languages a newly wanted item is monitored for
+// when the caller does not specify any.
+func monitorLanguages() []string {
+	langs := viper.GetStringSlice("monitor.languages")
+	if len(langs) == 0 {
+		return []string{"en"}
+	}
+	return langs
+}
+
+// monitorMaxRetries returns how many times an item is retried before it is
+// marked failed and auto-blacklisted.
+func monitorMaxRetries() int {
+	n := viper.GetInt("monitor.max_retries")
+	if n < 1 {
+		return defaultMonitorMaxRetries
+	}
+	return n
+}
+
+// startMonitoring starts the automatic subtitle monitoring loop, but only when
+// the operator has explicitly enabled it.
+//
+// It is OFF BY DEFAULT, and that is a deliberate safety decision rather than
+// conservatism. The loop calls scanner.ProcessFile with upgrade enabled for
+// every monitored item, which contacts subtitle providers and writes subtitle
+// files into the operator's media directories, unattended, on a timer. Turning
+// that on as a side effect of upgrading the server would mean an installation
+// starts modifying a media library nobody asked it to touch. Bazarr enables its
+// equivalent by default, but Bazarr asks during setup; there is no such prompt
+// here yet, so the safe default wins until there is.
+//
+// Set monitor.enabled to true to turn it on. Related keys: monitor.interval
+// (minutes), monitor.languages, monitor.max_retries, monitor.quality_check.
+func startMonitoring(ctx context.Context) {
+	logger := logging.GetLogger("monitor")
+
+	if !viper.GetBool("monitor.enabled") {
+		logger.Info("automatic subtitle monitoring is disabled; " +
+			"set monitor.enabled to true to have subtitles downloaded on a schedule")
+		return
+	}
+
+	store, err := database.GetSharedStore()
+	if err != nil {
+		logger.Warnf("automatic monitoring not started, cannot open store: %v", err)
+		return
+	}
+
+	// nil clients when the integration is not configured — the monitor treats
+	// a nil client as "skip this source" rather than an error.
+	var sonarrClient *sonarr.Client
+	if u := arr.BaseURL("integrations.sonarr"); u != "" {
+		sonarrClient = sonarr.NewClient(u, viper.GetString("integrations.sonarr.api_key"))
+	}
+	var radarrClient *radarr.Client
+	if u := arr.BaseURL("integrations.radarr"); u != "" {
+		radarrClient = radarr.NewClient(u, viper.GetString("integrations.radarr.api_key"))
+	}
+
+	interval := monitorInterval()
+	mon := monitoring.NewEpisodeMonitor(interval, sonarrClient, radarrClient, store,
+		monitorMaxRetries(), viper.GetBool("monitor.quality_check"))
+
+	logger.Infof("starting automatic subtitle monitoring every %s", interval)
+
+	go func() {
+		// Populate the wanted list from Sonarr/Radarr before the first pass, so
+		// an operator with an *arr configured does not have to add paths by
+		// hand. Deliberately *not* derived from the local media library: that
+		// would enrol every scanned file at once and turn a single opt-in into
+		// a library-wide download. Items can still be added one at a time via
+		// POST /api/wanted.
+		opts := monitoring.SyncOptions{
+			Languages:  monitorLanguages(),
+			MaxRetries: monitorMaxRetries(),
+		}
+		if sonarrClient != nil {
+			if err := mon.SyncFromSonarr(ctx, opts); err != nil {
+				logger.Warnf("sync wanted list from Sonarr: %v", err)
+			}
+		}
+		if radarrClient != nil {
+			if err := mon.SyncFromRadarr(ctx, opts); err != nil {
+				logger.Warnf("sync wanted list from Radarr: %v", err)
+			}
+		}
+
+		// Start blocks until ctx is cancelled, and returns early if the very
+		// first check fails.
+		if err := mon.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Warnf("automatic subtitle monitoring stopped: %v", err)
+		}
+	}()
+}
+
+// wantedItem is the API representation of a monitored item.
+//
+// It is a distinct type from database.MonitoredItem rather than a re-encoding
+// of it because Languages is stored as a JSON string in the database; handing
+// that to the UI would force it to parse JSON out of a JSON field.
+type wantedItem struct {
+	ID          string    `json:"id"`
+	MediaID     string    `json:"media_id,omitempty"`
+	Path        string    `json:"path"`
+	Languages   []string  `json:"languages"`
+	Status      string    `json:"status"`
+	RetryCount  int       `json:"retry_count"`
+	MaxRetries  int       `json:"max_retries"`
+	LastChecked time.Time `json:"last_checked"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// wantedHandler serves the "wanted" list: media that is being monitored
+// because it is missing subtitles in one or more desired languages.
+//
+// This is Bazarr's central concept, and it is backed by the existing
+// monitored_items table, which already carries status, retry count and
+// blacklist integration. No schema change was needed.
+//
+//	GET    /api/wanted                       list every monitored item
+//	POST   /api/wanted {path, languages}     start monitoring a path
+//	DELETE /api/wanted {path}                stop monitoring a path
+//
+// Note that adding an item here does not by itself download anything. The
+// monitoring loop that acts on this list is opt-in and off by default; see
+// startMonitoring in server.go for why.
+func wantedHandler() http.Handler {
+	type body struct {
+		Path      string   `json:"path"`
+		Languages []string `json:"languages"`
+	}
+	logger := logging.GetLogger("wanted")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		store, err := database.GetSharedStore()
+		if err != nil {
+			logger.Warnf("open store: %v", err)
+			http.Error(w, "database unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			items, err := store.ListMonitoredItems()
+			if err != nil {
+				logger.Warnf("list monitored items: %v", err)
+				http.Error(w, "failed to list wanted items", http.StatusInternalServerError)
+				return
+			}
+			// Always a slice, never nil: the UI iterates the response, and a
+			// JSON null would force every caller to guard against it.
+			out := make([]wantedItem, 0, len(items))
+			for _, it := range items {
+				var langs []string
+				if err := json.Unmarshal([]byte(it.Languages), &langs); err != nil {
+					// A row with unparseable languages is reported with none
+					// rather than dropped, so it stays visible and fixable.
+					logger.Warnf("item %s has unparseable languages %q: %v", it.Path, it.Languages, err)
+					langs = nil
+				}
+				out = append(out, wantedItem{
+					ID:          it.ID,
+					MediaID:     it.MediaID,
+					Path:        it.Path,
+					Languages:   langs,
+					Status:      it.Status,
+					RetryCount:  it.RetryCount,
+					MaxRetries:  it.MaxRetries,
+					LastChecked: it.LastChecked,
+					CreatedAt:   it.CreatedAt,
+				})
+			}
+			writeJSON(w, out)
+
+		case http.MethodPost:
+			var q body
+			if err := json.NewDecoder(r.Body).Decode(&q); err != nil || q.Path == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			clean, err := security.ValidateAndSanitizePath(q.Path)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			langs := q.Languages
+			if len(langs) == 0 {
+				langs = monitorLanguages()
+			}
+			for _, l := range langs {
+				if err := security.ValidateLanguageCode(l); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			}
+
+			// nil Sonarr/Radarr clients: this path adds one item the operator
+			// named, so no *arr lookup is involved.
+			mon := monitoring.NewEpisodeMonitor(monitorInterval(), nil, nil, store,
+				monitorMaxRetries(), false)
+			opts := monitoring.SyncOptions{Languages: langs, MaxRetries: monitorMaxRetries()}
+			if err := mon.AddToMonitoring(database.MediaItem{Path: clean}, opts); err != nil {
+				logger.Warnf("add %s: %v", clean, err)
+				http.Error(w, "failed to add wanted item", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+
+		case http.MethodDelete:
+			var q body
+			if err := json.NewDecoder(r.Body).Decode(&q); err != nil || q.Path == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mon := monitoring.NewEpisodeMonitor(monitorInterval(), nil, nil, store,
+				monitorMaxRetries(), false)
+			if err := mon.RemoveFromMonitoring(q.Path); err != nil {
+				logger.Warnf("remove %s: %v", q.Path, err)
+				http.Error(w, "failed to remove wanted item", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}

--- a/pkg/webserver/wanted_test.go
+++ b/pkg/webserver/wanted_test.go
@@ -1,0 +1,187 @@
+// file: pkg/webserver/wanted_test.go
+// version: 1.0.0
+// guid: 2d90f4a7-6b13-4c85-a0e2-9f38c714b6de
+// last-edited: 2026-07-25
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+)
+
+// useWantedStore points the handler at a throwaway Pebble store and a media
+// file it will accept.
+//
+// Pebble rather than SQLite so these run without the sqlite build tag, which CI
+// does not set. Returns the path of a real media file: addToMonitoring skips
+// paths that do not exist on disk, so a fabricated one would silently no-op and
+// the test would assert nothing.
+func useWantedStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	prev := map[string]any{
+		"db_backend":      viper.Get("db_backend"),
+		"db_path":         viper.Get("db_path"),
+		"monitor.enabled": viper.Get("monitor.enabled"),
+	}
+	t.Cleanup(func() {
+		if err := database.CloseSharedStores(); err != nil {
+			t.Errorf("CloseSharedStores: %v", err)
+		}
+		for k, v := range prev {
+			viper.Set(k, v)
+		}
+	})
+	viper.Set("db_backend", "pebble")
+	viper.Set("db_path", filepath.Join(dir, "db"))
+
+	media := filepath.Join(dir, "Some.Movie.2021.1080p.mkv")
+	if err := os.WriteFile(media, []byte("not really a video"), 0o644); err != nil {
+		t.Fatalf("write media file: %v", err)
+	}
+	return media
+}
+
+func decodeWanted(t *testing.T, body []byte) []wantedItem {
+	t.Helper()
+	var got []wantedItem
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode wanted list: %v (body: %s)", err, body)
+	}
+	return got
+}
+
+// TestWantedRoundTrip covers add, list and remove through the handler.
+func TestWantedRoundTrip(t *testing.T) {
+	media := useWantedStore(t)
+	h := wantedHandler()
+
+	// Empty list must be [] rather than null: the UI iterates it directly.
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/wanted", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET empty: got %d (body %s)", rr.Code, rr.Body.String())
+	}
+	if strings.TrimSpace(rr.Body.String()) == "null" {
+		t.Error("GET returned JSON null for an empty list; the UI would have to guard against it")
+	}
+	if n := len(decodeWanted(t, rr.Body.Bytes())); n != 0 {
+		t.Fatalf("expected an empty list, got %d items", n)
+	}
+
+	// Add.
+	body := `{"path":` + jsonStr(media) + `,"languages":["en","es"]}`
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/wanted", strings.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("POST: got %d (body %s)", rr.Code, rr.Body.String())
+	}
+
+	// List reflects it, with languages decoded into a real array.
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/wanted", nil))
+	items := decodeWanted(t, rr.Body.Bytes())
+	if len(items) != 1 {
+		t.Fatalf("expected 1 wanted item, got %d", len(items))
+	}
+	if items[0].Path != media {
+		t.Errorf("path = %q, want %q", items[0].Path, media)
+	}
+	if len(items[0].Languages) != 2 {
+		t.Errorf("languages = %v, want two entries decoded from the stored JSON string",
+			items[0].Languages)
+	}
+
+	// Remove.
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodDelete, "/api/wanted",
+		strings.NewReader(`{"path":`+jsonStr(media)+`}`)))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: got %d (body %s)", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/wanted", nil))
+	if n := len(decodeWanted(t, rr.Body.Bytes())); n != 0 {
+		t.Errorf("expected the list to be empty after DELETE, got %d items", n)
+	}
+}
+
+// TestWantedRejectsBadInput verifies the handler validates before touching the
+// store.
+func TestWantedRejectsBadInput(t *testing.T) {
+	useWantedStore(t)
+	h := wantedHandler()
+
+	for name, tc := range map[string]struct {
+		method, body string
+		want         int
+	}{
+		"empty path":         {http.MethodPost, `{"path":""}`, http.StatusBadRequest},
+		"relative path":      {http.MethodPost, `{"path":"relative/file.mkv"}`, http.StatusBadRequest},
+		"malformed json":     {http.MethodPost, `{`, http.StatusBadRequest},
+		"bad language":       {http.MethodPost, `{"path":"/tmp/a.mkv","languages":["../etc"]}`, http.StatusBadRequest},
+		"delete empty path":  {http.MethodDelete, `{"path":""}`, http.StatusBadRequest},
+		"unsupported method": {http.MethodPatch, ``, http.StatusMethodNotAllowed},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequest(tc.method, "/api/wanted", strings.NewReader(tc.body)))
+			if rr.Code != tc.want {
+				t.Errorf("got %d, want %d (body %s)", rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestStartMonitoringDefaultsOff is a safety test, not a behaviour test.
+//
+// The monitoring loop calls scanner.ProcessFile with upgrade enabled, which
+// contacts subtitle providers and writes files into the operator's media
+// directories on a timer. If it ever started without an explicit opt-in, a
+// server upgrade would silently begin modifying a media library. This asserts
+// the default stays off.
+func TestStartMonitoringDefaultsOff(t *testing.T) {
+	useWantedStore(t)
+	viper.Set("monitor.enabled", nil)
+
+	if viper.GetBool("monitor.enabled") {
+		t.Fatal("monitor.enabled defaults to true; the monitoring loop would " +
+			"download subtitles into the user's media directories without being asked")
+	}
+
+	// Must return promptly without starting anything.
+	startMonitoring(context.Background())
+}
+
+// TestMonitorIntervalNeverZero guards against a startup panic: time.NewTicker
+// panics on a non-positive duration, and monitor.interval is routinely unset.
+func TestMonitorIntervalNeverZero(t *testing.T) {
+	prev := viper.Get("monitor.interval")
+	t.Cleanup(func() { viper.Set("monitor.interval", prev) })
+
+	for _, v := range []any{nil, 0, -5} {
+		viper.Set("monitor.interval", v)
+		if got := monitorInterval(); got <= 0 {
+			t.Errorf("monitor.interval=%v gave %v; time.NewTicker would panic", v, got)
+		}
+	}
+}
+
+// jsonStr quotes s as a JSON string.
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/webui/src/Wanted.jsx
+++ b/webui/src/Wanted.jsx
@@ -1,7 +1,5 @@
 import {
   Add as AddIcon,
-  CheckBox as CheckBoxIcon,
-  CheckBoxOutlineBlank as CheckBoxOutlineBlankIcon,
   Delete as DeleteIcon,
   Download as DownloadIcon,
   FilterList as FilterIcon,
@@ -75,6 +73,7 @@ export default function Wanted({ backendAvailable = true }) {
   const [lang, setLang] = useState('en');
   const [results, setResults] = useState([]);
   const [wanted, setWanted] = useState([]);
+  const [wantedError, setWantedError] = useState('');
   const [searching, setSearching] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -199,30 +198,44 @@ export default function Wanted({ backendAvailable = true }) {
     }
   };
 
-  const add = async url => {
+  // The wanted list tracks *media files* that are missing subtitles, matching
+  // Bazarr. It previously held subtitle download URLs bookmarked from search
+  // results, which is a different concept that Bazarr has no equivalent of and
+  // that no backend ever implemented.
+  const reloadWanted = async () => {
+    const res = await fetch('/api/wanted');
+    if (res.ok) {
+      setWanted((await res.json()) || []);
+    }
+  };
+
+  const add = async (mediaPath, languages) => {
     try {
       const res = await fetch('/api/wanted', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ path: mediaPath, languages }),
       });
       if (res.ok) {
-        setWanted([...wanted, url]);
+        await reloadWanted();
+      } else {
+        setWantedError(`Could not monitor ${mediaPath}`);
       }
     } catch (error) {
       console.error('Failed to add to wanted list:', error);
+      setWantedError(`Could not monitor ${mediaPath}`);
     }
   };
 
-  const remove = async url => {
+  const remove = async mediaPath => {
     try {
       const res = await fetch('/api/wanted', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ path: mediaPath }),
       });
       if (res.ok) {
-        setWanted(wanted.filter(item => item !== url));
+        setWanted(wanted.filter(item => item.path !== mediaPath));
       }
     } catch (error) {
       console.error('Failed to remove from wanted list:', error);
@@ -502,6 +515,22 @@ export default function Wanted({ backendAvailable = true }) {
                   >
                     {searching ? 'Searching...' : 'Search'}
                   </Button>
+                  <Button
+                    variant="outlined"
+                    startIcon={<AddIcon />}
+                    onClick={() => add(path.trim(), [lang])}
+                    disabled={
+                      !path.trim() ||
+                      wanted.some(item => item.path === path.trim())
+                    }
+                    fullWidth
+                    size="small"
+                    sx={{ mt: 1 }}
+                  >
+                    {wanted.some(item => item.path === path.trim())
+                      ? 'Monitored'
+                      : 'Monitor this file'}
+                  </Button>
                 </Grid>
               </Grid>
 
@@ -769,24 +798,6 @@ export default function Wanted({ backendAvailable = true }) {
                                   <PreviewIcon fontSize="small" />
                                 </IconButton>
                               </Tooltip>
-                              <Tooltip title="Add to Wanted">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => add(result.downloadUrl)}
-                                  disabled={wanted.includes(result.downloadUrl)}
-                                  color={
-                                    wanted.includes(result.downloadUrl)
-                                      ? 'success'
-                                      : 'default'
-                                  }
-                                >
-                                  {wanted.includes(result.downloadUrl) ? (
-                                    <CheckBoxIcon fontSize="small" />
-                                  ) : (
-                                    <AddIcon fontSize="small" />
-                                  )}
-                                </IconButton>
-                              </Tooltip>
                             </Box>
                           </TableCell>
                         </TableRow>
@@ -807,13 +818,23 @@ export default function Wanted({ backendAvailable = true }) {
                 <WantedIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
                 Wanted List ({wanted.length})
               </Typography>
+              {wantedError && (
+                <Alert
+                  severity="error"
+                  onClose={() => setWantedError('')}
+                  sx={{ mb: 1 }}
+                >
+                  {wantedError}
+                </Alert>
+              )}
               {loading ? (
                 <Box display="flex" justifyContent="center" p={2}>
                   <CircularProgress size={24} />
                 </Box>
               ) : wanted.length === 0 ? (
                 <Alert severity="info">
-                  No items in wanted list. Add subtitles from search results.
+                  Nothing is being monitored. Use &ldquo;Monitor this
+                  file&rdquo; to have subtitles searched for automatically.
                 </Alert>
               ) : (
                 <Paper
@@ -821,20 +842,56 @@ export default function Wanted({ backendAvailable = true }) {
                   sx={{ maxHeight: 400, overflow: 'auto' }}
                 >
                   <List dense>
-                    {wanted.map((url, index) => (
-                      <ListItem key={index} divider={index < wanted.length - 1}>
+                    {wanted.map((item, index) => (
+                      <ListItem
+                        key={item.id || item.path}
+                        divider={index < wanted.length - 1}
+                      >
                         <ListItemText
                           primary={
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                fontFamily: 'monospace',
-                                fontSize: '0.75rem',
-                                wordBreak: 'break-all',
-                              }}
+                            <Tooltip title={item.path}>
+                              <Typography variant="body2" noWrap>
+                                {item.path.split('/').pop()}
+                              </Typography>
+                            </Tooltip>
+                          }
+                          secondary={
+                            <Box
+                              component="span"
+                              display="flex"
+                              gap={0.5}
+                              alignItems="center"
+                              flexWrap="wrap"
+                              mt={0.5}
                             >
-                              {url}
-                            </Typography>
+                              {(item.languages || []).map(code => (
+                                <Chip
+                                  key={code}
+                                  label={code.toUpperCase()}
+                                  size="small"
+                                />
+                              ))}
+                              <Chip
+                                label={item.status}
+                                size="small"
+                                color={
+                                  item.status === 'found'
+                                    ? 'success'
+                                    : item.status === 'failed' ||
+                                        item.status === 'blacklisted'
+                                      ? 'error'
+                                      : 'default'
+                                }
+                              />
+                              {item.retry_count > 0 && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
+                                  {item.retry_count}/{item.max_retries} tries
+                                </Typography>
+                              )}
+                            </Box>
                           }
                         />
                         <ListItemSecondaryAction>
@@ -842,7 +899,7 @@ export default function Wanted({ backendAvailable = true }) {
                             edge="end"
                             size="small"
                             color="error"
-                            onClick={() => remove(url)}
+                            onClick={() => remove(item.path)}
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>

--- a/webui/src/__tests__/Wanted.test.jsx
+++ b/webui/src/__tests__/Wanted.test.jsx
@@ -1,34 +1,99 @@
 // file: webui/src/__tests__/Wanted.test.jsx
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { expect, vi } from 'vitest';
 import Wanted from '../Wanted.jsx';
 
+// The wanted list holds media files missing subtitles (Bazarr's model), not
+// bookmarked subtitle download URLs.
+//
+// The previous test asserted a GET `/api/search?provider=...` call the
+// component had already stopped making, so it was failing on the base branch
+// before any of these changes.
 describe('Wanted component', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     global.fetch = vi.fn();
   });
 
-  test('loads wanted list on mount and searches', async () => {
+  const wantedItem = {
+    id: 'item-1',
+    path: '/media/Some.Movie.2021.1080p.mkv',
+    languages: ['en'],
+    status: 'pending',
+    retry_count: 0,
+    max_retries: 3,
+  };
+
+  test('renders monitored media on mount', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve(['a']),
+      json: () => Promise.resolve([wantedItem]),
+    });
+
+    render(<Wanted />);
+
+    // Shown by basename, with its language and status. Scoped to the list
+    // item: 'EN' also appears in the page's language selector.
+    const name = await screen.findByText('Some.Movie.2021.1080p.mkv');
+    const row = within(name.closest('li'));
+    expect(row.getByText('EN')).toBeInTheDocument();
+    expect(row.getByText('pending')).toBeInTheDocument();
+  });
+
+  test('monitoring a file posts the media path, not a subtitle URL', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+    render(<Wanted />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/wanted'));
+
+    fireEvent.change(screen.getByPlaceholderText('/path/to/movie.mkv'), {
+      target: { value: '/media/Another.Movie.mkv' },
+    });
+
+    // POST, then the component reloads the list.
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+    fireEvent.click(screen.getByText('Monitor this file'));
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/wanted',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            path: '/media/Another.Movie.mkv',
+            languages: ['en'],
+          }),
+        })
+      )
+    );
+  });
+
+  test('removing sends the media path', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([wantedItem]),
     });
     render(<Wanted />);
-    await screen.findByText('a');
+    await screen.findByText('Some.Movie.2021.1080p.mkv');
 
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(['u']),
-    });
-    fireEvent.change(screen.getByPlaceholderText('/path/to/movie.mkv'), {
-      target: { value: 'f' },
-    });
-    fireEvent.click(screen.getByText('Search'));
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    fireEvent.click(screen.getByTestId('DeleteIcon').closest('button'));
+
     await waitFor(() =>
-      expect(fetch).toHaveBeenLastCalledWith(
-        '/api/search?provider=embedded&path=f&lang=en'
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/wanted',
+        expect.objectContaining({
+          method: 'DELETE',
+          body: JSON.stringify({ path: wantedItem.path }),
+        })
       )
     );
   });


### PR DESCRIPTION
> **Stacked on #2209** — base is `fix/shared-store`, not `main`. Merge #2209 first; GitHub retargets this automatically. It genuinely depends on that PR: the monitoring loop needs an in-process store, which on Pebble requires `GetSharedStore`.

Closes the last of the four missing routes found in the #2207 sweep.

## 1. The wanted list

`/api/wanted` never existed, though the UI has always called it. The SPA catch-all turned that into `200` + `index.html`, so the page accepted the response, failed to parse it, and rendered empty with **nothing in the server log**.

Backed by the existing `monitored_items` table — it already carries status, retry count and blacklist integration, so **no schema change**.

```
GET    /api/wanted                     list monitored media
POST   /api/wanted {path, languages}   start monitoring a file
DELETE /api/wanted {path}              stop monitoring a file
```

**Semantics changed deliberately.** The page previously kept a list of subtitle *download URLs* bookmarked from search results. Bazarr has no such concept, and no backend ever implemented it. Wanted now means *media files missing subtitles* — Bazarr's central screen — shown with languages, status and retry count. "Add to Wanted" on a search result becomes **"Monitor this file"**, which acts on the media path.

## 2. The monitoring loop — off by default

The loop that consumes this list previously existed only in the `monitor` CLI command, so `subtitle-manager web` never searched for missing subtitles on its own. It now runs in the web server, behind `monitor.enabled`, **defaulting to off**.

**This is the most important decision in the PR, and it's backed by evidence, not caution.** The loop runs the full download pipeline — it contacts providers and writes subtitle files into the operator's media directories, unattended, on a timer. I verified this rather than assuming it:

```
$ ls ~/sm-eval-media/
Some.Movie.2021.1080p.en.srt      <-- written by the loop, unprompted
Some.Movie.2021.1080p.mkv
```

Bazarr enables its equivalent by default, but Bazarr *asks during setup*. There's no such prompt here yet, so defaulting to on would mean **upgrading the server silently starts modifying a media library**. When a setup prompt exists, flipping the default is a one-line change.

`TestStartMonitoringDefaultsOff` guards it.

Keys: `monitor.interval` (minutes, default 60), `monitor.languages` (default `["en"]`), `monitor.max_retries` (default 3), `monitor.quality_check`.

**Population** comes from Sonarr/Radarr at startup when configured. Deliberately **not** derived from the local media library — that would enrol every scanned file at once and turn a single opt-in into a library-wide download. Individual files are always addable via POST.

## Bug caught while wiring

`EpisodeMonitor.Start` does `time.NewTicker(m.interval)` with no floor, and `time.NewTicker` **panics** on a non-positive duration. `monitor.interval` is routinely unset, so an unconfigured server would have panicked at startup. `monitorInterval()` clamps; `TestMonitorIntervalNeverZero` covers nil/0/negative.

## End-to-end verification (Pebble)

| step | result |
|---|---|
| empty list | `[]`, not `null` |
| POST a media path | `201` |
| GET | item with languages decoded to a real array, `status: pending` |
| loop enabled | picks item up, sets `status: found` + `last_checked` |
| next cycle | `Checking 0 monitored items` — completed items correctly skipped |
| DELETE | `204`, list empty |
| monitoring off (default) | logs that it's disabled, starts nothing |

## Tests

Written against **Pebble, not SQLite**, so they run in CI — which builds without `-tags sqlite`, where the rest of this package skips entirely.

`/api/wanted` moved from `knownMissingAPIPaths` into `frontendAPIPaths`, so the route guard now actually covers it instead of skipping it.

**Frontend:** the existing `Wanted.test.jsx` asserted a `GET /api/search?provider=...` call the component had already stopped making — it was **failing on the base branch** before these changes. Rewritten to cover the real contract. Verified no regressions by diffing failing test files against the base:

```
failing only in mine: (none)
fixed by mine:        src/__tests__/Wanted.test.jsx
```

Base: 11 failed files / 19 tests. Mine: 10 / 18, with 3 more passing. The other 10 are pre-existing and unrelated.

## One observation, not fixed here

The loop marked the item `found` after writing a 2-byte `.srt`. Whether `scanner.ProcessFile` should treat that as success is pre-existing behaviour I didn't touch, but it's worth a look — a "found" that isn't a usable subtitle would mean the item stops being retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH