### PR TITLE
fix(providers): compute provider status instead of inventing it

### DIFF
--- a/changelog.d/fix-provider-status-real.md
+++ b/changelog.d/fix-provider-status-real.md
@@ -1,5 +1,5 @@
 <!-- file: changelog.d/fix-provider-status-real.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 3a9d61b8-52c7-4e0f-8b34-7d1e05f4a2c9 -->
 <!-- last-edited: 2026-07-30 -->
 
@@ -51,6 +51,19 @@ retry a throttled provider without also erasing the record of why it was
 throttled.
 
 Response codes are unchanged (`202` and `204`).
+
+### Unset times are omitted from the JSON, not zero-valued
+
+`last_success`, `last_failure` and `retry_after` are pointers so that "never
+happened" is an absent field rather than `0001-01-01T00:00:00Z`.
+
+`encoding/json` does **not** apply `omitempty` to structs, so a plain
+`time.Time` is always serialised. With the obvious field types, every one of the
+52 providers shipped a `last_success` — and the field whose entire purpose is to
+separate a working provider from a stub was present on all of them and
+distinguished nothing. The Go-level tests asserted `IsZero()` and passed
+throughout; this was only visible by querying a running server. There is now a
+test that asserts on the marshalled JSON.
 
 ### Known issue this surfaced
 

--- a/changelog.d/fix-provider-status-real.md
+++ b/changelog.d/fix-provider-status-real.md
@@ -1,0 +1,72 @@
+<!-- file: changelog.d/fix-provider-status-real.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3a9d61b8-52c7-4e0f-8b34-7d1e05f4a2c9 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### `/api/providers/status` reported invented data
+
+The endpoint was backed by a cache that could only ever hold fiction.
+`providers.Refresh` did not check anything — it marked every provider name it
+was handed as `available: true` — and the one caller passed it a hardcoded
+`[]string{"opensubtitles", "subscene"}`. Nothing scheduled it, so the endpoint
+returned `{}` until someone POSTed to `/api/providers/refresh`, and after that
+it reported exactly two providers as healthy: one real, and one
+(`subscene`) that is a non-functional stub which has never been able to return a
+subtitle. Every genuinely working provider — `napiprojekt`, `gestdown`,
+`podnapisi`, `embedded` — was absent.
+
+Status is now **computed on read** from state the process already holds, so
+there is nothing to refresh and nothing to schedule:
+
+- `enabled` — from the provider's configuration.
+- `available` — whether a search would consult it *right now*: enabled and not
+  currently throttled. It deliberately does **not** mean "known to work".
+- `throttled` / `retry_after` — from the existing backoff map.
+- `last_success` / `last_failure` — from fetches that actually happened.
+
+`last_success` is what distinguishes a working provider from a stub, and it
+needs no hand-maintained list of "real" providers to do it: a stub simply never
+succeeds. A second copy of that list in Go would have gone stale the first time
+someone implemented a provider and forgot to update it.
+
+Outcomes are recorded in `SetBackoff`, which both fetch loops already call —
+zero after a provider returned a subtitle, non-zero after one failed. No change
+to the fetch path was needed.
+
+### Changed
+
+#### The two reset endpoints now do different, real things
+
+- `POST /api/providers/refresh` clears provider **throttling**, so backed-off
+  providers are retried immediately. This mirrors Bazarr's "reset provider
+  throttling" and is the useful action that remains once availability is
+  computed rather than cached. It is what an operator wants after fixing
+  credentials.
+- `POST /api/providers/reset` clears the recorded **success/failure history**.
+
+Keeping these separate matters: conflating them would mean an operator cannot
+retry a throttled provider without also erasing the record of why it was
+throttled.
+
+Response codes are unchanged (`202` and `204`).
+
+### Known issue this surfaced
+
+**Nothing in the running server calls `providers.RegisterInstance`.** The
+provider *instance* layer — multiple configured instances of a provider, each
+with its own credentials, priority, tags and throttle state — is populated only
+by tests. On a real deployment `Instances()` is always empty, so:
+
+- searches always take the name-based fallback over the registered provider
+  names, and per-instance priority, tags and backoff never apply; and
+- a status implementation keyed purely on instances would have returned `{}` on
+  every real install.
+
+`List` therefore falls back to reporting the registered provider names, which is
+what a search on that deployment would actually consult. That keeps this change
+honest, but it is a workaround: the instance layer being unreachable is a
+separate gap, and wiring provider instances to configuration is its own piece of
+work. Flagged here rather than fixed quietly, because it also explains why
+per-provider configuration in the UI cannot currently take effect.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.8.0 -->
+<!-- version: 1.9.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-25 -->
+<!-- last-edited: 2026-07-30 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -120,6 +120,8 @@ effort — it is not fully achievable autonomously.
 | Notifications (Apprise / many channels) | ✅ | Apprise + Discord/Telegram/email; **fire on subtitle events** |
 | Plex incoming webhook | ✅ | `POST /api/webhooks/plex` (`library.new`) |
 | External-Whisper URL/model/timeout config | ✅ | `whisper.transcribe_url` (native /asr), model, timeout |
+| Provider status / throttle view | ✅ | `/api/providers/status` computed on read (enabled/throttled/last success); no UI consumer yet |
+| Per-provider instance config (priority, tags, credentials) | 🔴 | `RegisterInstance` has **no production caller** — the instance layer is unreachable; searches always use the name fallback |
 
 ## Implementation plan (backend)
 

--- a/pkg/providers/instance.go
+++ b/pkg/providers/instance.go
@@ -1,4 +1,8 @@
 // file: pkg/providers/instance.go
+// version: 1.1.0
+// guid: d7e9e164-3f86-4b97-95c8-c821bb4fe988
+// last-edited: 2026-07-30
+
 package providers
 
 import (
@@ -87,7 +91,20 @@ func ListInstances() []Instance {
 }
 
 // SetBackoff records a backoff duration for a provider instance. A zero or negative duration clears the backoff.
+//
+// This doubles as the seam where provider outcomes are recorded for
+// /api/providers/status. Every call site already means one of exactly two
+// things — the fetch loops call SetBackoff(id, 0) only after a provider
+// returned a subtitle, and SetBackoff(id, >0) only after one failed — so
+// recording here captures real history without threading a status call
+// through the fetch path.
 func SetBackoff(id string, d time.Duration) {
+	if d <= 0 {
+		recordSuccess(id)
+	} else {
+		recordFailure(id)
+	}
+
 	backoffMu.Lock()
 	defer backoffMu.Unlock()
 	if d <= 0 {

--- a/pkg/providers/status.go
+++ b/pkg/providers/status.go
@@ -1,47 +1,174 @@
 // file: pkg/providers/status.go
+// version: 2.0.0
+// guid: f23c08ee-e040-4796-b45c-5b550e7b8282
+// last-edited: 2026-07-30
+
 package providers
 
 import (
-	"context"
 	"sync"
 	"time"
 )
 
-// Status represents the availability of a provider.
+// Status describes what is known about one provider instance.
+//
+// Every field is derived from state the process already holds — the instance
+// registry, the backoff map, and the outcome of fetches that have actually
+// happened. Nothing here is probed.
+//
+// The previous implementation stored the result of a "check" that did not
+// exist: Refresh marked every name it was given as Available regardless of
+// reality, and it was called with a hardcoded list of two providers. The status
+// map was therefore empty until someone POSTed to /api/providers/refresh, and
+// then reported exactly two providers as healthy — one of which (subscene) is a
+// non-functional stub. Reporting nothing would have been more informative.
 type Status struct {
-	Name      string    `json:"name"`
-	Available bool      `json:"available"`
+	// Name is the provider name, e.g. "opensubtitles".
+	Name string `json:"name"`
+	// InstanceID identifies the configured instance. Several instances of one
+	// provider can exist, each with its own credentials and throttle state.
+	InstanceID string `json:"instance_id,omitempty"`
+	// Enabled reflects the instance's configuration.
+	Enabled bool `json:"enabled"`
+	// Available is true when the provider would be consulted by a search right
+	// now: enabled, and not currently backed off.
+	Available bool `json:"available"`
+	// Throttled is true while the provider is in backoff after a failure.
+	Throttled bool `json:"throttled"`
+	// RetryAfter is when the backoff expires. Zero when not throttled.
+	RetryAfter time.Time `json:"retry_after,omitempty"`
+	// LastSuccess is when this instance last returned a subtitle. Zero means
+	// it has never succeeded — which, for the many providers that are still
+	// stubs, is the honest answer and needs no hardcoded list to produce.
+	LastSuccess time.Time `json:"last_success,omitempty"`
+	// LastFailure is when this instance last failed.
+	LastFailure time.Time `json:"last_failure,omitempty"`
+	// CheckedAt is when this snapshot was computed.
 	CheckedAt time.Time `json:"checked_at"`
 }
 
+// outcome records what has actually happened to one provider instance.
+type outcome struct {
+	lastSuccess time.Time
+	lastFailure time.Time
+}
+
 var (
-	statusMu  sync.Mutex
-	statusMap = map[string]Status{}
+	outcomeMu  sync.RWMutex
+	outcomeMap = map[string]outcome{}
 )
 
-// Refresh simulates checking each provider and marks them as available.
-func Refresh(ctx context.Context, names []string) {
-	statusMu.Lock()
-	defer statusMu.Unlock()
-	for _, n := range names {
-		statusMap[n] = Status{Name: n, Available: true, CheckedAt: time.Now()}
+// recordSuccess notes that an instance returned a subtitle.
+func recordSuccess(id string) {
+	if id == "" {
+		return
 	}
+	outcomeMu.Lock()
+	defer outcomeMu.Unlock()
+	o := outcomeMap[id]
+	o.lastSuccess = time.Now()
+	outcomeMap[id] = o
 }
 
-// Reset clears all stored provider status information.
+// recordFailure notes that an instance failed to return a subtitle.
+func recordFailure(id string) {
+	if id == "" {
+		return
+	}
+	outcomeMu.Lock()
+	defer outcomeMu.Unlock()
+	o := outcomeMap[id]
+	o.lastFailure = time.Now()
+	outcomeMap[id] = o
+}
+
+// Reset clears the recorded provider history. Throttle state is left alone;
+// ResetThrottling handles that.
 func Reset() {
-	statusMu.Lock()
-	defer statusMu.Unlock()
-	statusMap = map[string]Status{}
+	outcomeMu.Lock()
+	defer outcomeMu.Unlock()
+	outcomeMap = map[string]outcome{}
 }
 
-// List returns a copy of the provider status map.
+// ResetThrottling clears every provider's backoff so throttled providers are
+// retried immediately.
+//
+// This mirrors Bazarr's "reset provider throttling" action. It is what
+// POST /api/providers/refresh now does: there is no availability to go and
+// fetch — status is computed on read — but "stop waiting out the backoff and
+// try again" is a real thing an operator wants after fixing credentials.
+func ResetThrottling() {
+	backoffMu.Lock()
+	defer backoffMu.Unlock()
+	backoffMap = map[string]time.Time{}
+}
+
+// List returns the status of every provider a search would currently consult,
+// keyed by instance ID (or by provider name when no instances are configured).
+//
+// Disabled instances are included: "configured but switched off" is
+// information, and omitting them would make a provider silently vanish from
+// the list rather than show up as disabled.
+//
+// Note on what Available means: "would be consulted by a search right now" —
+// enabled and not throttled. It deliberately does *not* mean "known to work".
+// Whether a provider has ever actually produced a subtitle is carried by
+// LastSuccess, which stays zero for the many providers that are still stubs.
+// Conflating the two is what made the old implementation useless.
 func List() map[string]Status {
-	statusMu.Lock()
-	defer statusMu.Unlock()
-	out := make(map[string]Status, len(statusMap))
-	for k, v := range statusMap {
-		out[k] = v
+	now := time.Now()
+
+	insts := ListInstances() // enabled and disabled, priority order
+	if len(insts) == 0 {
+		// No configured instances. This is not an edge case: nothing in the
+		// running server calls RegisterInstance, so on a real install the
+		// instance registry is always empty and searches fall back to the
+		// registered provider names. Reporting an empty map here would be
+		// accurate about instances and useless about the system — the status
+		// endpoint would answer "{}" on every deployment.
+		for _, name := range All() {
+			insts = append(insts, Instance{ID: name, Name: name, Enabled: true})
+		}
+	}
+
+	backoffMu.RLock()
+	deadlines := make(map[string]time.Time, len(insts))
+	for _, inst := range insts {
+		if until, ok := backoffMap[inst.ID]; ok {
+			deadlines[inst.ID] = until
+		}
+	}
+	backoffMu.RUnlock()
+
+	outcomeMu.RLock()
+	outcomes := make(map[string]outcome, len(insts))
+	for _, inst := range insts {
+		if o, ok := outcomeMap[inst.ID]; ok {
+			outcomes[inst.ID] = o
+		}
+	}
+	outcomeMu.RUnlock()
+
+	out := make(map[string]Status, len(insts))
+	for _, inst := range insts {
+		until, hasBackoff := deadlines[inst.ID]
+		throttled := hasBackoff && now.Before(until)
+		o := outcomes[inst.ID]
+
+		s := Status{
+			Name:        inst.Name,
+			InstanceID:  inst.ID,
+			Enabled:     inst.Enabled,
+			Throttled:   throttled,
+			Available:   inst.Enabled && !throttled,
+			LastSuccess: o.lastSuccess,
+			LastFailure: o.lastFailure,
+			CheckedAt:   now,
+		}
+		if throttled {
+			s.RetryAfter = until
+		}
+		out[inst.ID] = s
 	}
 	return out
 }

--- a/pkg/providers/status.go
+++ b/pkg/providers/status.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/status.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: f23c08ee-e040-4796-b45c-5b550e7b8282
 // last-edited: 2026-07-30
 
@@ -35,14 +35,25 @@ type Status struct {
 	Available bool `json:"available"`
 	// Throttled is true while the provider is in backoff after a failure.
 	Throttled bool `json:"throttled"`
-	// RetryAfter is when the backoff expires. Zero when not throttled.
-	RetryAfter time.Time `json:"retry_after,omitempty"`
-	// LastSuccess is when this instance last returned a subtitle. Zero means
-	// it has never succeeded — which, for the many providers that are still
-	// stubs, is the honest answer and needs no hardcoded list to produce.
-	LastSuccess time.Time `json:"last_success,omitempty"`
-	// LastFailure is when this instance last failed.
-	LastFailure time.Time `json:"last_failure,omitempty"`
+	// RetryAfter is when the backoff expires, or nil when not throttled.
+	//
+	// A pointer, not a time.Time: encoding/json's omitempty does NOT apply to
+	// structs, so a zero time.Time is serialised as "0001-01-01T00:00:00Z"
+	// rather than omitted. A client checking whether the field is present would
+	// see one on every provider.
+	RetryAfter *time.Time `json:"retry_after,omitempty"`
+	// LastSuccess is when this instance last returned a subtitle, or nil when
+	// it never has — which, for the many providers that are still stubs, is the
+	// honest answer and needs no hardcoded list to produce.
+	//
+	// Pointers for the same reason as RetryAfter: with a plain time.Time these
+	// serialised as "0001-01-01T00:00:00Z" on every provider, so the field that
+	// is supposed to separate a working provider from a stub was present
+	// everywhere and distinguished nothing. Caught by querying a running
+	// server; the Go-level tests asserted on IsZero() and never saw the JSON.
+	LastSuccess *time.Time `json:"last_success,omitempty"`
+	// LastFailure is when this instance last failed, or nil if it never has.
+	LastFailure *time.Time `json:"last_failure,omitempty"`
 	// CheckedAt is when this snapshot was computed.
 	CheckedAt time.Time `json:"checked_at"`
 }
@@ -156,17 +167,24 @@ func List() map[string]Status {
 		o := outcomes[inst.ID]
 
 		s := Status{
-			Name:        inst.Name,
-			InstanceID:  inst.ID,
-			Enabled:     inst.Enabled,
-			Throttled:   throttled,
-			Available:   inst.Enabled && !throttled,
-			LastSuccess: o.lastSuccess,
-			LastFailure: o.lastFailure,
-			CheckedAt:   now,
+			Name:       inst.Name,
+			InstanceID: inst.ID,
+			Enabled:    inst.Enabled,
+			Throttled:  throttled,
+			Available:  inst.Enabled && !throttled,
+			CheckedAt:  now,
+		}
+		if !o.lastSuccess.IsZero() {
+			t := o.lastSuccess
+			s.LastSuccess = &t
+		}
+		if !o.lastFailure.IsZero() {
+			t := o.lastFailure
+			s.LastFailure = &t
 		}
 		if throttled {
-			s.RetryAfter = until
+			u := until
+			s.RetryAfter = &u
 		}
 		out[inst.ID] = s
 	}

--- a/pkg/providers/status_test.go
+++ b/pkg/providers/status_test.go
@@ -1,0 +1,199 @@
+// file: pkg/providers/status_test.go
+// version: 1.0.0
+// guid: cb3753c6-7b0d-45cd-9137-9528ad6da276
+// last-edited: 2026-07-30
+
+package providers
+
+import (
+	"testing"
+	"time"
+)
+
+// useStatusState isolates the instance, backoff and outcome registries for one
+// test. All three are package-level globals, so a test that merely adds to them
+// leaks into every test that runs afterwards.
+func useStatusState(t *testing.T, insts ...Instance) {
+	t.Helper()
+
+	instancesMu.Lock()
+	prevInsts := instances
+	instances = map[string]Instance{}
+	for _, i := range insts {
+		instances[i.ID] = i
+	}
+	instancesMu.Unlock()
+
+	backoffMu.Lock()
+	prevBackoff := backoffMap
+	backoffMap = map[string]time.Time{}
+	backoffMu.Unlock()
+
+	outcomeMu.Lock()
+	prevOutcome := outcomeMap
+	outcomeMap = map[string]outcome{}
+	outcomeMu.Unlock()
+
+	t.Cleanup(func() {
+		instancesMu.Lock()
+		instances = prevInsts
+		instancesMu.Unlock()
+		backoffMu.Lock()
+		backoffMap = prevBackoff
+		backoffMu.Unlock()
+		outcomeMu.Lock()
+		outcomeMap = prevOutcome
+		outcomeMu.Unlock()
+	})
+}
+
+// TestListReportsConfiguredInstances covers the core of the rewrite: status is
+// derived from the instance registry, so every configured provider appears and
+// no unconfigured one does.
+//
+// The old implementation reported whatever the last Refresh call had been
+// handed, which in practice was a hardcoded pair of names — so real providers
+// never appeared at all and one non-functional stub was listed as healthy.
+func TestListReportsConfiguredInstances(t *testing.T) {
+	useStatusState(t,
+		Instance{ID: "opensubtitles-1", Name: "opensubtitles", Enabled: true, Priority: 10},
+		Instance{ID: "podnapisi-1", Name: "podnapisi", Enabled: true, Priority: 5},
+		Instance{ID: "gestdown-1", Name: "gestdown", Enabled: false, Priority: 1},
+	)
+
+	got := List()
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3: %v", len(got), got)
+	}
+
+	if _, ok := got["subscene-1"]; ok {
+		t.Error("an unconfigured provider appeared in the status list")
+	}
+	if s := got["podnapisi-1"]; !s.Available || s.Name != "podnapisi" {
+		t.Errorf("podnapisi = %+v, want an available entry", s)
+	}
+
+	// A disabled instance is listed, but not as available. Omitting it would
+	// make the provider silently vanish rather than show as switched off.
+	d := got["gestdown-1"]
+	if d.Enabled {
+		t.Error("disabled instance reported as enabled")
+	}
+	if d.Available {
+		t.Error("disabled instance reported as available")
+	}
+}
+
+// TestListNeverInventsAvailability is the regression guard for the specific
+// defect this change fixes.
+//
+// providers.Refresh marked every name it was passed Available: true without
+// performing any check. A provider that has never succeeded must not be
+// reported as healthy just because it is configured — Available means "would
+// be consulted right now", and LastSuccess carries whether it has ever worked.
+func TestListNeverInventsAvailability(t *testing.T) {
+	useStatusState(t, Instance{ID: "stub-1", Name: "stub", Enabled: true})
+
+	s := List()["stub-1"]
+	if !s.LastSuccess.IsZero() {
+		t.Error("a provider that never ran reports a last success")
+	}
+	if !s.LastFailure.IsZero() {
+		t.Error("a provider that never ran reports a last failure")
+	}
+}
+
+// TestStatusTracksThrottling verifies backoff is reflected as throttled and
+// unavailable, and that an expired backoff is not.
+func TestStatusTracksThrottling(t *testing.T) {
+	useStatusState(t,
+		Instance{ID: "thr-1", Name: "thr", Enabled: true},
+		Instance{ID: "exp-1", Name: "exp", Enabled: true},
+	)
+
+	SetBackoff("thr-1", time.Minute)
+	// Already elapsed: recorded, but no longer in force.
+	backoffMu.Lock()
+	backoffMap["exp-1"] = time.Now().Add(-time.Minute)
+	backoffMu.Unlock()
+
+	got := List()
+
+	thr := got["thr-1"]
+	if !thr.Throttled {
+		t.Error("a backed-off provider is not reported as throttled")
+	}
+	if thr.Available {
+		t.Error("a throttled provider is reported as available; a search would skip it")
+	}
+	if thr.RetryAfter.IsZero() {
+		t.Error("a throttled provider reports no retry time")
+	}
+
+	exp := got["exp-1"]
+	if exp.Throttled || !exp.Available {
+		t.Errorf("expired backoff still counted: %+v", exp)
+	}
+	if !exp.RetryAfter.IsZero() {
+		t.Error("an expired backoff still reports a retry time")
+	}
+}
+
+// TestSetBackoffRecordsOutcomes verifies the seam that gives status real
+// history.
+//
+// SetBackoff is the single point both fetch loops already call: zero after a
+// provider returned a subtitle, non-zero after one failed. Recording there
+// means status reflects what actually happened without the fetch path having
+// to know status exists.
+func TestSetBackoffRecordsOutcomes(t *testing.T) {
+	useStatusState(t,
+		Instance{ID: "ok-1", Name: "ok", Enabled: true},
+		Instance{ID: "bad-1", Name: "bad", Enabled: true},
+	)
+
+	SetBackoff("bad-1", time.Minute) // a failure
+	SetBackoff("ok-1", 0)            // a success
+
+	got := List()
+	if got["ok-1"].LastSuccess.IsZero() {
+		t.Error("a successful fetch recorded no success")
+	}
+	if !got["ok-1"].LastFailure.IsZero() {
+		t.Error("a successful fetch recorded a failure")
+	}
+	if got["bad-1"].LastFailure.IsZero() {
+		t.Error("a failed fetch recorded no failure")
+	}
+	if !got["bad-1"].LastSuccess.IsZero() {
+		t.Error("a failed fetch recorded a success")
+	}
+}
+
+// TestResetThrottlingClearsBackoffOnly verifies the two reset endpoints do
+// different things: POST /api/providers/refresh clears throttles so providers
+// are retried now, and POST /api/providers/reset clears recorded history.
+// Conflating them would mean an operator cannot retry a throttled provider
+// without also erasing the record of why it was throttled.
+func TestResetThrottlingClearsBackoffOnly(t *testing.T) {
+	useStatusState(t, Instance{ID: "r-1", Name: "r", Enabled: true})
+
+	SetBackoff("r-1", time.Minute)
+	if !List()["r-1"].Throttled {
+		t.Fatal("precondition: provider should be throttled")
+	}
+
+	ResetThrottling()
+	after := List()["r-1"]
+	if after.Throttled {
+		t.Error("ResetThrottling left the provider throttled")
+	}
+	if after.LastFailure.IsZero() {
+		t.Error("ResetThrottling erased the failure history; that is Reset's job")
+	}
+
+	Reset()
+	if !List()["r-1"].LastFailure.IsZero() {
+		t.Error("Reset did not clear the recorded history")
+	}
+}

--- a/pkg/providers/status_test.go
+++ b/pkg/providers/status_test.go
@@ -1,11 +1,12 @@
 // file: pkg/providers/status_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: cb3753c6-7b0d-45cd-9137-9528ad6da276
 // last-edited: 2026-07-30
 
 package providers
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -95,11 +96,49 @@ func TestListNeverInventsAvailability(t *testing.T) {
 	useStatusState(t, Instance{ID: "stub-1", Name: "stub", Enabled: true})
 
 	s := List()["stub-1"]
-	if !s.LastSuccess.IsZero() {
+	if s.LastSuccess != nil {
 		t.Error("a provider that never ran reports a last success")
 	}
-	if !s.LastFailure.IsZero() {
+	if s.LastFailure != nil {
 		t.Error("a provider that never ran reports a last failure")
+	}
+}
+
+// TestStatusJSONOmitsUnsetTimes asserts on the serialised form, not the Go
+// struct.
+//
+// This is the bug the Go-level assertions could not see. The time fields were
+// plain time.Time with `omitempty`, but encoding/json does not apply omitempty
+// to structs — a zero time.Time serialises as "0001-01-01T00:00:00Z" rather
+// than being omitted. Every one of the 52 providers therefore shipped a
+// last_success, so the field meant to separate a working provider from a stub
+// was present on all of them and distinguished nothing. IsZero() in Go looked
+// fine throughout; only querying a running server showed it.
+func TestStatusJSONOmitsUnsetTimes(t *testing.T) {
+	useStatusState(t,
+		Instance{ID: "never-1", Name: "never", Enabled: true},
+		Instance{ID: "worked-1", Name: "worked", Enabled: true},
+	)
+	SetBackoff("worked-1", 0) // a success
+
+	raw, err := json.Marshal(List())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, present := got["never-1"]["last_success"]; present {
+		t.Errorf("a provider that never succeeded still carries last_success in "+
+			"JSON (%s); clients cannot tell it from one that works", raw)
+	}
+	if _, present := got["never-1"]["retry_after"]; present {
+		t.Error("an unthrottled provider carries retry_after in JSON")
+	}
+	if _, present := got["worked-1"]["last_success"]; !present {
+		t.Error("a provider that succeeded is missing last_success in JSON")
 	}
 }
 
@@ -126,7 +165,7 @@ func TestStatusTracksThrottling(t *testing.T) {
 	if thr.Available {
 		t.Error("a throttled provider is reported as available; a search would skip it")
 	}
-	if thr.RetryAfter.IsZero() {
+	if thr.RetryAfter == nil {
 		t.Error("a throttled provider reports no retry time")
 	}
 
@@ -134,7 +173,7 @@ func TestStatusTracksThrottling(t *testing.T) {
 	if exp.Throttled || !exp.Available {
 		t.Errorf("expired backoff still counted: %+v", exp)
 	}
-	if !exp.RetryAfter.IsZero() {
+	if exp.RetryAfter != nil {
 		t.Error("an expired backoff still reports a retry time")
 	}
 }
@@ -156,16 +195,16 @@ func TestSetBackoffRecordsOutcomes(t *testing.T) {
 	SetBackoff("ok-1", 0)            // a success
 
 	got := List()
-	if got["ok-1"].LastSuccess.IsZero() {
+	if got["ok-1"].LastSuccess == nil {
 		t.Error("a successful fetch recorded no success")
 	}
-	if !got["ok-1"].LastFailure.IsZero() {
+	if got["ok-1"].LastFailure != nil {
 		t.Error("a successful fetch recorded a failure")
 	}
-	if got["bad-1"].LastFailure.IsZero() {
+	if got["bad-1"].LastFailure == nil {
 		t.Error("a failed fetch recorded no failure")
 	}
-	if !got["bad-1"].LastSuccess.IsZero() {
+	if got["bad-1"].LastSuccess != nil {
 		t.Error("a failed fetch recorded a success")
 	}
 }
@@ -188,12 +227,12 @@ func TestResetThrottlingClearsBackoffOnly(t *testing.T) {
 	if after.Throttled {
 		t.Error("ResetThrottling left the provider throttled")
 	}
-	if after.LastFailure.IsZero() {
+	if after.LastFailure == nil {
 		t.Error("ResetThrottling erased the failure history; that is Reset's job")
 	}
 
 	Reset()
-	if !List()["r-1"].LastFailure.IsZero() {
+	if List()["r-1"].LastFailure != nil {
 		t.Error("Reset did not clear the recorded history")
 	}
 }

--- a/pkg/webserver/system.go
+++ b/pkg/webserver/system.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/system.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 37c23ec8-b8b9-4086-be5c-8058fee3fd54
+// last-edited: 2026-07-30
 
 package webserver
 
@@ -122,15 +123,23 @@ func providerStatusHandler() http.Handler {
 	})
 }
 
-// providerRefreshHandler refreshes status information for all providers.
+// providerRefreshHandler clears provider throttling so backed-off providers
+// are retried immediately.
+//
+// It used to call providers.Refresh with a hardcoded []string{"opensubtitles",
+// "subscene"}, which marked exactly those two names Available without checking
+// anything — so the endpoint reported a stub provider as healthy and omitted
+// every real one. Availability is now computed on read, leaving nothing to
+// refresh; clearing throttles is the useful action that remains, and matches
+// Bazarr's "reset provider throttling".
 func providerRefreshHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		providers.Refresh(r.Context(), []string{"opensubtitles", "subscene"})
+		providers.ResetThrottling()
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
 
-// providerResetHandler clears provider status data.
+// providerResetHandler clears the recorded provider success/failure history.
 func providerResetHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		providers.Reset()

--- a/pkg/webserver/system_test.go
+++ b/pkg/webserver/system_test.go
@@ -1,3 +1,8 @@
+// file: pkg/webserver/system_test.go
+// version: 1.1.0
+// guid: 8a41f7c2-3d95-4e60-b1a8-92f5c0d3e714
+// last-edited: 2026-07-30
+
 package webserver
 
 import (
@@ -8,6 +13,7 @@ import (
 
 	auth "github.com/jdfalk/subtitle-manager/pkg/gcommonauth"
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/testutil"
 )
 
@@ -355,5 +361,56 @@ func TestErrorDashboardEndpoints(t *testing.T) {
 			t.Fatalf("%s: %v %d", path, err, r.StatusCode)
 		}
 		r.Body.Close()
+	}
+}
+
+// TestProviderStatusReflectsConfiguredProviders asserts the *content* of the
+// status endpoint, not just that it returns 200.
+//
+// TestProviderEndpoints above checks status codes and is gated behind
+// skipIfNoSQLite, so it does not run in CI. The defect this guards against was
+// invisible to a status-code check anyway: the endpoint returned a cheerful
+// 200 with a body listing two hardcoded provider names as available, one of
+// them a non-functional stub, and omitting every provider actually configured.
+func TestProviderStatusReflectsConfiguredProviders(t *testing.T) {
+	// No instances are configured in this process, which is also the state of
+	// every real deployment: nothing in the server calls RegisterInstance. The
+	// endpoint must therefore report the registered provider names rather than
+	// an empty object.
+
+	rr := httptest.NewRecorder()
+	providerStatusHandler().ServeHTTP(rr,
+		httptest.NewRequest(http.MethodGet, "/api/providers/status", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var got map[string]providers.Status
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, rr.Body.String())
+	}
+
+	if len(got) == 0 {
+		t.Fatal("status is empty; the endpoint reports nothing on a default install")
+	}
+
+	// A real provider must be present...
+	real, ok := got["opensubtitles"]
+	if !ok {
+		t.Fatalf("opensubtitles missing from status: %d entries", len(got))
+	}
+	if real.Name != "opensubtitles" {
+		t.Errorf("got %+v, want the opensubtitles entry", real)
+	}
+
+	// ...and a provider that has never run must not claim to have succeeded.
+	// The old implementation marked its two hardcoded names Available without
+	// any check; LastSuccess is what actually distinguishes a working provider
+	// from a stub, and it must stay zero until something really worked.
+	for id, s := range got {
+		if !s.LastSuccess.IsZero() {
+			t.Errorf("%s reports a last success though nothing has run", id)
+		}
 	}
 }

--- a/pkg/webserver/system_test.go
+++ b/pkg/webserver/system_test.go
@@ -409,7 +409,7 @@ func TestProviderStatusReflectsConfiguredProviders(t *testing.T) {
 	// any check; LastSuccess is what actually distinguishes a working provider
 	// from a stub, and it must stay zero until something really worked.
 	for id, s := range got {
-		if !s.LastSuccess.IsZero() {
+		if s.LastSuccess != nil {
 			t.Errorf("%s reports a last success though nothing has run", id)
 		}
 	}


### PR DESCRIPTION
## The defect

`/api/providers/status` was backed by a cache that could only ever hold fiction:

```go
// Refresh simulates checking each provider and marks them as available.
func Refresh(ctx context.Context, names []string) {
	for _, n := range names {
		statusMap[n] = Status{Name: n, Available: true, CheckedAt: time.Now()}
	}
}
```

It checked nothing, and its one caller passed a hardcoded `[]string{"opensubtitles", "subscene"}`. Nothing scheduled it. So the endpoint returned `{}` until someone POSTed `/refresh`, and after that reported exactly two providers as healthy — one real, and **`subscene`, a non-functional stub that has never been capable of returning a subtitle**. Every genuinely working provider (`napiprojekt`, `gestdown`, `podnapisi`, `embedded`) was absent.

## The fix

Status is **computed on read** from state the process already holds, so there is nothing to refresh and nothing to schedule — both the "empty until refreshed" and "refresh is never scheduled" problems dissolve rather than getting patched:

| field | source |
|---|---|
| `enabled` | provider configuration |
| `available` | enabled **and** not currently throttled |
| `throttled` / `retry_after` | the existing backoff map |
| `last_success` / `last_failure` | fetches that actually happened |

`available` deliberately means *"would be consulted right now"*, **not** *"known to work"*. Conflating those is what made the old version useless. `last_success` is what separates a working provider from a stub — and it needs no hand-maintained list of "real" providers to do it, since a stub simply never succeeds. A second copy of that list in Go would rot the first time someone implemented a provider and forgot it.

Outcomes are recorded in **`SetBackoff`**, which both fetch loops already call with zero on success and non-zero on failure. That means real per-provider history with **zero changes to `multi.go`** — which #2214 rewrites, so these two PRs don't touch the same file.

## Both reset endpoints now do real, distinct things

- `POST /api/providers/refresh` → clears **throttling**, retrying backed-off providers immediately (Bazarr's "reset provider throttling"; what you want after fixing credentials)
- `POST /api/providers/reset` → clears recorded **history**

Conflating them would mean you can't retry a throttled provider without also erasing the record of why it was throttled. Response codes unchanged (`202`/`204`).

## ⚠️ What this surfaced — worth your attention

**Nothing in the running server calls `providers.RegisterInstance`.** The provider *instance* layer — multiple instances per provider, each with its own credentials, priority, tags and throttle state — is populated **only by tests**. On a real deployment `Instances()` is always empty, which means:

- searches always take the name-based fallback, so **per-instance priority, tags and backoff never apply in production**; and
- a status implementation keyed purely on instances would have returned `{}` on every real install.

`List` therefore falls back to reporting registered provider names — what a search on that deployment actually consults. That keeps this PR honest, but it's a workaround. Wiring provider instances to configuration is its own piece of work, and it also explains why per-provider configuration in the UI cannot currently take effect. Added to the parity matrix as 🔴 rather than fixed quietly here.

Also worth knowing: **no frontend component consumes any of these endpoints.** `api.js` defines `getStatus`/`refresh`/`reset`; nothing calls them. This PR makes the API honest; surfacing it in the UI is separate.

## Verification

Full suite green under `-race`. Every guard checked for non-vacuity by breaking the fix:

| Break | Result |
|---|---|
| restore unconditional `available: true` | ✅ fails — disabled *and* throttled providers reported available |
| drop outcome recording from `SetBackoff` | ✅ fails — no success/failure recorded |
| make `refresh` also clear history | ✅ fails — "erased the failure history; that is Reset's job" |
| return `{}` when no instances (pre-fix reality) | ✅ fails — "reports nothing on a default install" |

The endpoint-level test asserts **content**, not just a `200`. The existing `TestProviderEndpoints` only checks status codes and is gated behind `skipIfNoSQLite`, so it doesn't run in CI — and a status-code check could never have caught this anyway: the broken endpoint returned a cheerful `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH