### PR TITLE
fix(webserver): mount rescan-all and clean the wanted DELETE path

### DIFF
--- a/changelog.d/fix-route-drift-tail.md
+++ b/changelog.d/fix-route-drift-tail.md
@@ -1,0 +1,50 @@
+<!-- file: changelog.d/fix-route-drift-tail.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8b4e21d7-3c06-4f95-a1e8-6d720f3ba9c4 -->
+<!-- last-edited: 2026-07-26 -->
+
+### Fixed
+
+#### Global "Rescan Library" button now does something
+
+`POST /api/library/rescan-all` is mounted. The button in the app bar has always
+called it, but no handler was registered, so the request fell through to the
+single-page-app catch-all and came back as `index.html` with a `200` — the
+frontend logged "Global library rescan started" and nothing was scanned.
+
+It is an alias for the existing `libraryRescanHandler`, which already rescans
+every configured library path; `/api/library/resync` is an alias of the same
+handler. No new behaviour was needed, only the missing registration.
+
+#### Removing a wanted item with an unclean path
+
+`DELETE /api/wanted` matched the request path literally, while `POST` stores the
+`filepath.Clean`-ed path. An equivalent but unclean spelling (`/media/./a.mkv`)
+therefore matched no row and still returned `204`, reporting a successful delete
+that removed nothing. The path is now cleaned before matching.
+
+Only cleaned, deliberately not run through the full `ValidateAndSanitizePath`
+allowlist: items synced from Sonarr or Radarr carry *that* server's paths, which
+need not lie under an allowed base directory, and enforcing the allowlist here
+would have made those items permanently undeletable. The allowlist exists to
+guard filesystem access, and this branch performs none — it is a key match
+against rows the store already holds.
+
+### Notes
+
+Two paths the web UI calls still have no handler, and both are recorded in
+`route_coverage_test.go` with the reason rather than silently omitted:
+
+- `/api/bulk-operation` — `MediaLibrary.jsx` defines `handleBulkOperation` and
+  `toggleFileSelection`, but **nothing references them**: there is no selection
+  checkbox and no bulk toolbar. This is dead frontend code rather than a feature
+  missing its backend, so writing a handler would mean inventing a request
+  contract no UI sends. The selection UI and the endpoint should be built
+  together.
+- `/api/notifications/test/{type}` — blocked on a config namespace mismatch, not
+  on the handler. The notification settings page saves through
+  `POST /api/config`, which sets flat keys (`discord_webhook`), while the runtime
+  reads namespaced ones (`notifications.discord_webhook`). A test button on top
+  of that would report "not configured" immediately after a successful save, or
+  report success for a channel that never fires in production. The key bridge
+  and the endpoint have to land together.

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/route_coverage_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6b2c9d41-8f37-4a52-9c60-1d4e7a8b3f05
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 package webserver
 
@@ -37,6 +37,7 @@ var frontendAPIPaths = []string{
 	"/api/library/browse",
 	"/api/providers/status",
 	"/api/wanted",
+	"/api/library/rescan-all",
 }
 
 // knownMissingAPIPaths are paths the web UI calls that have no backend handler
@@ -48,9 +49,22 @@ var frontendAPIPaths = []string{
 // API surface is covered" when it means "these ten are". Each entry is skipped
 // with its caller; delete the entry when the handler lands.
 var knownMissingAPIPaths = map[string]string{
-	"/api/bulk-operation":     "MediaLibrary.jsx — bulk media operations",
-	"/api/library/rescan-all": "App.jsx — rescan every library path",
-	"/api/notifications/test": "NotificationSettings.jsx — send a test notification",
+	// Not merely unmounted — there is no caller either. MediaLibrary.jsx defines
+	// handleBulkOperation and toggleFileSelection, but nothing in the component
+	// references them: there is no selection checkbox and no bulk toolbar. So
+	// this is dead frontend code rather than a working feature missing its
+	// backend, and writing a handler would mean inventing a request contract no
+	// UI actually sends. Build the selection UI and the endpoint together, or
+	// delete the dead functions.
+	"/api/bulk-operation": "MediaLibrary.jsx — bulk media operations; no UI invokes it",
+	// NotificationSettings.jsx calls /api/notifications/test/{type}. Held back
+	// deliberately: the settings page saves through POST /api/config, which
+	// viper.Set()s flat keys ("discord_webhook"), while the runtime reads
+	// namespaced ones ("notifications.discord_webhook"). A test button on top of
+	// that would report "not configured" straight after a successful save, or
+	// worse, report success for a channel that never fires in production. The
+	// key bridge and the endpoint have to land together.
+	"/api/notifications/test": "NotificationSettings.jsx — blocked on the config key namespace mismatch",
 }
 
 // TestFrontendAPIPathsAreMounted verifies no frontend-called API path falls

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/server.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 package webserver
 
@@ -236,6 +236,11 @@ func newMux(db *sql.DB) (*http.ServeMux, string, error) {
 	mux.Handle(prefix+"/api/library/paths", authMiddleware(db, "basic", libraryPathsHandler()))
 	mux.Handle(prefix+"/api/library/rescan", authMiddleware(db, "basic", libraryRescanHandler()))
 	mux.Handle(prefix+"/api/library/resync", authMiddleware(db, "basic", libraryRescanHandler()))
+	// rescan-all is the name App.jsx's global "Rescan Library" button calls.
+	// libraryRescanHandler already rescans every configured path, so this is an
+	// alias rather than a new behaviour — the same relationship /api/library/resync
+	// already has to /api/library/rescan.
+	mux.Handle(prefix+"/api/library/rescan-all", authMiddleware(db, "basic", libraryRescanHandler()))
 	// Whisper pipeline endpoints (library-search bridge, double-subs, drift verify)
 	mux.Handle(prefix+"/api/library/search", authMiddleware(db, "basic", librarySearchHandler()))
 	mux.Handle(prefix+"/api/library/search/status", authMiddleware(db, "basic", librarySearchStatusHandler()))

--- a/pkg/webserver/wanted.go
+++ b/pkg/webserver/wanted.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/wanted.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a3c5e19-4b28-4d06-9f71-2c8e0a45b3d7
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 package webserver
 
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/viper"
@@ -257,10 +258,24 @@ func wantedHandler() http.Handler {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
+			// Match on the cleaned path. POST stores the path returned by
+			// ValidateAndSanitizePath, which is filepath.Clean-ed, so a caller
+			// passing an equivalent-but-unclean path ("/media/./a.mkv") would
+			// otherwise match nothing and get a 204 having deleted nothing.
+			//
+			// Deliberately only Clean, not the full ValidateAndSanitizePath:
+			// items synced from Sonarr/Radarr carry that server's paths, which
+			// need not lie under GetAllowedBaseDirs. Enforcing the allowlist
+			// here would make those items permanently undeletable. The allowlist
+			// guards filesystem access, and this branch performs none — it is a
+			// key match against rows the store already holds.
+			clean := filepath.Clean(q.Path)
 			mon := monitoring.NewEpisodeMonitor(monitorInterval(), nil, nil, store,
 				monitorMaxRetries(), false)
-			if err := mon.RemoveFromMonitoring(q.Path); err != nil {
-				logger.Warnf("remove %s: %v", q.Path, err)
+			// 204 whether or not a row matched: DELETE is idempotent, and the UI
+			// only ever sends a path it just read back from GET.
+			if err := mon.RemoveFromMonitoring(clean); err != nil {
+				logger.Warnf("remove %s: %v", clean, err)
 				http.Error(w, "failed to remove wanted item", http.StatusInternalServerError)
 				return
 			}

--- a/pkg/webserver/wanted_test.go
+++ b/pkg/webserver/wanted_test.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/wanted_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2d90f4a7-6b13-4c85-a0e2-9f38c714b6de
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 package webserver
 
@@ -116,6 +116,44 @@ func TestWantedRoundTrip(t *testing.T) {
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/wanted", nil))
 	if n := len(decodeWanted(t, rr.Body.Bytes())); n != 0 {
 		t.Errorf("expected the list to be empty after DELETE, got %d items", n)
+	}
+}
+
+// TestWantedDeleteMatchesUncleanPath verifies DELETE normalises the path before
+// matching.
+//
+// POST stores the ValidateAndSanitizePath result, which is filepath.Clean-ed.
+// Matching the raw request path meant an equivalent-but-unclean spelling
+// ("/media/./a.mkv") matched no row, and the caller still got a 204 — a delete
+// that reported success having removed nothing.
+func TestWantedDeleteMatchesUncleanPath(t *testing.T) {
+	media := useWantedStore(t)
+	h := wantedHandler()
+
+	post := httptest.NewRequest(http.MethodPost, "/api/wanted",
+		strings.NewReader(`{"path":`+jsonStr(media)+`,"languages":["en"]}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, post)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("POST: got %d (body %s)", rr.Code, rr.Body.String())
+	}
+
+	// Same file, spelled with a redundant "." element.
+	// filepath.Join would clean it back out, so build the string directly.
+	dir, base := filepath.Split(media)
+	unclean := dir + "./" + base
+
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodDelete, "/api/wanted",
+		strings.NewReader(`{"path":`+jsonStr(unclean)+`}`)))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: got %d (body %s)", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/wanted", nil))
+	if n := len(decodeWanted(t, rr.Body.Bytes())); n != 0 {
+		t.Errorf("item survived DELETE via %q: %d still monitored", unclean, n)
 	}
 }
 


### PR DESCRIPTION
Two small fixes plus honest bookkeeping on what is still missing.

## `/api/library/rescan-all` was never mounted

The global **Rescan Library** button in `App.jsx` has always called it. Unmounted API paths here do not 404 — they fall through to the SPA catch-all and return `index.html` with a `200` — so `response.ok` passed, the frontend logged *"Global library rescan started"*, and nothing was scanned.

`libraryRescanHandler` already iterates every configured library path, so this is an alias rather than new behaviour. `/api/library/resync` is already an alias of the same handler, so this follows existing precedent.

## `DELETE /api/wanted` could report a delete it did not perform

`POST` stores the `ValidateAndSanitizePath` result, which is `filepath.Clean`-ed. `DELETE` matched the request path literally, so an equivalent-but-unclean spelling (`/media/./a.mkv`) matched no row and still returned `204`.

**Deliberately only `Clean`, not the full allowlist.** Items synced from Sonarr/Radarr carry *that* server's paths, which need not lie under `GetAllowedBaseDirs`; enforcing the allowlist here would make those items permanently undeletable. The allowlist guards filesystem access, and this branch performs none — it is a key match against rows the store already holds.

`204` is retained whether or not a row matched: DELETE is idempotent and the UI only sends paths it just read back from GET.

## What is still missing, and why

Both remaining unmounted paths stay in `knownMissingAPIPaths` with an accurate reason rather than being quietly dropped:

- **`/api/bulk-operation`** — not a backend gap. `MediaLibrary.jsx` defines `handleBulkOperation` and `toggleFileSelection`, but **nothing references them**: there is no selection checkbox and no bulk toolbar. Writing a handler would mean inventing a request contract no UI sends. The selection UI and the endpoint should be built together.
- **`/api/notifications/test/{type}`** — blocked on a config namespace mismatch, not on the handler. The settings page saves through `POST /api/config`, which `viper.Set`s **flat** keys (`discord_webhook`), while the runtime reads **namespaced** ones (`notifications.discord_webhook`). A test button on top of that would report "not configured" right after a successful save, or report success for a channel that never fires. That fix is coming as its own PR.

## Verification

The new `TestWantedDeleteMatchesUncleanPath` was confirmed to **fail** against the unfixed code (`item survived DELETE ... 1 still monitored`) and pass with it, so it is not vacuous.

`gofmt` clean, `go build ./...`, `go vet`, and `go test -race ./pkg/webserver/` all pass. The route guard runs without the sqlite build tag, so it executes in CI rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH