### PR TITLE
perf(providers): query providers in parallel waves

### DIFF
--- a/changelog.d/perf-parallel-provider-fetch.md
+++ b/changelog.d/perf-parallel-provider-fetch.md
@@ -1,0 +1,71 @@
+<!-- file: changelog.d/perf-parallel-provider-fetch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6c623f40-2b17-4636-b077-633333e6a190 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Changed
+
+#### Providers are now queried in parallel
+
+Subtitle search consulted providers strictly one at a time, waiting up to 15s
+for each, and then *sleeping* an extra second per provider already tried before
+starting the next. A search that had to pass ten providers before finding a hit
+spent most of its time asleep; against the full registry a miss could take many
+minutes. This is the main reason library scans felt stalled.
+
+Providers are now queried in waves of four concurrently, and the inter-provider
+sleep is gone entirely. It was never load protection — consecutive requests go
+to *different* services — and per-provider retry pressure is already handled by
+the existing backoff map.
+
+Decisions worth reviewing later:
+
+- **Results are resolved in priority order, not completion order.** Returning
+  whichever provider answers first would be faster still, but it silently
+  inverts the configured provider priority: the preferred provider is usually
+  the slower one, because it is the one actually searching. A wave therefore
+  takes as long as its slowest member rather than its fastest. If you would
+  rather have raw speed than honour priority, this is the knob to change.
+- **Wave size is four.** Large enough to matter, small enough that a background
+  scan does not open ~55 simultaneous connections. It is a package-level `var`,
+  so it can be made configurable if that turns out to be the wrong number.
+- **Two instances of the same provider are never queried at once.** Distinct
+  providers are distinct services, but two instances of one provider share an
+  upstream host and rate limit, so overlapping them trades latency for 429s.
+- **The no-instances fallback path is parallelised too, but records no
+  backoff.** That path (the default on a fresh install, and the one
+  `pkg/scanner` takes) identifies providers by bare name; the backoff map is
+  keyed by instance ID, so writing to it there would invent state a code path
+  that never had any, changing which providers later calls even attempt.
+
+### Unchanged on purpose
+
+The three provider loops are now one implementation, but which of them emits a
+`SearchFailed` event is **exactly as before**: only a search over configured
+provider instances does. The name-based fallback and tag-filtered searches stay
+silent.
+
+That inconsistency looks like a bug worth fixing while the code is open, and it
+deliberately was not. `SearchFailed` reaches `pkg/webhooks`, which POSTs it to
+the operator's configured endpoint, and `pkg/scanner` calls into here **once per
+file**. Emitting from the fallback path — the default on a fresh install — would
+turn a single scan of a 10,000-file library into 10,000 outbound webhooks. That
+is a real behavioural change that deserves its own decision, not a side effect of
+a performance change. There is a test pinning the current emission points so the
+question has to be answered deliberately.
+
+### Fixed
+
+#### Data race in the provider registry
+
+The `factories` map was unguarded, which was safe only because providers were
+consulted serially. Querying them concurrently makes `Get` run from several
+goroutines at once, and `RegisterFactory` writes the same map. It is now behind
+a `RWMutex`. This was latent before the change rather than caused by it, but
+parallel fetching is what makes it reachable.
+
+#### Provider requests could outlive a cancelled search
+
+Provider calls in a wave are now waited on before the wave returns, so a
+cancelled or completed search leaves nothing running in the background against
+providers no caller is waiting on.

--- a/changelog.d/perf-parallel-provider-fetch.md
+++ b/changelog.d/perf-parallel-provider-fetch.md
@@ -56,6 +56,38 @@ question has to be answered deliberately.
 
 ### Fixed
 
+#### Providers returning "200 OK" with junk were treated as successful downloads
+
+Most of the ~55 registered providers are stubs that GET
+`https://api.<name>.com/subtitles/...` — hostnames nobody controls. Several
+resolve to parked pages or generic gateways that answer `200` to anything, and
+whatever came back was accepted as a subtitle.
+
+This is not hypothetical. Fetching a **nonexistent** media path against a
+default configuration succeeded and wrote a **2-byte file containing `OK`**
+where the subtitle should be:
+
+    $ subtitle-manager fetch nonexistent-garbage-path en out.srt
+    level=info msg="downloaded subtitle to out.srt"
+    $ cat out.srt
+    OK
+
+The second-order effect is worse than the junk file: a provider that "succeeds"
+ends the search, so a stub answering `200` to everything **preempts the real
+providers that would have found an actual subtitle**. The more providers are
+configured, the likelier a search is silently poisoned.
+
+Responses are now checked for subtitle structure — a `-->` timing separator
+(SRT, WebVTT) or SubStation Alpha's `[Script Info]` / `[Events]` / `Dialogue:`
+markers — and anything else is treated as a fetch failure so the next provider
+is tried. Verified against a live run: the command above now reports
+`no subtitle found` and writes nothing, while a real fetch still returns a
+45,970-byte subtitle.
+
+The check is permissive about format and strict about structure, so a subtitle
+in any supported format passes while an error page, JSON error body or parked
+placeholder does not.
+
 #### Data race in the provider registry
 
 The `factories` map was unguarded, which was safe only because providers were

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.8.0 -->
+<!-- version: 1.9.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-25 -->
+<!-- last-edited: 2026-07-30 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -84,7 +84,7 @@ effort — it is not fully achievable autonomously.
 | Score-gated accept/reject (min-score) | ✅ | wired into `ProcessFile` + `FetchWithProfile` |
 | Score-based upgrade | ✅ | compares persisted `DownloadRecord.MatchScore` |
 | Adaptive searching | 🟡 | fixed retry→blacklist; in-memory provider backoff |
-| Parallel provider fetch (core path) | 🟡 | `multi.go` is serial with backoff sleeps |
+| Parallel provider fetch (core path) | ✅ | `multi.go` runs waves of 4, resolved in priority order |
 | Use embedded tracks as a source | ✅ | `embedded` provider extracts muxed tracks via ffmpeg |
 | Ignore PGS/image subtitles | ✅ | `video.SubtitleStream.ImageBased()` skipped by embedded |
 | Desired-languages via profiles | ✅ | `FetchWithProfile` iterates by priority |

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,6 +1,7 @@
 // file: pkg/events/events.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 123e4567-e89b-12d3-a456-426614174006
+// last-edited: 2026-07-30
 
 package events
 
@@ -65,6 +66,14 @@ var globalPublisher EventPublisher
 // SetGlobalPublisher sets the global event publisher.
 func SetGlobalPublisher(publisher EventPublisher) {
 	globalPublisher = publisher
+}
+
+// GetGlobalPublisher returns the current global event publisher, which may be
+// nil. It exists so a caller that swaps the publisher — a test asserting which
+// code paths emit events, in practice — can put the previous one back rather
+// than leaving the global cleared for everything that runs afterwards.
+func GetGlobalPublisher() EventPublisher {
+	return globalPublisher
 }
 
 // PublishSubtitleDownloaded publishes a subtitle downloaded event.

--- a/pkg/providers/instance_test.go
+++ b/pkg/providers/instance_test.go
@@ -231,7 +231,7 @@ func TestFetchFromTagged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchFromTagged err: %v", err)
 	}
-	if id != "p2" || string(data) != "ok" {
+	if id != "p2" || !bytes.Contains(data, []byte("ok")) {
 		t.Fatalf("unexpected result %s %s", data, id)
 	}
 }

--- a/pkg/providers/instance_test.go
+++ b/pkg/providers/instance_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strconv"
@@ -45,13 +46,16 @@ func TestFetchFromAllInstances(t *testing.T) {
 	})
 
 	m1.On("Fetch", mock.Anything, "file.mkv", "en").Return([]byte(nil), errors.New("fail"))
-	m2.On("Fetch", mock.Anything, "file.mkv", "en").Return([]byte("ok"), nil)
+	// A real subtitle: provider responses are validated, so "ok" would now be
+	// rejected as not-a-subtitle and the fetch would report nothing found.
+	okSub := []byte("1\n00:00:01,000 --> 00:00:02,000\nok\n")
+	m2.On("Fetch", mock.Anything, "file.mkv", "en").Return(okSub, nil)
 
 	data, id, err := FetchFromAll(context.Background(), "file.mkv", "en", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(data) != "ok" || id != "p2" {
+	if !bytes.Contains(data, []byte("ok")) || id != "p2" {
 		t.Fatalf("unexpected result %s %s", data, id)
 	}
 
@@ -218,7 +222,10 @@ func TestFetchFromTagged(t *testing.T) {
 
 	testutil.MustNoError(t, "tag p2", database.AssignTagToEntity(db, tagID, "provider", "p2"))
 
-	m2.On("Fetch", mock.Anything, "file.mkv", "en").Return([]byte("ok"), nil)
+	// A real subtitle: provider responses are validated, so "ok" would now be
+	// rejected as not-a-subtitle and the fetch would report nothing found.
+	okSub := []byte("1\n00:00:01,000 --> 00:00:02,000\nok\n")
+	m2.On("Fetch", mock.Anything, "file.mkv", "en").Return(okSub, nil)
 
 	data, id, err := FetchFromTagged(context.Background(), "file.mkv", "en", "", []string{"fast"}, tm)
 	if err != nil {

--- a/pkg/providers/multi.go
+++ b/pkg/providers/multi.go
@@ -225,6 +225,15 @@ func runWave(ctx context.Context, insts []Instance, wave []int, mediaPath, lang,
 			c, cancel := context.WithTimeout(wctx, providerTimeout)
 			defer cancel()
 			data, err := p.Fetch(c, mediaPath, lang)
+			// A 200 is not a subtitle. Most providers are stubs pointing at
+			// hostnames nobody controls, and several answer 200 to anything —
+			// which was accepted as a successful download and, worse, ended the
+			// search before a real provider was tried. Treat it as a failure so
+			// the next provider gets its turn.
+			if err == nil && !looksLikeSubtitle(data) {
+				err = ErrNotSubtitle
+				data = nil
+			}
 			ch <- fetchOutcome{data: data, err: err}
 		}()
 	}

--- a/pkg/providers/multi.go
+++ b/pkg/providers/multi.go
@@ -1,94 +1,93 @@
 // file: pkg/providers/multi.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: 2f8c1a05-6d43-4b79-9e20-3a7c5d8b0164
+// last-edited: 2026-07-30
 
 package providers
 
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jdfalk/subtitle-manager/pkg/events"
 )
 
-// FetchFromAll tries each known provider in order until one returns a subtitle.
-// It uses an increasing delay between provider attempts to avoid rapid retries.
-// The provider API key is reused when applicable. The name of the provider that
+// maxConcurrentFetches bounds how many providers are queried at once.
+//
+// Four is a deliberate middle: the previous behaviour was strictly serial, so
+// a library scan paid the full latency of every provider that failed before
+// the one that worked — with ~55 registered providers and a 15s per-provider
+// timeout, a miss could take many minutes. Firing all of them at once instead
+// would open ~55 simultaneous connections from a background scan, which is
+// both unfriendly to the services and liable to trip local connection limits.
+//
+// It is a var rather than a const so tests can pin it to 1 and assert the
+// concurrent path selects exactly what the old serial path did.
+var maxConcurrentFetches = 4
+
+const (
+	// providerTimeout bounds a single provider's Fetch. Unchanged from the
+	// serial implementation.
+	providerTimeout = 15 * time.Second
+	// backoffStep scales the per-instance backoff applied after a failure.
+	backoffStep = time.Second
+)
+
+// fetchOptions carries the per-caller behaviour that used to be encoded by
+// having three near-duplicate copies of the provider loop.
+type fetchOptions struct {
+	// useBackoff reads and records per-instance backoff. The name-based
+	// fallback has no real instance IDs to key it on.
+	useBackoff bool
+	// publishFailure emits a SearchFailed event when nothing is found.
+	//
+	// This is not on for every caller, deliberately. SearchFailed reaches
+	// pkg/webhooks, which POSTs it to the operator's configured endpoint, and
+	// pkg/scanner calls into here once per file — so turning it on for the
+	// name-based fallback (the default on a fresh install) would fire one
+	// outbound webhook per file of a full library scan. The pre-existing
+	// emission points are preserved exactly; see the changelog for the
+	// inconsistency this leaves behind.
+	publishFailure bool
+}
+
+// fetchOutcome is one provider's result, carried back from its goroutine.
+type fetchOutcome struct {
+	data []byte
+	err  error
+}
+
+// FetchFromAll tries the known providers until one returns a subtitle,
+// querying up to maxConcurrentFetches of them at a time. The provider API key
+// is reused when applicable. The name (or instance ID) of the provider that
 // succeeded is returned along with the subtitle bytes.
+//
+// Providers are still consulted in priority order: see fetchFromInstances for
+// why concurrency does not mean "whoever answers first wins".
 func FetchFromAll(ctx context.Context, mediaPath, lang, key string) ([]byte, string, error) {
 	insts := Instances()
 	if len(insts) == 0 {
+		// No configured instances: fall back to every registered provider
+		// name. This is the default path on a fresh install, not an edge
+		// case — pkg/scanner reaches it for any library with no provider
+		// instances set up.
+		//
+		// Backoff is deliberately not applied here. The backoff map is keyed
+		// by instance ID, and synthesising IDs from bare provider names would
+		// start recording state for a path that has never had any, changing
+		// which providers a subsequent call even attempts.
 		names := All()
-		delay := time.Second
-		for i, name := range names {
-			p, err := Get(name, key)
-			if err != nil {
-				continue
-			}
-			c, cancel := context.WithTimeout(ctx, 15*time.Second)
-			data, err := p.Fetch(c, mediaPath, lang)
-			cancel()
-			if err == nil {
-				return data, name, nil
-			}
-			if ctx.Err() != nil {
-				return nil, "", ctx.Err()
-			}
-			// Context-aware inter-provider delay so a cancelled or bounded
-			// context aborts immediately instead of blocking on a blind sleep
-			// (this matches the instance-based loops below).
-			select {
-			case <-time.After(time.Duration(i+1) * delay):
-			case <-ctx.Done():
-				return nil, "", ctx.Err()
-			}
+		insts = make([]Instance, 0, len(names))
+		for _, name := range names {
+			insts = append(insts, Instance{ID: name, Name: name, Enabled: true})
 		}
-		return nil, "", fmt.Errorf("no subtitle found")
+		return fetchFromInstances(ctx, insts, mediaPath, lang, key,
+			fetchOptions{useBackoff: false, publishFailure: false})
 	}
-
-	delay := time.Second
-	var lastError error
-	for i, inst := range insts {
-		if IsInBackoff(inst.ID) {
-			continue
-		}
-		p, err := Get(inst.Name, key)
-		if err != nil {
-			continue
-		}
-		c, cancel := context.WithTimeout(ctx, 15*time.Second)
-		data, err := p.Fetch(c, mediaPath, lang)
-		cancel()
-		if err == nil {
-			SetBackoff(inst.ID, 0)
-			return data, inst.ID, nil
-		}
-		lastError = err
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
-		}
-		SetBackoff(inst.ID, time.Duration(i+1)*delay)
-		select {
-		case <-time.After(time.Duration(i+1) * delay):
-		case <-ctx.Done():
-			return nil, "", ctx.Err()
-		}
-	}
-
-	// Send search failed event
-	errorMsg := "no subtitle found"
-	if lastError != nil {
-		errorMsg = lastError.Error()
-	}
-	events.PublishSearchFailed(ctx, events.SearchFailedData{
-		Query:     fmt.Sprintf("media:%s lang:%s", mediaPath, lang),
-		Language:  lang,
-		Error:     errorMsg,
-		Timestamp: time.Now(),
-	})
-
-	return nil, "", fmt.Errorf("no subtitle found")
+	return fetchFromInstances(ctx, insts, mediaPath, lang, key,
+		fetchOptions{useBackoff: true, publishFailure: true})
 }
 
 // FetchFromTagged limits provider attempts to instances matching all tags.
@@ -102,35 +101,157 @@ func FetchFromTagged(ctx context.Context, mediaPath, lang, key string, tags []st
 	if len(insts) == 0 {
 		return nil, "", fmt.Errorf("no subtitle found")
 	}
-	return fetchFromInstances(ctx, insts, mediaPath, lang, key)
+	return fetchFromInstances(ctx, insts, mediaPath, lang, key,
+		fetchOptions{useBackoff: true, publishFailure: false})
 }
 
-func fetchFromInstances(ctx context.Context, insts []Instance, mediaPath, lang, key string) ([]byte, string, error) {
-	delay := time.Second
-	for i, inst := range insts {
-		if IsInBackoff(inst.ID) {
-			continue
+// fetchFromInstances queries insts in priority order, up to
+// maxConcurrentFetches at a time, and returns the first subtitle found.
+//
+// This is the single implementation behind both FetchFromAll and
+// FetchFromTagged, which previously carried near-duplicate copies of the loop
+// that had drifted apart. Their remaining differences are now explicit in
+// opts rather than implicit in three separately-maintained loop bodies.
+func fetchFromInstances(ctx context.Context, insts []Instance, mediaPath, lang, key string, opts fetchOptions) ([]byte, string, error) {
+	var lastError error
+
+	next := 0
+	for next < len(insts) {
+		// Assemble the next wave, walking the list in priority order.
+		wave := make([]int, 0, maxConcurrentFetches)
+		inWave := make(map[string]bool, maxConcurrentFetches)
+		for next < len(insts) && len(wave) < maxConcurrentFetches {
+			inst := insts[next]
+			if opts.useBackoff && IsInBackoff(inst.ID) {
+				next++
+				continue
+			}
+			// Two instances of the same provider share one upstream service
+			// and one rate limit, so they must not be queried concurrently —
+			// the point of running in parallel is to overlap *different*
+			// hosts. Stop the wave here and let this instance start the next
+			// one, which keeps the overall priority order intact.
+			if inWave[inst.Name] {
+				break
+			}
+			inWave[inst.Name] = true
+			wave = append(wave, next)
+			next++
 		}
-		p, err := Get(inst.Name, key)
+		if len(wave) == 0 {
+			break
+		}
+
+		data, id, done, err := runWave(ctx, insts, wave, mediaPath, lang, key, opts.useBackoff)
+		if done {
+			return data, id, err
+		}
 		if err != nil {
-			continue
-		}
-		c, cancel := context.WithTimeout(ctx, 15*time.Second)
-		data, err := p.Fetch(c, mediaPath, lang)
-		cancel()
-		if err == nil {
-			SetBackoff(inst.ID, 0)
-			return data, inst.ID, nil
+			lastError = err
 		}
 		if ctx.Err() != nil {
 			return nil, "", ctx.Err()
 		}
-		SetBackoff(inst.ID, time.Duration(i+1)*delay)
+	}
+
+	if opts.publishFailure {
+		errorMsg := "no subtitle found"
+		if lastError != nil {
+			errorMsg = lastError.Error()
+		}
+		events.PublishSearchFailed(ctx, events.SearchFailedData{
+			Query:     fmt.Sprintf("media:%s lang:%s", mediaPath, lang),
+			Language:  lang,
+			Error:     errorMsg,
+			Timestamp: time.Now(),
+		})
+	}
+
+	return nil, "", fmt.Errorf("no subtitle found")
+}
+
+// runWave queries every instance in one wave concurrently and resolves the
+// results in priority order. It reports (data, id, done, err); done is true
+// when the caller should stop, either because a subtitle was found or because
+// the context ended.
+//
+// Resolving in priority order rather than completion order is the whole
+// correctness question here. Taking whichever provider answers first would
+// silently invert the operator's configured priority whenever a lower-ranked
+// provider happens to be faster — which is most of the time, since the
+// preferred provider is usually the one doing real work. So slot k is only
+// consulted once every slot before it has failed.
+//
+// The cost is that a wave takes as long as its slowest member rather than its
+// fastest, bounded by providerTimeout. That is still far better than the
+// serial path, which paid every provider's latency plus a growing sleep
+// between each one.
+func runWave(ctx context.Context, insts []Instance, wave []int, mediaPath, lang, key string, useBackoff bool) ([]byte, string, bool, error) {
+	// Nothing to do if the caller already gave up; without this an aborted
+	// search would still fire a full wave of provider requests.
+	if err := ctx.Err(); err != nil {
+		return nil, "", true, err
+	}
+
+	// Cancelling the wave stops the losers as soon as a winner is known,
+	// rather than leaving them running against a provider nobody is waiting
+	// on any more.
+	wctx, cancelWave := context.WithCancel(ctx)
+
+	// Deferred before cancelWave so it runs *after* it (defers are LIFO):
+	// cancel first, then wait for the goroutines to observe it and exit. No
+	// wave outlives the call that started it — otherwise a cancelled search
+	// leaves provider requests running in the background, and the goroutines
+	// keep touching package state after the caller has moved on.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer cancelWave()
+
+	results := make([]chan fetchOutcome, len(wave))
+	for slot, idx := range wave {
+		// Buffered so a goroutine whose result is never read still exits
+		// instead of blocking forever on the send.
+		ch := make(chan fetchOutcome, 1)
+		results[slot] = ch
+		inst := insts[idx]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p, err := Get(inst.Name, key)
+			if err != nil {
+				ch <- fetchOutcome{err: err}
+				return
+			}
+			c, cancel := context.WithTimeout(wctx, providerTimeout)
+			defer cancel()
+			data, err := p.Fetch(c, mediaPath, lang)
+			ch <- fetchOutcome{data: data, err: err}
+		}()
+	}
+
+	var lastErr error
+	for slot, idx := range wave {
+		var out fetchOutcome
 		select {
-		case <-time.After(time.Duration(i+1) * delay):
+		case out = <-results[slot]:
 		case <-ctx.Done():
-			return nil, "", ctx.Err()
+			return nil, "", true, ctx.Err()
+		}
+
+		inst := insts[idx]
+		if out.err == nil {
+			if useBackoff {
+				SetBackoff(inst.ID, 0)
+			}
+			return out.data, inst.ID, true, nil
+		}
+		lastErr = out.err
+		if useBackoff {
+			// Derived from the instance's static position in the priority
+			// list, not from the order goroutines happened to finish in, so
+			// the recorded backoff is deterministic under concurrency.
+			SetBackoff(inst.ID, time.Duration(idx+1)*backoffStep)
 		}
 	}
-	return nil, "", fmt.Errorf("no subtitle found")
+	return nil, "", false, lastErr
 }

--- a/pkg/providers/multi_test.go
+++ b/pkg/providers/multi_test.go
@@ -1,14 +1,18 @@
 // file: pkg/providers/multi_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 6b1e9c04-8a37-4d52-9f60-2c5d0a7b3841
+// last-edited: 2026-07-30
 
 package providers
 
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/jdfalk/subtitle-manager/pkg/events"
 )
 
 type alwaysFailProvider struct{}
@@ -17,12 +21,121 @@ func (alwaysFailProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]
 	return nil, fmt.Errorf("fail")
 }
 
+// scriptedProvider is a provider whose latency and outcome the test controls,
+// and which records when it starts and stops so concurrency can be observed
+// rather than inferred from wall-clock timing alone.
+type scriptedProvider struct {
+	name  string
+	delay time.Duration
+	body  []byte // non-nil means success
+	obs   *observer
+}
+
+func (p scriptedProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	p.obs.enter(p.name)
+	defer p.obs.exit()
+
+	select {
+	case <-time.After(p.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if p.body == nil {
+		return nil, fmt.Errorf("%s: no subtitle", p.name)
+	}
+	return p.body, nil
+}
+
+// observer tracks concurrent Fetch calls and the order they were started in.
+type observer struct {
+	mu      sync.Mutex
+	active  int
+	peak    int
+	started []string
+}
+
+func newObserver() *observer { return &observer{} }
+
+func (o *observer) enter(name string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.active++
+	if o.active > o.peak {
+		o.peak = o.active
+	}
+	o.started = append(o.started, name)
+}
+
+func (o *observer) exit() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.active--
+}
+
+// useInstances replaces the global instance registry for one test and restores
+// it afterwards. The registry is package-level shared state, so a test that
+// merely adds to it leaks into every later test in the package.
+func useInstances(t *testing.T, insts ...Instance) {
+	t.Helper()
+	instancesMu.Lock()
+	prev := instances
+	instances = map[string]Instance{}
+	for _, i := range insts {
+		instances[i.ID] = i
+	}
+	instancesMu.Unlock()
+
+	backoffMu.Lock()
+	prevBackoff := backoffMap
+	backoffMap = map[string]time.Time{}
+	backoffMu.Unlock()
+
+	t.Cleanup(func() {
+		instancesMu.Lock()
+		instances = prev
+		instancesMu.Unlock()
+		backoffMu.Lock()
+		backoffMap = prevBackoff
+		backoffMu.Unlock()
+	})
+}
+
+// useFactories replaces the whole provider factory registry for one test.
+//
+// RegisterFactory has no per-test scope, so by the time a test runs, sibling
+// tests have added mock factories that succeed. Any test exercising the
+// name-based fallback (which walks the entire registry) is otherwise at their
+// mercy — it will "pass" because some unrelated mock returned a subtitle.
+func useFactories(t *testing.T, fs map[string]func() Provider) {
+	t.Helper()
+	factoriesMu.Lock()
+	prev := factories
+	factories = map[string]func() Provider{}
+	for n, f := range fs {
+		factories[n] = f
+	}
+	factoriesMu.Unlock()
+	t.Cleanup(func() {
+		factoriesMu.Lock()
+		factories = prev
+		factoriesMu.Unlock()
+	})
+}
+
+// useConcurrency pins maxConcurrentFetches for one test.
+func useConcurrency(t *testing.T, n int) {
+	t.Helper()
+	prev := maxConcurrentFetches
+	maxConcurrentFetches = n
+	t.Cleanup(func() { maxConcurrentFetches = prev })
+}
+
 // TestFetchFromAllHonorsCancelledContext verifies FetchFromAll returns promptly
-// with the context error instead of blocking on inter-provider delays when the
-// context is already cancelled.
+// with the context error instead of blocking when the context is already
+// cancelled.
 func TestFetchFromAllHonorsCancelledContext(t *testing.T) {
 	RegisterFactory("failtest", func() Provider { return alwaysFailProvider{} })
-	RegisterInstance(Instance{ID: "failtest-1", Name: "failtest", Enabled: true})
+	useInstances(t, Instance{ID: "failtest-1", Name: "failtest", Enabled: true})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
@@ -35,4 +148,324 @@ func TestFetchFromAllHonorsCancelledContext(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("FetchFromAll did not abort promptly: %v", elapsed)
 	}
+}
+
+// TestFetchFromAllPrefersHigherPriority is the test that distinguishes a
+// correct concurrent implementation from a plausible one.
+//
+// Running providers concurrently makes it natural to return whichever answers
+// first. That would silently invert the operator's configured priority: the
+// preferred provider is usually the slower one, because it is the one actually
+// searching. Here the high-priority provider takes 150ms and the low-priority
+// one returns instantly, so "first success wins" picks the wrong provider
+// while every other test in this file still passes.
+func TestFetchFromAllPrefersHigherPriority(t *testing.T) {
+	obs := newObserver()
+	RegisterFactory("slowgood", func() Provider {
+		return scriptedProvider{name: "slowgood", delay: 150 * time.Millisecond,
+			body: []byte("preferred"), obs: obs}
+	})
+	RegisterFactory("fastgood", func() Provider {
+		return scriptedProvider{name: "fastgood", delay: 0,
+			body: []byte("secondary"), obs: obs}
+	})
+
+	useConcurrency(t, 4)
+	useInstances(t,
+		Instance{ID: "slowgood-1", Name: "slowgood", Enabled: true, Priority: 100},
+		Instance{ID: "fastgood-1", Name: "fastgood", Enabled: true, Priority: 1},
+	)
+
+	data, id, err := FetchFromAll(context.Background(), "/media/movie.mkv", "en", "")
+	if err != nil {
+		t.Fatalf("FetchFromAll: %v", err)
+	}
+	if id != "slowgood-1" {
+		t.Errorf("winner = %q, want slowgood-1: the faster low-priority provider "+
+			"was preferred, which inverts the configured provider order", id)
+	}
+	if string(data) != "preferred" {
+		t.Errorf("data = %q, want the high-priority provider's body", data)
+	}
+}
+
+// TestFetchFromAllQueriesProvidersConcurrently verifies the wave actually
+// overlaps distinct providers.
+//
+// Asserted on observed concurrent Fetch calls rather than elapsed time: a
+// timing-only assertion passes on a fast machine even if the calls are serial.
+func TestFetchFromAllQueriesProvidersConcurrently(t *testing.T) {
+	obs := newObserver()
+	var insts []Instance
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("concurrent%d", i)
+		RegisterFactory(name, func() Provider {
+			return scriptedProvider{name: name, delay: 100 * time.Millisecond, obs: obs}
+		})
+		insts = append(insts, Instance{
+			ID: name + "-1", Name: name, Enabled: true, Priority: 100 - i,
+		})
+	}
+
+	useConcurrency(t, 4)
+	useInstances(t, insts...)
+
+	start := time.Now()
+	if _, _, err := FetchFromAll(context.Background(), "/m.mkv", "en", ""); err == nil {
+		t.Fatal("expected no subtitle found; every provider fails here")
+	}
+	elapsed := time.Since(start)
+
+	obs.mu.Lock()
+	peak := obs.peak
+	obs.mu.Unlock()
+
+	if peak < 2 {
+		t.Errorf("peak concurrent fetches = %d, want at least 2: providers are "+
+			"still being queried one at a time", peak)
+	}
+	// Four 100ms providers serially is >=400ms plus the old inter-provider
+	// sleeps (1s+2s+3s), so ~6.4s. One wave is ~100ms. The bound is loose
+	// because it only needs to separate "one wave" from "serial" on a
+	// contended CI runner; the peak assertion above is the precise one.
+	if elapsed > time.Second {
+		t.Errorf("elapsed = %v, want roughly one provider's latency", elapsed)
+	}
+}
+
+// TestFetchNeverRunsOneProviderConcurrently verifies two instances of the same
+// provider are not queried at the same time.
+//
+// Overlapping distinct providers is fine — they are separate services. Two
+// instances of one provider share a single upstream host and rate limit, so
+// firing them together turns the speed-up into a 429.
+func TestFetchNeverRunsOneProviderConcurrently(t *testing.T) {
+	obs := newObserver()
+	RegisterFactory("shared", func() Provider {
+		return scriptedProvider{name: "shared", delay: 60 * time.Millisecond, obs: obs}
+	})
+
+	useConcurrency(t, 4)
+	useInstances(t,
+		Instance{ID: "shared-a", Name: "shared", Enabled: true, Priority: 30},
+		Instance{ID: "shared-b", Name: "shared", Enabled: true, Priority: 20},
+		Instance{ID: "shared-c", Name: "shared", Enabled: true, Priority: 10},
+	)
+
+	if _, _, err := FetchFromAll(context.Background(), "/m.mkv", "en", ""); err == nil {
+		t.Fatal("expected no subtitle found")
+	}
+
+	obs.mu.Lock()
+	peak := obs.peak
+	obs.mu.Unlock()
+	if peak > 1 {
+		t.Errorf("peak concurrent fetches against one provider = %d, want 1: "+
+			"instances of the same provider share a rate limit", peak)
+	}
+}
+
+// TestFetchSerialEquivalence pins concurrency to 1 and checks the wave path
+// selects exactly what the old serial loop did: strict priority order, first
+// success wins, and a deterministic per-instance backoff derived from list
+// position rather than completion order.
+func TestFetchSerialEquivalence(t *testing.T) {
+	obs := newObserver()
+	RegisterFactory("eq_fail_a", func() Provider {
+		return scriptedProvider{name: "eq_fail_a", obs: obs}
+	})
+	RegisterFactory("eq_fail_b", func() Provider {
+		return scriptedProvider{name: "eq_fail_b", obs: obs}
+	})
+	RegisterFactory("eq_ok", func() Provider {
+		return scriptedProvider{name: "eq_ok", body: []byte("ok"), obs: obs}
+	})
+
+	useConcurrency(t, 1)
+	useInstances(t,
+		Instance{ID: "eq_fail_a-1", Name: "eq_fail_a", Enabled: true, Priority: 30},
+		Instance{ID: "eq_fail_b-1", Name: "eq_fail_b", Enabled: true, Priority: 20},
+		Instance{ID: "eq_ok-1", Name: "eq_ok", Enabled: true, Priority: 10},
+	)
+
+	_, id, err := FetchFromAll(context.Background(), "/m.mkv", "en", "")
+	if err != nil {
+		t.Fatalf("FetchFromAll: %v", err)
+	}
+	if id != "eq_ok-1" {
+		t.Errorf("winner = %q, want eq_ok-1", id)
+	}
+
+	obs.mu.Lock()
+	order := append([]string(nil), obs.started...)
+	obs.mu.Unlock()
+	want := []string{"eq_fail_a", "eq_fail_b", "eq_ok"}
+	if len(order) != len(want) {
+		t.Fatalf("providers queried = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("providers queried = %v, want strict priority order %v", order, want)
+		}
+	}
+
+	// The two failures must be in backoff; the success must have cleared it.
+	if !IsInBackoff("eq_fail_a-1") || !IsInBackoff("eq_fail_b-1") {
+		t.Error("failed instances should be in backoff")
+	}
+	if IsInBackoff("eq_ok-1") {
+		t.Error("a successful instance must have its backoff cleared")
+	}
+
+	// The durations, not just the fact of a backoff. They are derived from
+	// each instance's static position in the priority list precisely so they
+	// stay deterministic under concurrency; deriving them from completion
+	// order instead would still leave both instances "in backoff" and pass
+	// the checks above. The second instance is one backoffStep later than the
+	// first, so their deadlines must differ by about that much.
+	backoffMu.RLock()
+	first, second := backoffMap["eq_fail_a-1"], backoffMap["eq_fail_b-1"]
+	backoffMu.RUnlock()
+	gap := second.Sub(first)
+	if gap < backoffStep/2 || gap > backoffStep*2 {
+		t.Errorf("backoff deadlines differ by %v, want about %v: the duration is "+
+			"not being derived from the instance's position in the list", gap, backoffStep)
+	}
+}
+
+// TestFetchSkipsInstancesInBackoff verifies a backed-off instance is passed
+// over without occupying a slot in the wave.
+func TestFetchSkipsInstancesInBackoff(t *testing.T) {
+	obs := newObserver()
+	RegisterFactory("bo_skipped", func() Provider {
+		return scriptedProvider{name: "bo_skipped", body: []byte("nope"), obs: obs}
+	})
+	RegisterFactory("bo_used", func() Provider {
+		return scriptedProvider{name: "bo_used", body: []byte("yes"), obs: obs}
+	})
+
+	useConcurrency(t, 4)
+	useInstances(t,
+		Instance{ID: "bo_skipped-1", Name: "bo_skipped", Enabled: true, Priority: 99},
+		Instance{ID: "bo_used-1", Name: "bo_used", Enabled: true, Priority: 1},
+	)
+	SetBackoff("bo_skipped-1", time.Minute)
+
+	_, id, err := FetchFromAll(context.Background(), "/m.mkv", "en", "")
+	if err != nil {
+		t.Fatalf("FetchFromAll: %v", err)
+	}
+	if id != "bo_used-1" {
+		t.Errorf("winner = %q, want bo_used-1; the backed-off instance was queried anyway", id)
+	}
+
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	for _, n := range obs.started {
+		if n == "bo_skipped" {
+			t.Error("an instance in backoff was queried")
+		}
+	}
+}
+
+// TestFetchFromAllFallsBackToRegisteredNames covers the path taken when no
+// provider instances are configured, which is the default on a fresh install
+// and the one pkg/scanner reaches. Backoff must not be recorded there: the
+// backoff map is keyed by instance ID and this path has none.
+func TestFetchFromAllFallsBackToRegisteredNames(t *testing.T) {
+	useConcurrency(t, 4)
+	useInstances(t) // no instances at all
+
+	useFactories(t, map[string]func() Provider{
+		"fb_fail": func() Provider { return alwaysFailProvider{} },
+	})
+
+	if _, _, err := FetchFromAll(context.Background(), "/m.mkv", "en", ""); err == nil {
+		t.Fatal("expected no subtitle found")
+	}
+
+	backoffMu.RLock()
+	n := len(backoffMap)
+	backoffMu.RUnlock()
+	if n != 0 {
+		t.Errorf("backoff recorded %d entries on the name-based path, want 0", n)
+	}
+}
+
+// countingPublisher records SearchFailed emissions. Only the methods used here
+// do anything; the rest satisfy the interface.
+type countingPublisher struct {
+	mu     sync.Mutex
+	failed int
+}
+
+func (c *countingPublisher) PublishSearchFailed(context.Context, events.SearchFailedData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failed++
+}
+func (c *countingPublisher) PublishSubtitleDownloaded(context.Context, events.SubtitleDownloadedData) {
+}
+func (c *countingPublisher) PublishSubtitleUpgraded(context.Context, events.SubtitleUpgradedData) {}
+func (c *countingPublisher) PublishSubtitleFailed(context.Context, events.SubtitleFailedData)     {}
+
+func (c *countingPublisher) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.failed
+}
+
+// useEventCounter installs a counting publisher for one test.
+func useEventCounter(t *testing.T) *countingPublisher {
+	t.Helper()
+	c := &countingPublisher{}
+	prev := events.GetGlobalPublisher()
+	events.SetGlobalPublisher(c)
+	t.Cleanup(func() { events.SetGlobalPublisher(prev) })
+	return c
+}
+
+// TestSearchFailedEmissionIsUnchanged pins which code paths publish a
+// SearchFailed event.
+//
+// This matters more than it looks: SearchFailed reaches pkg/webhooks, which
+// POSTs it to the operator's configured endpoint, and pkg/scanner calls
+// FetchFromAll once per file. Unifying the three provider loops made it easy
+// to accidentally emit from the name-based fallback — the default on a fresh
+// install — which would turn one library scan into one outbound webhook per
+// file. The emission points are therefore exactly the pre-existing ones.
+func TestSearchFailedEmissionIsUnchanged(t *testing.T) {
+	RegisterFactory("emit_fail", func() Provider { return alwaysFailProvider{} })
+
+	t.Run("configured instances publish", func(t *testing.T) {
+		useConcurrency(t, 4)
+		useInstances(t, Instance{ID: "emit_fail-1", Name: "emit_fail", Enabled: true})
+		c := useEventCounter(t)
+
+		if _, _, err := FetchFromAll(context.Background(), "/m.mkv", "en", ""); err == nil {
+			t.Fatal("expected no subtitle found")
+		}
+		if got := c.count(); got != 1 {
+			t.Errorf("SearchFailed emitted %d times, want 1", got)
+		}
+	})
+
+	t.Run("name-based fallback stays silent", func(t *testing.T) {
+		useConcurrency(t, 4)
+		useInstances(t) // none configured -> fallback over registered names
+		// Every provider must fail, or the search succeeds and no failure
+		// event would be published regardless of the option under test.
+		useFactories(t, map[string]func() Provider{
+			"emit_fail": func() Provider { return alwaysFailProvider{} },
+		})
+		c := useEventCounter(t)
+
+		if _, _, err := FetchFromAll(context.Background(), "/m.mkv", "en", ""); err == nil {
+			t.Fatal("expected no subtitle found; the fallback registry only fails here")
+		}
+		if got := c.count(); got != 0 {
+			t.Errorf("SearchFailed emitted %d times on the fallback path, want 0: "+
+				"a full library scan would fire one webhook per file", got)
+		}
+	})
 }

--- a/pkg/providers/multi_test.go
+++ b/pkg/providers/multi_test.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -19,6 +20,16 @@ type alwaysFailProvider struct{}
 
 func (alwaysFailProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
 	return nil, fmt.Errorf("fail")
+}
+
+// subtitleBody builds a minimal but genuine SRT payload.
+//
+// Provider responses are validated now — a 200 carrying something that is not a
+// subtitle counts as a failure — so test fixtures have to be real subtitles or
+// they exercise the rejection path instead of the one under test.
+func subtitleBody(marker string) []byte {
+	return []byte("1\n00:00:01,000 --> 00:00:02,000\n" + marker + "\n\n" +
+		"2\n00:00:03,000 --> 00:00:04,000\nsecond cue\n")
 }
 
 // scriptedProvider is a provider whose latency and outcome the test controls,
@@ -163,11 +174,11 @@ func TestFetchFromAllPrefersHigherPriority(t *testing.T) {
 	obs := newObserver()
 	RegisterFactory("slowgood", func() Provider {
 		return scriptedProvider{name: "slowgood", delay: 150 * time.Millisecond,
-			body: []byte("preferred"), obs: obs}
+			body: subtitleBody("preferred"), obs: obs}
 	})
 	RegisterFactory("fastgood", func() Provider {
 		return scriptedProvider{name: "fastgood", delay: 0,
-			body: []byte("secondary"), obs: obs}
+			body: subtitleBody("secondary"), obs: obs}
 	})
 
 	useConcurrency(t, 4)
@@ -184,7 +195,7 @@ func TestFetchFromAllPrefersHigherPriority(t *testing.T) {
 		t.Errorf("winner = %q, want slowgood-1: the faster low-priority provider "+
 			"was preferred, which inverts the configured provider order", id)
 	}
-	if string(data) != "preferred" {
+	if !bytes.Contains(data, []byte("preferred")) {
 		t.Errorf("data = %q, want the high-priority provider's body", data)
 	}
 }
@@ -278,7 +289,7 @@ func TestFetchSerialEquivalence(t *testing.T) {
 		return scriptedProvider{name: "eq_fail_b", obs: obs}
 	})
 	RegisterFactory("eq_ok", func() Provider {
-		return scriptedProvider{name: "eq_ok", body: []byte("ok"), obs: obs}
+		return scriptedProvider{name: "eq_ok", body: subtitleBody("ok"), obs: obs}
 	})
 
 	useConcurrency(t, 1)
@@ -338,10 +349,10 @@ func TestFetchSerialEquivalence(t *testing.T) {
 func TestFetchSkipsInstancesInBackoff(t *testing.T) {
 	obs := newObserver()
 	RegisterFactory("bo_skipped", func() Provider {
-		return scriptedProvider{name: "bo_skipped", body: []byte("nope"), obs: obs}
+		return scriptedProvider{name: "bo_skipped", body: subtitleBody("nope"), obs: obs}
 	})
 	RegisterFactory("bo_used", func() Provider {
-		return scriptedProvider{name: "bo_used", body: []byte("yes"), obs: obs}
+		return scriptedProvider{name: "bo_used", body: subtitleBody("yes"), obs: obs}
 	})
 
 	useConcurrency(t, 4)

--- a/pkg/providers/registry.go
+++ b/pkg/providers/registry.go
@@ -1,8 +1,14 @@
+// file: pkg/providers/registry.go
+// version: 1.1.0
+// guid: 85c2d092-08c4-4009-b9ec-502f12ae3794
+// last-edited: 2026-07-30
+
 package providers
 
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/jdfalk/subtitle-manager/pkg/providers/addic7ed"
 	"github.com/jdfalk/subtitle-manager/pkg/providers/animekalesi"
@@ -112,9 +118,20 @@ var factories = map[string]func() Provider{
 	"zimuku":           func() Provider { return zimuku.New() },
 }
 
+// factoriesMu guards factories.
+//
+// The map was unguarded while providers were only ever consulted one at a
+// time. FetchFromAll now queries several concurrently, so Get is called from
+// multiple goroutines and the map needs a lock — concurrent reads alone are
+// safe, but RegisterFactory writes it, and Go's race detector (correctly)
+// flags the combination.
+var factoriesMu sync.RWMutex
+
 // RegisterFactory adds a provider factory to the registry. Primarily used in tests
 // to register mock providers.
 func RegisterFactory(name string, f func() Provider) {
+	factoriesMu.Lock()
+	defer factoriesMu.Unlock()
 	factories[name] = f
 }
 
@@ -123,7 +140,10 @@ func Get(name, _ string) (Provider, error) {
 	if name == "opensubtitles" {
 		return opensubtitles.New(""), nil
 	}
-	if f, ok := factories[name]; ok {
+	factoriesMu.RLock()
+	f, ok := factories[name]
+	factoriesMu.RUnlock()
+	if ok {
 		return f(), nil
 	}
 	return nil, fmt.Errorf("unknown provider %s", name)
@@ -131,11 +151,13 @@ func Get(name, _ string) (Provider, error) {
 
 // All returns the list of known provider names in alphabetical order.
 func All() []string {
+	factoriesMu.RLock()
 	names := make([]string, 0, len(factories)+1)
 	names = append(names, "opensubtitles")
 	for n := range factories {
 		names = append(names, n)
 	}
+	factoriesMu.RUnlock()
 	sort.Strings(names)
 	return names
 }

--- a/pkg/providers/validate.go
+++ b/pkg/providers/validate.go
@@ -1,0 +1,71 @@
+// file: pkg/providers/validate.go
+// version: 1.0.0
+// guid: f6bafd75-4871-464c-adce-fb0e0890cf03
+// last-edited: 2026-07-30
+
+package providers
+
+import (
+	"bytes"
+	"errors"
+	"unicode/utf8"
+)
+
+// ErrNotSubtitle reports that a provider returned something that is not a
+// subtitle. It is treated as a fetch failure so the search moves on.
+var ErrNotSubtitle = errors.New("provider response is not a subtitle")
+
+// minSubtitleBytes is a floor below which no real subtitle exists. A single
+// SRT cue — index, timecode line, one line of text — is already ~40 bytes.
+const minSubtitleBytes = 32
+
+// looksLikeSubtitle reports whether data plausibly contains subtitles.
+//
+// # Why this is necessary
+//
+// Most of the registered providers are stubs that GET
+// https://api.<name>.com/subtitles/... — hostnames nobody controls. Several
+// resolve to parked pages, captive portals or generic API gateways that answer
+// 200 to anything. Without this check, subtitle-manager accepted whatever came
+// back: fetching a *nonexistent* media path succeeded and wrote a 2-byte file
+// containing "OK" next to the media, reporting success.
+//
+// The second-order effect is worse than the junk file. A provider that
+// "succeeds" ends the search, so a stub answering 200 to everything preempts
+// the real providers that would have found an actual subtitle — the more
+// providers are configured, the likelier a search is silently poisoned.
+//
+// The check is deliberately permissive about format and strict about
+// structure: SRT and WebVTT both use "-->" between timestamps, and
+// SubStation Alpha has a [Script Info] or [Events] section with Dialogue
+// lines. Anything without one of those markers is not a subtitle in a format
+// this application can use, whatever else it may be.
+func looksLikeSubtitle(data []byte) bool {
+	if len(data) < minSubtitleBytes {
+		return false
+	}
+	// A subtitle is text. Binary payloads are archives that should already have
+	// been extracted, or error pages that happen to be long.
+	if !utf8.Valid(data) {
+		return false
+	}
+
+	// Only the head needs inspecting; markers appear early in every format.
+	head := data
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	lower := bytes.ToLower(head)
+
+	// SRT and WebVTT.
+	if bytes.Contains(head, []byte("-->")) {
+		return true
+	}
+	// SubStation Alpha / Advanced SubStation Alpha.
+	if bytes.Contains(lower, []byte("[script info]")) ||
+		bytes.Contains(lower, []byte("[events]")) ||
+		bytes.Contains(lower, []byte("dialogue:")) {
+		return true
+	}
+	return false
+}

--- a/pkg/providers/validate_test.go
+++ b/pkg/providers/validate_test.go
@@ -1,0 +1,86 @@
+// file: pkg/providers/validate_test.go
+// version: 1.0.0
+// guid: 3e7d1b96-0c45-4a28-95f1-8b60e2a4c7d3
+// last-edited: 2026-07-30
+
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLooksLikeSubtitle(t *testing.T) {
+	srt := "1\n00:00:01,000 --> 00:00:02,000\nHello world\n\n2\n00:00:03,000 --> 00:00:04,000\nGoodbye\n"
+	ass := "[Script Info]\nTitle: x\n\n[Events]\nFormat: Layer, Start, End\nDialogue: 0,0:00:01.00,0:00:02.00,Default,,hi\n"
+	vtt := "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello world, this is a caption line\n"
+
+	for name, tc := range map[string]struct {
+		in   string
+		want bool
+	}{
+		"srt":    {srt, true},
+		"ass":    {ass, true},
+		"webvtt": {vtt, true},
+
+		// The case that prompted this: a live host answering 200 to anything.
+		// Fetching a nonexistent media path wrote this to disk as a subtitle.
+		"the literal OK a parked host returned": {"OK", false},
+
+		"empty":           {"", false},
+		"html error page": {"<!doctype html><html><head><title>404 Not Found</title></head><body>Not found here at all</body></html>", false},
+		"json api error":  {`{"error":"not found","message":"no subtitle available for this media file"}`, false},
+		"plain prose":     {strings.Repeat("just some text that is long enough to pass a length check. ", 3), false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := looksLikeSubtitle([]byte(tc.in)); got != tc.want {
+				t.Errorf("looksLikeSubtitle(%.40q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// okProvider mimics a stub provider whose hostname resolves to something that
+// answers 200 to every request.
+type okProvider struct{}
+
+func (okProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return []byte("OK"), nil
+}
+
+// realProvider returns an actual subtitle.
+type realProvider struct{}
+
+func (realProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return []byte("1\n00:00:01,000 --> 00:00:02,000\nHello world\n"), nil
+}
+
+// TestFetchRejectsNonSubtitleAndContinues is the behavioural guard.
+//
+// A provider that answers 200 with junk used to end the search successfully:
+// the junk was written to disk as a subtitle, and — the worse half — the real
+// provider behind it was never consulted. Ordering the junk provider first
+// reproduces exactly that.
+func TestFetchRejectsNonSubtitleAndContinues(t *testing.T) {
+	RegisterFactory("junk200", func() Provider { return okProvider{} })
+	RegisterFactory("realsub", func() Provider { return realProvider{} })
+
+	useConcurrency(t, 4)
+	useInstances(t,
+		Instance{ID: "junk200-1", Name: "junk200", Enabled: true, Priority: 100},
+		Instance{ID: "realsub-1", Name: "realsub", Enabled: true, Priority: 1},
+	)
+
+	data, id, err := FetchFromAll(context.Background(), "/media/movie.mkv", "en", "")
+	if err != nil {
+		t.Fatalf("FetchFromAll: %v", err)
+	}
+	if id != "realsub-1" {
+		t.Errorf("winner = %q, want realsub-1: a provider returning %q was accepted "+
+			"as a subtitle and ended the search", id, "OK")
+	}
+	if !strings.Contains(string(data), "-->") {
+		t.Errorf("data = %q, want a real subtitle", data)
+	}
+}


### PR DESCRIPTION
## What

Subtitle search consulted providers **strictly one at a time** — up to 15s each, then an extra `(i+1)` second *sleep* before the next. A search that passed ten providers before a hit spent most of its time asleep; against the full registry a miss could run for minutes. This is a large part of why library scans feel stalled.

Providers are now queried in **waves of four**, and the inter-provider sleep is removed entirely. It was never load protection — consecutive requests go to *different* services — and per-provider retry pressure is already handled by the existing backoff map.

## Decisions worth reviewing

- **Results resolve in priority order, not completion order.** Returning whichever provider answers first would be faster still, but silently inverts configured provider priority: the preferred provider is usually the *slower* one, because it's the one actually searching. A wave therefore costs its slowest member, not its fastest. `TestFetchFromAllPrefersHigherPriority` is the test that distinguishes this from the plausible-but-wrong implementation — it fails with `winner = "fastgood-1"` against first-success-wins.
- **Wave size 4**, a package-level `var` so it can be made configurable. Big enough to matter; small enough that a background scan doesn't open ~55 simultaneous connections.
- **Two instances of the same provider are never concurrent.** Distinct providers are distinct services; two instances of one provider share a host and rate limit, so overlapping them trades latency for 429s.
- **The fallback path records no backoff.** It identifies providers by bare name; the backoff map is keyed by instance ID, so writing there would invent state that path never had.

## Two latent bugs found on the way

- **`factories` was an unguarded package-level map.** Safe only while `Get` ran serially. Now behind a `RWMutex` — `go test -race` caught this immediately once fetches overlapped.
- **Provider calls could outlive their search.** A cancelled search left requests running in the background. Waves are now waited on before returning.

## Deliberately *not* changed

The three provider loops are unified, but **`SearchFailed` emission is exactly as before** — only searches over configured instances emit. Unifying them made it easy to accidentally emit from the fallback path too, and that path is the default on a fresh install, reached by `pkg/scanner` **once per file**. Since `SearchFailed` reaches `pkg/webhooks` and POSTs to the operator's endpoint, that would turn one scan of a 10,000-file library into 10,000 outbound webhooks. `TestSearchFailedEmissionIsUnchanged` pins it so the question gets answered deliberately rather than as a side effect.

## Verification

Full suite green under `-race`. Every new guard was checked for non-vacuity by breaking the fix and confirming the test fails:

| Break | Result |
|---|---|
| first-success-wins | ✅ fails — picks the low-priority provider |
| remove same-provider guard | ✅ fails — peak concurrency 3, want 1 |
| constant backoff duration | ✅ fails — deadlines differ by 27µs, want ~1s |
| fallback emits events | ✅ fails — 1 emission, want 0 |

That last check initially **passed while broken** — the fallback walked the shared registry and succeeded via a mock another test had registered, so no failure event fired either way. Added a `useFactories` helper to scope the registry per test; the assertion is real now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH