### PR TITLE
fix(notifications): connect the settings page to the runtime

### DIFF
--- a/changelog.d/fix-notifications-wiring.md
+++ b/changelog.d/fix-notifications-wiring.md
@@ -1,0 +1,79 @@
+<!-- file: changelog.d/fix-notifications-wiring.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d5093e6b-71a4-4c82-9f37-8ae2b04c1d95 -->
+<!-- last-edited: 2026-07-26 -->
+
+### Fixed
+
+#### Notification settings were saved where nothing read them
+
+The Notifications settings page saved through `POST /api/config`, which hands
+each key to `viper.Set` exactly as received, and the page sent bare keys
+(`discord_webhook`). The runtime has always read namespaced ones
+(`notifications.discord_webhook`). Nothing read what the page wrote, so
+configuring notifications appeared to succeed and then never delivered
+anything.
+
+The page now saves dotted keys, which `viper.Set` nests correctly. Settings
+saved by an older build are still read as a fallback, so an upgrade does not
+silently disable a channel that was working; re-saving the page migrates them.
+
+#### Email notifications could not work at all
+
+`SMTPNotifier` has existed in `pkg/notifications`, with unit tests, since before
+this change — but nothing ever constructed one. The runtime only knew about
+`notifications.email_url`, a webhook that happens to send mail, while the
+settings page collects SMTP host, port, credentials, sender and recipients. The
+two halves never met, so the email tab could not work regardless of the key
+namespace. SMTP settings now build a notifier, with recipients accepted as a
+comma or semicolon separated list.
+
+The SMTP host is deliberately **not** run through `validateWebhookURL`: it is
+not a URL, and an operator's own mail relay is usually on a private address,
+which that allowlist exists to reject. It is treated as operator-supplied
+infrastructure, like the Apprise endpoint.
+
+### Added
+
+#### `POST /api/notifications/test/{type}`
+
+The "Send test notification" buttons have always called this; no handler was
+registered, so the request fell through to the single-page-app catch-all and
+returned `index.html` with a `200` — the page reported *"notification sent
+successfully"* having sent nothing.
+
+It reports what actually happened rather than a blanket success:
+
+- an unconfigured channel is a `400` that says so, not a fake success;
+- a provider that rejects the message is a `502`, not a success;
+- `push` (Pushover) returns `501`: only the hostname is allowlisted, there is
+  no sender implementation;
+- `webhook` returns `501` pointing at `/api/webhooks/config` and
+  `/api/webhooks/test`, the existing subsystem that already implements generic
+  webhooks with methods, headers and retries. That settings tab duplicates it.
+
+Supported channels are `discord`, `telegram`, `email` and `apprise`.
+
+The test uses **saved** configuration, not the values currently in the form, so
+settings must be saved before testing. The request carries only a message;
+matching Bazarr, which tests live form values, would mean putting credentials in
+the request body.
+
+Both the test endpoint and the event publisher build their notification service
+through the same helper, so "the test succeeded" and "events are delivered"
+cannot disagree — a test button exercising a different code path than production
+is worse than no button, because it reports confidence it has not earned.
+
+Delivery goes through `notifications.New`, which enforces HTTPS, rejects private
+and link-local addresses, and applies a provider allowlist. Skipping it would
+have made this endpoint an SSRF primitive, since it fetches an operator-supplied
+URL on demand. There are tests for the link-local metadata address, private
+addresses, plain HTTP and non-allowlisted hosts.
+
+### Changed
+
+`Service.Send` no longer stops at the first failing channel. A single broken
+webhook previously suppressed delivery to every channel configured after it; all
+channels are now attempted and the first error returned. Response bodies are
+also drained and closed — three of the four delivery paths leaked their
+connection on every notification.

--- a/changelog.d/fix-notifications-wiring.md
+++ b/changelog.d/fix-notifications-wiring.md
@@ -91,3 +91,15 @@ webhook previously suppressed delivery to every channel configured after it; all
 channels are now attempted and the first error returned. Response bodies are
 also drained and closed — three of the four delivery paths leaked their
 connection on every notification.
+
+#### SMTP messages now carry From, To and MIME headers
+
+`SMTPNotifier` previously sent only a `Subject`. Messages without `From`/`To` and
+a content type are widely rejected or filed as spam, so the notifier that had
+never been wired in would likely have failed in practice even once connected.
+
+Header values are stripped of CR/LF so an address taken from configuration
+cannot introduce a header line. The message body needs no such treatment: it is
+placed after the blank line that terminates the headers, so newlines in it start
+body lines, and Go's SMTP client dot-stuffs the body so a lone `.` cannot end
+the DATA command early.

--- a/changelog.d/fix-notifications-wiring.md
+++ b/changelog.d/fix-notifications-wiring.md
@@ -70,6 +70,20 @@ have made this endpoint an SSRF primitive, since it fetches an operator-supplied
 URL on demand. There are tests for the link-local metadata address, private
 addresses, plain HTTP and non-allowlisted hosts.
 
+#### Settings that are saved but still have no effect
+
+Now that the page writes where the runtime reads, three fields it collects are
+persisted but not yet consumed, and are called out rather than left looking
+functional:
+
+- `smtp_tls` — `SMTPNotifier` uses `smtp.SendMail`, which negotiates STARTTLS
+  opportunistically. The behaviour is right; the switch does not control it.
+- `discord_username` and `discord_avatar` — Discord webhooks accept `username`
+  and `avatar_url` overrides, but the payload does not send them yet.
+
+Pushover and generic-webhook fields on that page are likewise persisted with no
+sender behind them; see the `501` responses above.
+
 ### Changed
 
 `Service.Send` no longer stops at the first failing channel. A single broken

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -1,10 +1,14 @@
 // file: pkg/notifications/email.go
+// version: 1.1.0
+// guid: 7b26e0a9-4d31-4c58-91f7-2a05c3b8e6d4
+// last-edited: 2026-07-26
 package notifications
 
 import (
 	"context"
 	"fmt"
 	"net/smtp"
+	"strings"
 )
 
 // SMTPNotifier sends email using an SMTP server.
@@ -30,6 +34,34 @@ func (s SMTPNotifier) Notify(ctx context.Context, msg string) error {
 	if s.Addr == "" || s.From == "" || len(s.To) == 0 {
 		return fmt.Errorf("smtp configuration incomplete")
 	}
-	data := []byte("Subject: Subtitle Manager\r\n\r\n" + msg)
-	return send(s.Addr, s.Auth, s.From, s.To, data)
+	// Build the header block explicitly. Previously only a Subject was sent,
+	// which many MTAs and spam filters reject outright for lacking From/To.
+	//
+	// msg is placed after the blank line that terminates the headers, so its
+	// content cannot introduce one; a CR/LF inside it starts a new body line,
+	// not a new header. Control characters are stripped from the header values
+	// regardless, because those are the fields where injection would matter,
+	// and Go's SMTP client dot-stuffs the body so a lone "." cannot end the
+	// DATA command early.
+	var b strings.Builder
+	b.WriteString("From: " + sanitizeHeader(s.From) + "\r\n")
+	b.WriteString("To: " + sanitizeHeader(strings.Join(s.To, ", ")) + "\r\n")
+	b.WriteString("Subject: Subtitle Manager\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(msg)
+
+	return send(s.Addr, s.Auth, s.From, s.To, []byte(b.String()))
+}
+
+// sanitizeHeader removes the characters that could terminate a header line and
+// begin another, so an address taken from configuration cannot inject headers.
+func sanitizeHeader(v string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' {
+			return -1
+		}
+		return r
+	}, v)
 }

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -1,3 +1,8 @@
+// file: pkg/notifications/notifications.go
+// version: 1.1.0
+// guid: 5d3b90c7-1e64-4a28-8f05-c9271b6ea340
+// last-edited: 2026-07-26
+
 // Package notifications provides notification services for subtitle-manager.
 // It supports sending notifications via Discord, Telegram, Email, and other channels.
 //
@@ -50,7 +55,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +76,18 @@ type Service struct {
 	// not subject to the strict public-webhook allowlist. Set it directly on
 	// the struct after New.
 	AppriseURL string
-	client     *http.Client
+	// SMTP, when non-nil, delivers mail by talking to an SMTP server directly,
+	// rather than POSTing to the webhook-style EmailURL above. The two are
+	// independent: EmailURL is an HTTP endpoint that happens to send mail,
+	// while this is a real mail submission.
+	//
+	// Set directly on the struct after New. Unlike DiscordWebhook and EmailURL,
+	// the SMTP host is not run through validateWebhookURL — it is not a URL,
+	// and outbound mail to an operator's own relay (often on a private address)
+	// is exactly what the webhook allowlist is designed to reject. It is
+	// operator-supplied infrastructure, treated like AppriseURL.
+	SMTP   *SMTPNotifier
+	client *http.Client
 }
 
 // New creates a Service with the provided endpoints.
@@ -200,58 +218,121 @@ func isPrivateOrLocalhost(host string) bool {
 	return false
 }
 
-// Send dispatches the message to all configured notification targets.
-func (s *Service) Send(ctx context.Context, msg string) error {
-	if s.DiscordWebhook != "" {
-		body, _ := json.Marshal(map[string]string{"content": msg})
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.DiscordWebhook, bytes.NewReader(body))
-		if err == nil {
-			req.Header.Set("Content-Type", "application/json")
-			_, err = s.client.Do(req)
-		}
-		if err != nil {
-			return err
+// Channel names an individual delivery target. They double as the {type} path
+// segment of POST /api/notifications/test/{type}.
+type Channel string
+
+const (
+	ChannelDiscord  Channel = "discord"
+	ChannelTelegram Channel = "telegram"
+	ChannelEmail    Channel = "email"
+	ChannelApprise  Channel = "apprise"
+)
+
+// ErrChannelNotConfigured reports that a channel was asked to deliver a message
+// while its credentials are unset. Callers distinguish this from a delivery
+// failure: "you have not configured this yet" and "the provider rejected it"
+// need different messages in the UI.
+var ErrChannelNotConfigured = errors.New("notification channel is not configured")
+
+// Configured reports whether c has the settings it needs to deliver.
+func (s *Service) Configured(c Channel) bool {
+	switch c {
+	case ChannelDiscord:
+		return s.DiscordWebhook != ""
+	case ChannelTelegram:
+		return s.TelegramToken != "" && s.TelegramChatID != ""
+	case ChannelEmail:
+		return s.EmailURL != "" || s.SMTP != nil
+	case ChannelApprise:
+		return s.AppriseURL != ""
+	}
+	return false
+}
+
+// Channels returns every channel this service is configured to deliver on.
+func (s *Service) Channels() []Channel {
+	var out []Channel
+	for _, c := range []Channel{ChannelDiscord, ChannelTelegram, ChannelEmail, ChannelApprise} {
+		if s.Configured(c) {
+			out = append(out, c)
 		}
 	}
-	if s.TelegramToken != "" && s.TelegramChatID != "" {
-		u := "https://api.telegram.org/bot" + s.TelegramToken + "/sendMessage"
-		body := url.Values{"chat_id": {s.TelegramChatID}, "text": {msg}}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(body.Encode()))
-		if err == nil {
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			_, err = s.client.Do(req)
-		}
-		if err != nil {
-			return err
-		}
+	return out
+}
+
+// post sends body to rawURL and discards the response.
+//
+// Draining and closing the body matters even though the content is unused: an
+// unclosed response body leaks its connection out of the client's pool, and
+// these are sent on every subtitle event.
+func (s *Service) post(ctx context.Context, rawURL, contentType string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return err
 	}
-	if s.EmailURL != "" {
-		body, _ := json.Marshal(map[string]string{"message": msg})
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.EmailURL, bytes.NewReader(body))
-		if err == nil {
-			req.Header.Set("Content-Type", "application/json")
-			_, err = s.client.Do(req)
-		}
-		if err != nil {
-			return err
-		}
+	req.Header.Set("Content-Type", contentType)
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
 	}
-	if s.AppriseURL != "" {
-		// Apprise API expects a JSON body with a "body" field (and optionally a
-		// "title"); the configured notification targets live server-side.
-		body, _ := json.Marshal(map[string]string{"body": msg, "title": "subtitle-manager"})
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.AppriseURL, bytes.NewReader(body))
-		if err == nil {
-			req.Header.Set("Content-Type", "application/json")
-			var resp *http.Response
-			resp, err = s.client.Do(req)
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}
-		if err != nil {
-			return err
-		}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s returned %s", req.URL.Host, resp.Status)
 	}
 	return nil
+}
+
+// SendTo delivers msg on a single channel, returning ErrChannelNotConfigured
+// when that channel has no settings.
+//
+// Send fans out to every configured channel and is what the event pipeline
+// uses. This exists for the "send a test notification" button, which has to
+// report per-channel success rather than an aggregate.
+func (s *Service) SendTo(ctx context.Context, c Channel, msg string) error {
+	if !s.Configured(c) {
+		return fmt.Errorf("%s: %w", c, ErrChannelNotConfigured)
+	}
+	switch c {
+	case ChannelDiscord:
+		body, _ := json.Marshal(map[string]string{"content": msg})
+		return s.post(ctx, s.DiscordWebhook, "application/json", body)
+
+	case ChannelTelegram:
+		u := "https://api.telegram.org/bot" + s.TelegramToken + "/sendMessage"
+		form := url.Values{"chat_id": {s.TelegramChatID}, "text": {msg}}
+		return s.post(ctx, u, "application/x-www-form-urlencoded", []byte(form.Encode()))
+
+	case ChannelEmail:
+		// SMTP takes precedence: if the operator configured a real mail server,
+		// that is the more specific intent than a webhook that sends mail.
+		if s.SMTP != nil {
+			return s.SMTP.Notify(ctx, msg)
+		}
+		body, _ := json.Marshal(map[string]string{"message": msg})
+		return s.post(ctx, s.EmailURL, "application/json", body)
+
+	case ChannelApprise:
+		// The Apprise API expects a JSON body with a "body" field (and
+		// optionally a "title"); the delivery targets live server-side.
+		body, _ := json.Marshal(map[string]string{"body": msg, "title": "subtitle-manager"})
+		return s.post(ctx, s.AppriseURL, "application/json", body)
+	}
+	return fmt.Errorf("unknown notification channel %q", c)
+}
+
+// Send dispatches the message to all configured notification targets.
+//
+// Delivery continues past a failing channel rather than returning on the first
+// error, so one broken webhook cannot silently suppress every other channel.
+// The first error is returned once all channels have been attempted.
+func (s *Service) Send(ctx context.Context, msg string) error {
+	var firstErr error
+	for _, c := range s.Channels() {
+		if err := s.SendTo(ctx, c, msg); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/pkg/notifications/notifications_test.go
+++ b/pkg/notifications/notifications_test.go
@@ -74,8 +74,60 @@ func TestSMTPNotifier(t *testing.T) {
 	if addr != "smtp:25" || from != "a@example.com" || len(to) != 1 || to[0] != "b@example.com" {
 		t.Fatalf("unexpected params")
 	}
-	if string(body) != "Subject: Subtitle Manager\r\n\r\nhi there" {
-		t.Fatalf("unexpected body: %s", body)
+	// From/To/MIME headers are required by many MTAs; a Subject-only message is
+	// widely rejected as spam.
+	head, text, ok := strings.Cut(string(body), "\r\n\r\n")
+	if !ok {
+		t.Fatalf("message has no header/body separator: %q", body)
+	}
+	for _, want := range []string{
+		"From: a@example.com",
+		"To: b@example.com",
+		"Subject: Subtitle Manager",
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+	} {
+		if !strings.Contains(head, want) {
+			t.Errorf("header block is missing %q:\n%s", want, head)
+		}
+	}
+	if text != "hi there" {
+		t.Errorf("body = %q, want the message unmodified", text)
+	}
+}
+
+// TestSMTPNotifierRejectsHeaderInjection verifies the message body cannot
+// introduce headers, and that a CR/LF smuggled into an address cannot either.
+//
+// The body is placed after the blank line that terminates the headers, so
+// newlines in it start body lines rather than headers. The addresses are the
+// fields where injection would actually matter, so those are stripped.
+func TestSMTPNotifierRejectsHeaderInjection(t *testing.T) {
+	var body []byte
+	n := SMTPNotifier{
+		Addr: "smtp:25",
+		From: "a@example.com\r\nBcc: attacker@example.com",
+		To:   []string{"b@example.com"},
+		Send: func(_ string, _ smtp.Auth, _ string, _ []string, msg []byte) error {
+			body = msg
+			return nil
+		},
+	}
+	if err := n.Notify(context.Background(), "line one\r\nBcc: other@example.com"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+
+	// Injection means a new header *line*. The smuggled text surviving inside
+	// the From value is inert, so assert on line starts rather than substring
+	// presence.
+	head, _, _ := strings.Cut(string(body), "\r\n\r\n")
+	for _, line := range strings.Split(head, "\r\n") {
+		if strings.HasPrefix(strings.ToLower(line), "bcc:") {
+			t.Errorf("a Bcc header line was injected:\n%s", head)
+		}
+	}
+	if strings.Count(head, "\r\n") != 4 {
+		t.Errorf("header block does not have exactly the 5 intended headers:\n%s", head)
 	}
 }
 

--- a/pkg/webserver/notifications.go
+++ b/pkg/webserver/notifications.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/smtp"
+	"path"
 	"strings"
 	"time"
 
@@ -176,8 +177,15 @@ func notificationTestHandler() http.Handler {
 			return
 		}
 
-		name := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/notifications/test"), "/")
-		if name == "" {
+		// path.Base rather than TrimPrefix of a literal "/api/notifications/test":
+		// the route is mounted at prefix+"/api/notifications/test/", where prefix
+		// comes from base_url. Behind a subpath the incoming path is
+		// "/sm/api/notifications/test/discord", which the literal prefix does not
+		// match — every channel would resolve as unknown and the feature would be
+		// dead for anyone running under a base URL. A channel name never contains
+		// a slash, so the last segment is exactly it.
+		name := path.Base(r.URL.Path)
+		if name == "" || name == "." || name == "/" || name == "test" {
 			http.Error(w, "no notification channel given", http.StatusBadRequest)
 			return
 		}

--- a/pkg/webserver/notifications.go
+++ b/pkg/webserver/notifications.go
@@ -1,0 +1,251 @@
+// file: pkg/webserver/notifications.go
+// version: 1.0.0
+// guid: 4c81f27a-06b3-4e59-9d84-b71e3a05c2f6
+// last-edited: 2026-07-26
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/notifications"
+)
+
+// notifyKey resolves a notification setting, preferring the namespaced key and
+// falling back to the bare one.
+//
+// Both spellings have to be read because the two halves of this feature
+// disagreed. The runtime has always read namespaced keys
+// ("notifications.discord_webhook"), while the settings page saves through
+// POST /api/config, which viper.Set()s exactly the keys the JSON body carries —
+// and NotificationSettings.jsx sent bare ones ("discord_webhook"). Nothing read
+// what the page wrote, so configuring notifications in the UI appeared to
+// succeed and then never delivered anything.
+//
+// The UI now sends namespaced keys. The fallback keeps configurations saved by
+// an older build working instead of silently dropping them on upgrade.
+func notifyKey(name string) string {
+	if v := viper.GetString("notifications." + name); v != "" {
+		return v
+	}
+	return viper.GetString(name)
+}
+
+// notifyEnabled reports whether a channel's "enabled" switch is on.
+//
+// Unset means enabled: a config that sets only discord_webhook, as every
+// pre-existing one does, must keep working. The switch only has effect once the
+// settings page has written it.
+func notifyEnabled(name string) bool {
+	for _, k := range []string{"notifications." + name, name} {
+		if viper.IsSet(k) {
+			return viper.GetBool(k)
+		}
+	}
+	return true
+}
+
+// smtpFromConfig builds an SMTP notifier from the settings page's fields, or
+// nil when no host is configured.
+//
+// pkg/notifications has had a fully unit-tested SMTPNotifier since before this
+// change, but nothing ever constructed one: the runtime only knew about
+// notifications.email_url, a webhook that happens to send mail. Meanwhile the
+// UI's email tab collects host/port/credentials/from/to. The two never met, so
+// the email tab could not work regardless of the key namespace.
+func smtpFromConfig() *notifications.SMTPNotifier {
+	host := notifyKey("smtp_host")
+	if host == "" {
+		return nil
+	}
+	port := viper.GetInt("notifications.smtp_port")
+	if port == 0 {
+		port = viper.GetInt("smtp_port")
+	}
+	if port == 0 {
+		port = 587
+	}
+
+	var auth smtp.Auth
+	user, pass := notifyKey("smtp_username"), notifyKey("smtp_password")
+	if user != "" {
+		auth = smtp.PlainAuth("", user, pass, host)
+	}
+
+	// The UI collects recipients as one free-text field; accept comma or
+	// semicolon separated addresses and drop empties.
+	var to []string
+	for _, addr := range strings.FieldsFunc(notifyKey("smtp_to"), func(r rune) bool {
+		return r == ',' || r == ';'
+	}) {
+		if addr = strings.TrimSpace(addr); addr != "" {
+			to = append(to, addr)
+		}
+	}
+	if len(to) == 0 {
+		return nil
+	}
+
+	return &notifications.SMTPNotifier{
+		Addr: fmt.Sprintf("%s:%d", host, port),
+		Auth: auth,
+		From: notifyKey("smtp_from"),
+		To:   to,
+	}
+}
+
+// notificationServiceFromConfig builds a notification Service from the current
+// configuration, or (nil, nil) when no channel is configured.
+//
+// Both the event publisher and the test-notification endpoint go through here
+// so that "test succeeded" and "events are delivered" cannot disagree — a test
+// button that exercises a different code path than production is worse than no
+// button, because it reports confidence it has not earned.
+func notificationServiceFromConfig() (*notifications.Service, error) {
+	var discord, telegramToken, telegramChat, email string
+	if notifyEnabled("discord_enabled") {
+		discord = notifyKey("discord_webhook")
+	}
+	if notifyEnabled("telegram_enabled") {
+		telegramToken = notifyKey("telegram_token")
+		telegramChat = notifyKey("telegram_chat_id")
+	}
+	if notifyEnabled("email_enabled") {
+		email = notifyKey("email_url")
+	}
+	apprise := notifyKey("apprise_url")
+
+	var smtpNotifier *notifications.SMTPNotifier
+	if notifyEnabled("email_enabled") {
+		smtpNotifier = smtpFromConfig()
+	}
+
+	if discord == "" && telegramToken == "" && email == "" && apprise == "" && smtpNotifier == nil {
+		return nil, nil
+	}
+
+	// Through notifications.New rather than constructing the struct directly:
+	// New runs validateWebhookURL, which enforces HTTPS, rejects private and
+	// link-local addresses and applies the provider allowlist. Bypassing it
+	// would turn this endpoint into an SSRF primitive, since the URL is
+	// operator-supplied and the server fetches it on demand.
+	svc, err := notifications.New(discord, telegramToken, telegramChat, email)
+	if err != nil {
+		return nil, err
+	}
+	// Apprise and SMTP are deliberately set after New: both are self-hosted
+	// infrastructure, commonly on a private address, which is precisely what
+	// the webhook allowlist exists to reject.
+	svc.AppriseURL = apprise
+	svc.SMTP = smtpNotifier
+	return svc, nil
+}
+
+// notificationTestHandler sends a test notification on a single channel.
+//
+//	POST /api/notifications/test/{type}
+//
+// {type} is one of discord, telegram, email or apprise. It reports what
+// actually happened rather than a blanket 200: an unconfigured channel is a
+// different answer than a provider that rejected the message, and the operator
+// needs to tell them apart.
+//
+// The test uses saved configuration, not the values currently typed into the
+// form, because the request carries only a message. Settings must be saved
+// before testing. Bazarr tests the live form values; matching that would need
+// the credentials in the request body, which is a meaningfully worse trade.
+func notificationTestHandler() http.Handler {
+	type reqBody struct {
+		Message string `json:"message"`
+	}
+	logger := logging.GetLogger("notifications")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		name := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/notifications/test"), "/")
+		if name == "" {
+			http.Error(w, "no notification channel given", http.StatusBadRequest)
+			return
+		}
+
+		// push and webhook are offered by the settings page but have no backend
+		// here, and saying so is the honest answer. Reporting success for a
+		// channel that will never fire is the specific failure this endpoint
+		// exists to prevent.
+		switch name {
+		case "push":
+			http.Error(w, "push (Pushover) notifications are not implemented yet; "+
+				"only the hostname is allowlisted, there is no sender",
+				http.StatusNotImplemented)
+			return
+		case "webhook":
+			http.Error(w, "generic webhooks are managed separately: configure them "+
+				"under /api/webhooks/config and test with /api/webhooks/test",
+				http.StatusNotImplemented)
+			return
+		}
+
+		channel := notifications.Channel(name)
+		switch channel {
+		case notifications.ChannelDiscord, notifications.ChannelTelegram,
+			notifications.ChannelEmail, notifications.ChannelApprise:
+		default:
+			http.Error(w, "unknown notification channel "+name, http.StatusBadRequest)
+			return
+		}
+
+		var q reqBody
+		// An absent or unparseable body is not fatal; the message is cosmetic.
+		_ = json.NewDecoder(r.Body).Decode(&q)
+		if strings.TrimSpace(q.Message) == "" {
+			q.Message = "Test notification from Subtitle Manager"
+		}
+
+		svc, err := notificationServiceFromConfig()
+		if err != nil {
+			// The error text comes from validateWebhookURL and names the
+			// rejected host, not any credential.
+			http.Error(w, "notification settings rejected: "+err.Error(),
+				http.StatusBadRequest)
+			return
+		}
+		if svc == nil || !svc.Configured(channel) {
+			http.Error(w, string(channel)+" is not configured; save its settings first",
+				http.StatusBadRequest)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+
+		if err := svc.SendTo(ctx, channel, q.Message); err != nil {
+			// Log the channel and error only. The Service holds bot tokens and
+			// SMTP passwords, and this is the one place tempted to dump config
+			// on failure.
+			logger.Warnf("test notification via %s failed: %v", channel, err)
+			status := http.StatusBadGateway
+			if errors.Is(err, notifications.ErrChannelNotConfigured) {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+
+		logger.Infof("test notification sent via %s", channel)
+		writeJSON(w, map[string]any{"status": "sent", "channel": string(channel)})
+	})
+}

--- a/pkg/webserver/notifications.go
+++ b/pkg/webserver/notifications.go
@@ -152,6 +152,37 @@ func notificationServiceFromConfig() (*notifications.Service, error) {
 	return svc, nil
 }
 
+// maxTestMessage bounds the test message. It is a fixed banner in the UI; the
+// field exists so the text can be varied, not so arbitrary payloads can be
+// relayed through the operator's notification channels.
+const maxTestMessage = 500
+
+// sanitizeTestMessage constrains the caller-supplied test message to a single
+// line of printable text.
+//
+// The message is relayed verbatim to an external provider — a webhook body, a
+// Telegram parameter, an SMTP message body — so it is untrusted input crossing
+// into another system's parser. Collapsing line breaks and dropping other
+// control characters keeps it from carrying structure into any of them,
+// independent of what each provider's encoder happens to do.
+func sanitizeTestMessage(msg string) string {
+	msg = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\r' || r == '\n' || r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		}
+		return r
+	}, msg)
+	// Collapse whitespace runs so a CRLF does not leave a double space.
+	msg = strings.Join(strings.Fields(msg), " ")
+	if len(msg) > maxTestMessage {
+		msg = msg[:maxTestMessage]
+	}
+	return msg
+}
+
 // notificationTestHandler sends a test notification on a single channel.
 //
 //	POST /api/notifications/test/{type}
@@ -219,7 +250,8 @@ func notificationTestHandler() http.Handler {
 		var q reqBody
 		// An absent or unparseable body is not fatal; the message is cosmetic.
 		_ = json.NewDecoder(r.Body).Decode(&q)
-		if strings.TrimSpace(q.Message) == "" {
+		q.Message = sanitizeTestMessage(q.Message)
+		if q.Message == "" {
 			q.Message = "Test notification from Subtitle Manager"
 		}
 

--- a/pkg/webserver/notifications_test.go
+++ b/pkg/webserver/notifications_test.go
@@ -285,3 +285,26 @@ func TestNotificationTestHandlerRejectsUnsafeWebhook(t *testing.T) {
 		})
 	}
 }
+
+// TestSanitizeTestMessage covers the boundary validation on the caller-supplied
+// test message, which is relayed verbatim into an external provider's parser.
+func TestSanitizeTestMessage(t *testing.T) {
+	for name, tc := range map[string]struct{ in, want string }{
+		"plain text survives":        {"hello there", "hello there"},
+		"newlines become spaces":     {"a\r\nBcc: x@y.z", "a Bcc: x@y.z"},
+		"other control chars go":     {"a\x00\x07b", "ab"},
+		"surrounding space trimmed":  {"  hi  ", "hi"},
+		"empty stays empty":          {"", ""},
+		"whitespace only is emptied": {" \r\n ", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := sanitizeTestMessage(tc.in); got != tc.want {
+				t.Errorf("sanitizeTestMessage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	if got := sanitizeTestMessage(strings.Repeat("x", maxTestMessage+50)); len(got) != maxTestMessage {
+		t.Errorf("length = %d, want it capped at %d", len(got), maxTestMessage)
+	}
+}

--- a/pkg/webserver/notifications_test.go
+++ b/pkg/webserver/notifications_test.go
@@ -1,0 +1,261 @@
+// file: pkg/webserver/notifications_test.go
+// version: 1.0.0
+// guid: 9e40c5b2-7a18-4f63-b2d5-0c86e1439af7
+// last-edited: 2026-07-26
+
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/notifications"
+)
+
+// useNotifyConfig applies keys to viper for one test and restores them after.
+func useNotifyConfig(t *testing.T, keys map[string]any) {
+	t.Helper()
+	prev := map[string]any{}
+	for k := range keys {
+		prev[k] = viper.Get(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range prev {
+			viper.Set(k, v)
+		}
+	})
+	for k, v := range keys {
+		viper.Set(k, v)
+	}
+}
+
+// TestNotifyKeyPrefersNamespaced covers the compatibility shim between the two
+// key spellings this feature used to disagree about.
+func TestNotifyKeyPrefersNamespaced(t *testing.T) {
+	useNotifyConfig(t, map[string]any{
+		"notifications.discord_webhook": "https://discord.com/api/webhooks/new",
+		"discord_webhook":               "https://discord.com/api/webhooks/old",
+		"telegram_token":                "123456789:abcdefghijklmnop",
+		"notifications.telegram_token":  nil,
+	})
+
+	if got := notifyKey("discord_webhook"); got != "https://discord.com/api/webhooks/new" {
+		t.Errorf("namespaced key should win, got %q", got)
+	}
+	// A config written by an older build has only the bare key; dropping it on
+	// upgrade would silently disable a working channel.
+	if got := notifyKey("telegram_token"); got != "123456789:abcdefghijklmnop" {
+		t.Errorf("bare key should be honoured as a fallback, got %q", got)
+	}
+}
+
+// TestNotifyEnabledDefaultsOn verifies an absent switch means enabled.
+//
+// Every configuration written before the settings page existed sets only the
+// webhook URL. If an unset switch meant "off", upgrading would silently stop
+// delivering notifications that had been working.
+func TestNotifyEnabledDefaultsOn(t *testing.T) {
+	useNotifyConfig(t, map[string]any{
+		"notifications.discord_enabled": nil,
+		"discord_enabled":               nil,
+	})
+	if !notifyEnabled("discord_enabled") {
+		t.Error("an unset enabled switch must default to on")
+	}
+
+	useNotifyConfig(t, map[string]any{"notifications.discord_enabled": false})
+	if notifyEnabled("discord_enabled") {
+		t.Error("an explicit false must disable the channel")
+	}
+}
+
+// TestNotificationServiceFromConfigSMTP verifies the email tab's SMTP fields
+// reach a notifier.
+//
+// SMTPNotifier existed and was unit-tested long before anything constructed
+// one: the runtime only knew notifications.email_url. This asserts the wiring,
+// not the SMTP protocol.
+func TestNotificationServiceFromConfigSMTP(t *testing.T) {
+	useNotifyConfig(t, map[string]any{
+		"notifications.smtp_host": "mail.example.com",
+		"notifications.smtp_port": 2525,
+		"notifications.smtp_from": "sm@example.com",
+		// Two recipients in one free-text field, as the UI collects them.
+		"notifications.smtp_to":         "a@example.com, b@example.com",
+		"notifications.discord_webhook": "",
+		"notifications.email_url":       "",
+		"notifications.apprise_url":     "",
+		"notifications.telegram_token":  "",
+		"discord_webhook":               "",
+		"email_url":                     "",
+		"apprise_url":                   "",
+		"telegram_token":                "",
+		"smtp_host":                     "",
+	})
+
+	svc, err := notificationServiceFromConfig()
+	if err != nil {
+		t.Fatalf("notificationServiceFromConfig: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("SMTP settings alone produced no service; the email tab would stay dead")
+	}
+	if svc.SMTP == nil {
+		t.Fatal("SMTP notifier not built from smtp_* settings")
+	}
+	if svc.SMTP.Addr != "mail.example.com:2525" {
+		t.Errorf("Addr = %q, want host:port from config", svc.SMTP.Addr)
+	}
+	if len(svc.SMTP.To) != 2 {
+		t.Errorf("To = %v, want the comma-separated field split into two", svc.SMTP.To)
+	}
+	if !svc.Configured(notifications.ChannelEmail) {
+		t.Error("email channel reports unconfigured despite a usable SMTP notifier")
+	}
+}
+
+// TestNotificationTestHandler covers the responses the settings page relies on
+// to tell an unconfigured channel from a failing one.
+func TestNotificationTestHandler(t *testing.T) {
+	useNotifyConfig(t, map[string]any{
+		"notifications.discord_webhook": "",
+		"notifications.telegram_token":  "",
+		"notifications.email_url":       "",
+		"notifications.apprise_url":     "",
+		"notifications.smtp_host":       "",
+		"discord_webhook":               "",
+		"telegram_token":                "",
+		"email_url":                     "",
+		"apprise_url":                   "",
+		"smtp_host":                     "",
+	})
+	h := notificationTestHandler()
+
+	for name, tc := range map[string]struct {
+		method, path string
+		want         int
+	}{
+		// Offered by the UI, no sender exists. Reporting success here is the
+		// exact failure this endpoint is meant to prevent.
+		"pushover is honest about being unimplemented": {
+			http.MethodPost, "/api/notifications/test/push", http.StatusNotImplemented},
+		"generic webhook points at its own subsystem": {
+			http.MethodPost, "/api/notifications/test/webhook", http.StatusNotImplemented},
+		"unknown channel": {
+			http.MethodPost, "/api/notifications/test/carrier-pigeon", http.StatusBadRequest},
+		"no channel given": {
+			http.MethodPost, "/api/notifications/test/", http.StatusBadRequest},
+		"unconfigured channel is a 400, not a fake success": {
+			http.MethodPost, "/api/notifications/test/discord", http.StatusBadRequest},
+		"GET is rejected": {
+			http.MethodGet, "/api/notifications/test/discord", http.StatusMethodNotAllowed},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path,
+				strings.NewReader(`{"message":"hello"}`)))
+			if rr.Code != tc.want {
+				t.Errorf("got %d, want %d (body %s)", rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestNotificationTestHandlerDelivers verifies a configured channel actually
+// sends, and that a rejecting provider is reported as a failure.
+//
+// Apprise is the channel used here because it is the only one whose URL is
+// deliberately not run through the webhook allowlist — it is self-hosted
+// infrastructure — which is what makes it reachable from an httptest server.
+func TestNotificationTestHandlerDelivers(t *testing.T) {
+	var gotBody string
+	var status int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(b)
+		gotBody = string(b)
+		w.WriteHeader(status)
+	}))
+	defer srv.Close()
+
+	base := map[string]any{
+		"notifications.apprise_url":     srv.URL,
+		"notifications.discord_webhook": "",
+		"notifications.telegram_token":  "",
+		"notifications.email_url":       "",
+		"notifications.smtp_host":       "",
+		"apprise_url":                   "",
+		"discord_webhook":               "",
+		"telegram_token":                "",
+		"email_url":                     "",
+		"smtp_host":                     "",
+	}
+
+	t.Run("delivers the message", func(t *testing.T) {
+		useNotifyConfig(t, base)
+		status = http.StatusOK
+		rr := httptest.NewRecorder()
+		notificationTestHandler().ServeHTTP(rr, httptest.NewRequest(
+			http.MethodPost, "/api/notifications/test/apprise",
+			strings.NewReader(`{"message":"ping from the test"}`)))
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200 (body %s)", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(gotBody, "ping from the test") {
+			t.Errorf("provider received %q, which does not carry the message", gotBody)
+		}
+	})
+
+	t.Run("a rejecting provider is a failure, not a success", func(t *testing.T) {
+		useNotifyConfig(t, base)
+		status = http.StatusUnauthorized
+		rr := httptest.NewRecorder()
+		notificationTestHandler().ServeHTTP(rr, httptest.NewRequest(
+			http.MethodPost, "/api/notifications/test/apprise",
+			strings.NewReader(`{"message":"hi"}`)))
+
+		if rr.Code == http.StatusOK {
+			t.Error("provider returned 401 but the endpoint reported success; " +
+				"the operator would believe notifications work")
+		}
+	})
+}
+
+// TestNotificationTestHandlerRejectsUnsafeWebhook verifies the SSRF guard is on
+// the path this endpoint takes.
+//
+// The endpoint fetches an operator-supplied URL on demand, so it would be an
+// SSRF primitive if it constructed the Service directly instead of going
+// through notifications.New, which enforces HTTPS, rejects private and
+// link-local addresses, and applies a provider allowlist.
+func TestNotificationTestHandlerRejectsUnsafeWebhook(t *testing.T) {
+	for name, target := range map[string]string{
+		"link-local metadata endpoint": "https://169.254.169.254/latest/meta-data/",
+		"private address":              "https://192.168.1.10/hook",
+		"plain http":                   "http://discord.com/api/webhooks/x",
+		"host outside the allowlist":   "https://evil.example.com/hook",
+	} {
+		t.Run(name, func(t *testing.T) {
+			useNotifyConfig(t, map[string]any{
+				"notifications.discord_webhook": target,
+				"discord_webhook":               "",
+			})
+			rr := httptest.NewRecorder()
+			notificationTestHandler().ServeHTTP(rr, httptest.NewRequest(
+				http.MethodPost, "/api/notifications/test/discord",
+				strings.NewReader(`{"message":"hi"}`)))
+
+			if rr.Code == http.StatusOK {
+				t.Fatalf("%s was accepted; the endpoint would fetch it on demand", target)
+			}
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("got %d, want 400 (body %s)", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/webserver/notifications_test.go
+++ b/pkg/webserver/notifications_test.go
@@ -165,6 +165,32 @@ func TestNotificationTestHandler(t *testing.T) {
 	}
 }
 
+// TestNotificationTestHandlerUnderBaseURL verifies the channel is still parsed
+// when the server runs under a base_url.
+//
+// The route is mounted at prefix+"/api/notifications/test/". Stripping the
+// literal "/api/notifications/test" would match nothing once prefix is
+// non-empty, so every channel would resolve as unknown and the feature would be
+// dead for anyone behind a subpath — while every test using an empty prefix
+// passed.
+func TestNotificationTestHandlerUnderBaseURL(t *testing.T) {
+	useNotifyConfig(t, map[string]any{
+		"notifications.discord_webhook": "",
+		"discord_webhook":               "",
+	})
+	rr := httptest.NewRecorder()
+	notificationTestHandler().ServeHTTP(rr, httptest.NewRequest(
+		http.MethodPost, "/subtitles/api/notifications/test/discord",
+		strings.NewReader(`{"message":"hi"}`)))
+
+	// discord is a known channel that happens to be unconfigured here, so the
+	// correct answer is "not configured" (400). "unknown channel" would also be
+	// a 400, so assert on the text to tell the two apart.
+	if body := rr.Body.String(); strings.Contains(body, "unknown notification channel") {
+		t.Errorf("channel not parsed under a base_url: %s", body)
+	}
+}
+
 // TestNotificationTestHandlerDelivers verifies a configured channel actually
 // sends, and that a rejecting provider is reported as a failure.
 //

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -58,15 +58,6 @@ var knownMissingAPIPaths = map[string]string{
 	// UI actually sends. Build the selection UI and the endpoint together, or
 	// delete the dead functions.
 	"/api/bulk-operation": "MediaLibrary.jsx — bulk media operations; no UI invokes it",
-	// NotificationSettings.jsx calls /api/notifications/test/{type}. Held back
-	// deliberately: the settings page saves through POST /api/config, which
-	// viper.Set()s flat keys ("discord_webhook"), while the runtime reads
-	// namespaced ones ("notifications.discord_webhook"). A test button on top of
-	// that would report "not configured" straight after a successful save, or
-	// worse, report success for a channel that never fires in production. The
-	// key bridge and the endpoint have to land together.
-	"/api/bulk-operation":     "MediaLibrary.jsx — bulk media operations",
-	"/api/library/rescan-all": "App.jsx — rescan every library path",
 }
 
 // TestFrontendAPIPathsAreMounted verifies no frontend-called API path falls

--- a/pkg/webserver/route_coverage_test.go
+++ b/pkg/webserver/route_coverage_test.go
@@ -38,6 +38,7 @@ var frontendAPIPaths = []string{
 	"/api/providers/status",
 	"/api/wanted",
 	"/api/library/rescan-all",
+	"/api/notifications/test/discord",
 }
 
 // knownMissingAPIPaths are paths the web UI calls that have no backend handler
@@ -64,7 +65,8 @@ var knownMissingAPIPaths = map[string]string{
 	// that would report "not configured" straight after a successful save, or
 	// worse, report success for a channel that never fires in production. The
 	// key bridge and the endpoint have to land together.
-	"/api/notifications/test": "NotificationSettings.jsx — blocked on the config key namespace mismatch",
+	"/api/bulk-operation":     "MediaLibrary.jsx — bulk media operations",
+	"/api/library/rescan-all": "App.jsx — rescan every library path",
 }
 
 // TestFrontendAPIPathsAreMounted verifies no frontend-called API path falls

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -234,6 +234,10 @@ func newMux(db *sql.DB) (*http.ServeMux, string, error) {
 	mux.Handle(prefix+"/api/webhooks/test", authMiddleware(db, "basic", webhookTestHandler()))
 	mux.Handle(prefix+"/api/webhooks/history", authMiddleware(db, "basic", webhookHistoryHandler()))
 	mux.Handle(prefix+"/api/webhooks/event-types", authMiddleware(db, "basic", webhookEventTypesHandler()))
+	// Test-notification endpoint for the settings page. Trailing slash: the UI
+	// calls /api/notifications/test/{type}, and ServeMux treats a trailing-slash
+	// pattern as a subtree match.
+	mux.Handle(prefix+"/api/notifications/test/", authMiddleware(db, "basic", notificationTestHandler()))
 	mux.Handle(prefix+"/api/translate", authMiddleware(db, "basic", translateHandler()))
 	mux.Handle(prefix+"/api/sync/batch", authMiddleware(db, "basic", syncBatchHandler()))
 	// New search API endpoints
@@ -1450,20 +1454,14 @@ func startSessionCleanup(db *sql.DB) {
 // delivery defaults to on and can be disabled via
 // notifications.notify_on_{download,upgrade,failure}.
 func notificationsPublisherFromConfig() events.EventPublisher {
-	discord := viper.GetString("notifications.discord_webhook")
-	telegramToken := viper.GetString("notifications.telegram_token")
-	telegramChat := viper.GetString("notifications.telegram_chat_id")
-	email := viper.GetString("notifications.email_url")
-	apprise := viper.GetString("notifications.apprise_url")
-	if discord == "" && telegramToken == "" && email == "" && apprise == "" {
-		return nil
-	}
-	svc, err := notifications.New(discord, telegramToken, telegramChat, email)
+	svc, err := notificationServiceFromConfig()
 	if err != nil {
 		logging.GetLogger("webserver").Warnf("notifications disabled: %v", err)
 		return nil
 	}
-	svc.AppriseURL = apprise
+	if svc == nil || len(svc.Channels()) == 0 {
+		return nil
+	}
 	np := notifications.NewEventPublisher(svc)
 	if viper.IsSet("notifications.notify_on_download") {
 		np.NotifyOnDownload = viper.GetBool("notifications.notify_on_download")

--- a/webui/src/__tests__/NotificationSettings.test.jsx
+++ b/webui/src/__tests__/NotificationSettings.test.jsx
@@ -1,0 +1,56 @@
+// file: webui/src/__tests__/NotificationSettings.test.jsx
+// version: 1.0.0
+// guid: 6a2d81f4-90c7-4b35-8e10-5f7c40b9e2d8
+// last-edited: 2026-07-26
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import NotificationSettings from '../components/NotificationSettings.jsx';
+
+// The key namespace is the whole point of these tests. POST /api/config passes
+// each key straight to viper.Set, and the Go runtime reads `notifications.*`.
+// Saving bare keys therefore wrote settings nowhere anything read them, and the
+// page reported success while never delivering a notification.
+describe('NotificationSettings config keys', () => {
+  test('saves keys under the notifications namespace', () => {
+    const onSave = vi.fn();
+    render(<NotificationSettings config={{}} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('Save Notification Settings'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0];
+
+    // Every key namespaced; none left bare, where the runtime cannot see it.
+    const bare = Object.keys(saved).filter(
+      k => !k.startsWith('notifications.')
+    );
+    expect(bare).toEqual([]);
+    expect(saved).toHaveProperty('notifications.discord_webhook');
+    expect(saved).toHaveProperty('notifications.smtp_host');
+  });
+
+  test('reads namespaced values', () => {
+    render(
+      <NotificationSettings
+        config={{
+          notifications: { email_enabled: true, smtp_host: 'mail.example.com' },
+        }}
+        onSave={vi.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue('mail.example.com')).toBeInTheDocument();
+  });
+
+  // A config written by an older build has the bare key. Ignoring it would make
+  // a working configuration look empty, inviting the user to overwrite it.
+  test('falls back to bare keys from older builds', () => {
+    render(
+      <NotificationSettings
+        config={{ email_enabled: true, smtp_host: 'legacy.example.com' }}
+        onSave={vi.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue('legacy.example.com')).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/NotificationSettings.jsx
+++ b/webui/src/components/NotificationSettings.jsx
@@ -1,4 +1,7 @@
 // file: webui/src/components/NotificationSettings.jsx
+// version: 1.1.0
+// guid: 2f7a4c81-b930-4d5e-a6c2-08e4f159db73
+// last-edited: 2026-07-26
 import {
   Delete as DeleteIcon,
   Chat as DiscordIcon,
@@ -96,43 +99,60 @@ export default function NotificationSettings({
   // Load configuration values when provided
   useEffect(() => {
     if (config) {
+      // Settings live under the `notifications` key, which is where the Go
+      // runtime reads them from. Older builds of this page saved them at the
+      // top level instead, where nothing read them, so fall back to the bare
+      // key: a configuration saved before that fix still populates the form
+      // rather than appearing blank.
+      const n = config.notifications || {};
+      const get = (key, fallback) => {
+        const v = n[key] !== undefined ? n[key] : config[key];
+        return v === undefined ? fallback : v;
+      };
+
       // Email
-      setEmailEnabled(config.email_enabled || false);
-      setSmtpHost(config.smtp_host || '');
-      setSmtpPort(config.smtp_port || 587);
-      setSmtpUsername(config.smtp_username || '');
-      setSmtpPassword(config.smtp_password || '');
-      setSmtpFrom(config.smtp_from || '');
-      setSmtpTo(config.smtp_to || '');
-      setSmtpTLS(config.smtp_tls !== false);
+      setEmailEnabled(get('email_enabled', false));
+      setSmtpHost(get('smtp_host', ''));
+      setSmtpPort(get('smtp_port', 587));
+      setSmtpUsername(get('smtp_username', ''));
+      setSmtpPassword(get('smtp_password', ''));
+      setSmtpFrom(get('smtp_from', ''));
+      setSmtpTo(get('smtp_to', ''));
+      setSmtpTLS(get('smtp_tls', true) !== false);
 
       // Discord
-      setDiscordEnabled(config.discord_enabled || false);
-      setDiscordWebhook(config.discord_webhook || '');
-      setDiscordUsername(config.discord_username || 'Subtitle Manager');
-      setDiscordAvatar(config.discord_avatar || '');
+      setDiscordEnabled(get('discord_enabled', false));
+      setDiscordWebhook(get('discord_webhook', ''));
+      setDiscordUsername(get('discord_username', 'Subtitle Manager'));
+      setDiscordAvatar(get('discord_avatar', ''));
 
       // Telegram
-      setTelegramEnabled(config.telegram_enabled || false);
-      setTelegramToken(config.telegram_token || '');
-      setTelegramChatId(config.telegram_chat_id || '');
+      setTelegramEnabled(get('telegram_enabled', false));
+      setTelegramToken(get('telegram_token', ''));
+      setTelegramChatId(get('telegram_chat_id', ''));
 
       // Push
-      setPushEnabled(config.push_enabled || false);
-      setPushoverToken(config.pushover_token || '');
-      setPushoverUser(config.pushover_user || '');
+      setPushEnabled(get('push_enabled', false));
+      setPushoverToken(get('pushover_token', ''));
+      setPushoverUser(get('pushover_user', ''));
 
       // Webhook
-      setWebhookEnabled(config.webhook_enabled || false);
-      setWebhookUrl(config.webhook_url || '');
-      setWebhookMethod(config.webhook_method || 'POST');
-      setWebhookHeaders(config.webhook_headers || '');
+      setWebhookEnabled(get('webhook_enabled', false));
+      setWebhookUrl(get('webhook_url', ''));
+      setWebhookMethod(get('webhook_method', 'POST'));
+      setWebhookHeaders(get('webhook_headers', ''));
     }
   }, [config]);
 
-  // Persist updated configuration
+  // Persist updated configuration.
+  //
+  // Keys are sent dotted ("notifications.smtp_host") because POST /api/config
+  // hands each key straight to viper.Set, which treats a dot as nesting. This
+  // page previously sent bare keys, so everything it saved landed at the top
+  // level of the config while the Go runtime read `notifications.*` — saving
+  // reported success and no notification was ever delivered.
   const handleSave = () => {
-    const newConfig = {
+    const settings = {
       email_enabled: emailEnabled,
       smtp_host: smtpHost,
       smtp_port: parseInt(smtpPort, 10),
@@ -161,6 +181,10 @@ export default function NotificationSettings({
       webhook_headers: webhookHeaders,
     };
 
+    const newConfig = {};
+    for (const [key, value] of Object.entries(settings)) {
+      newConfig[`notifications.${key}`] = value;
+    }
     onSave(newConfig);
   };
 


### PR DESCRIPTION
The Notifications settings page has never worked. Three separate reasons, all of which had to be fixed together.

## 1. Settings were saved where nothing read them

`POST /api/config` hands each key to `viper.Set` exactly as received. The page sent **bare** keys (`discord_webhook`); the runtime has always read **namespaced** ones (`notifications.discord_webhook`).

So saving reported success, wrote to the config file, and nothing ever read it. The page now saves dotted keys, which `viper.Set` nests correctly.

Configurations written by an older build are still read as a fallback — dropping them would silently disable a channel that had been working. Re-saving migrates them.

## 2. Email could not work regardless of the namespace

`SMTPNotifier` has existed in `pkg/notifications`, with unit tests, since before this change — but **nothing ever constructed one**. The runtime knew only `notifications.email_url`, a webhook that happens to send mail, while the settings page collects SMTP host, port, credentials, sender and recipients. The two halves never met.

SMTP settings now build a notifier. Recipients are accepted as a comma or semicolon separated list, matching the single free-text field the UI offers.

The SMTP host is deliberately **not** run through `validateWebhookURL`: it is not a URL, and an operator's own mail relay is usually on a private address — exactly what that allowlist exists to reject. Treated as operator-supplied infrastructure, like the Apprise endpoint.

## 3. `/api/notifications/test/{type}` was never mounted

The test buttons have always called it. Unmounted paths here fall through to the SPA catch-all and return `index.html` with a `200`, so the page reported *"notification sent successfully!"* having sent nothing.

It now reports what actually happened:

| Case | Response |
|---|---|
| Channel not configured | `400` saying so — not a fake success |
| Provider rejected the message | `502` |
| `push` (Pushover) | `501` — only the hostname is allowlisted, there is no sender |
| `webhook` | `501` pointing at `/api/webhooks/config` and `/api/webhooks/test` |

That last one is worth flagging: the webhook tab **duplicates an existing, working subsystem**. `pkg/webhooks` already implements outgoing endpoints with methods, headers, retries and its own test endpoint. Rather than build a second one, the endpoint points at it. Consolidating the UI is follow-up work.

Supported channels: `discord`, `telegram`, `email`, `apprise`.

The test uses **saved** configuration, not the values currently in the form — the request carries only a message. Bazarr tests live form values; matching that would mean putting credentials in the request body.

## Design notes

**One code path.** The test endpoint and the event publisher build their service through the same helper, so "the test succeeded" and "events are delivered" cannot disagree. A test button exercising a different path than production is worse than no button: it reports confidence it has not earned.

**SSRF.** Delivery goes through `notifications.New`, which enforces HTTPS, rejects private and link-local addresses, and applies a provider allowlist. This endpoint fetches an operator-supplied URL on demand, so bypassing it would make it an SSRF primitive. Tested against the link-local metadata address, private addresses, plain HTTP and non-allowlisted hosts.

**No credentials in logs.** The failure path logs the channel name and error only. The `Service` holds bot tokens and SMTP passwords, and a failure handler is the place most tempted to dump config.

## Drive-by fixes in `Service.Send`

- It returned on the first failing channel, so **one broken webhook silently suppressed every channel configured after it**. All channels are now attempted; the first error is returned.
- Three of the four delivery paths never closed their response body, leaking a connection on every notification. Only Apprise got it right.

## Verification

`go test -race` green for `pkg/webserver` and `pkg/notifications`. New tests cover the key fallback, the enabled-switch default, SMTP construction, every handler response above, the SSRF rejections, and real delivery through an `httptest` server (Apprise is the one channel whose lenient validation permits that).

Frontend: 3 new tests pass. Failing-file diff versus base is **identical** — 10 files, all pre-existing stale tests, no regressions.

## Note for merge order

Touches `route_coverage_test.go`, which #2211 also edits, so this needs a rebase after that merges. Content-wise they are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH