### PR TITLE
feat(providers): load provider instances from configuration

### DIFF
--- a/changelog.d/feat-provider-instance-config.md
+++ b/changelog.d/feat-provider-instance-config.md
@@ -1,0 +1,77 @@
+<!-- file: changelog.d/feat-provider-instance-config.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5e8b41d0-9c26-4a73-b0f5-3a17e2d6c845 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### Provider settings were saved but never applied
+
+`POST /api/providers` wrote `providers.<name>.enabled` into the config file and
+persisted it, and **nothing ever read it back**. The provider *instance*
+registry — which carries per-provider enablement, priority, tags and throttle
+state — had no production caller at all: outside tests, nothing called
+`RegisterInstance`, so `Instances()` was empty on every install. Every search
+fell through to the flat list of registered provider names, and enabling or
+disabling a provider in the UI had no effect on anything.
+
+Configuration is now loaded into the registry when the server starts, and
+re-loaded when provider settings are saved, so a change takes effect
+immediately rather than at the next restart.
+
+> This is the third instance of the same bug shape in this repository: settings
+> that save successfully and are read by nobody. The others were notification
+> keys written under a namespace the runtime did not read, and API routes that
+> returned `200` from the SPA catch-all having done nothing. A save that
+> silently does nothing is worse than an error, because it reports success.
+
+### ⚠️ Behaviour change to be aware of
+
+**If you have explicitly enabled any provider in your config file, search will
+now use only the providers you enabled.** Previously that setting was inert and
+every registered provider was tried. This is the intended meaning of the
+setting, and it matches Bazarr, but it is a real change for an existing config:
+a file that enables only `opensubtitles` now searches only `opensubtitles`.
+
+If you have **not** configured providers, nothing changes — see below.
+
+### The safety property
+
+On an install with no provider configuration, loading registers **zero**
+instances, leaving searches on the existing fallback across every registered
+provider. This is enforced by a test, because the failure would be silent:
+registering even one instance flips the search path from "every provider" to
+"only the configured ones", and subtitles would simply stop being found with no
+error anywhere.
+
+The trap is specific. `cmd/root.go` sets a default of
+`providers.embedded.enabled = true`, so on a bare install both `viper.GetBool`
+and `viper.IsSet` report `true` for `embedded` while the operator has configured
+nothing. A loader keyed on either would register exactly one instance and
+collapse search to embedded-only. Enablement is therefore read with
+`viper.InConfig`, which reports whether the key came from the config file — the
+question actually being asked. That behaviour was verified empirically against
+the pinned viper (v1.21.0) rather than assumed.
+
+### Decisions worth reviewing later
+
+- **Search order is deterministic.** Priority is optional in config, so equal
+  priorities are the common case; instances live in a map, whose iteration order
+  Go randomises per process, and `sort.Slice` is not stable. Ties are broken by
+  provider name, so the order is reproducible across restarts instead of
+  differing each time. Set `providers.<name>.priority` to override.
+- **Reloading replaces the registry rather than merging into it.**
+  `RegisterInstance` only adds or updates, so a provider you disabled would
+  otherwise linger and keep being searched. A new `SetInstances` swaps the whole
+  map.
+- **One instance per provider.** Config is keyed by provider name, so it can
+  express exactly one instance of each. Several instances of one provider with
+  distinct credentials — what the instance layer was originally built for —
+  needs a config schema that does not exist yet (a list, presumably). That is a
+  schema decision to make deliberately, not to invent here.
+- **The fetch path was not touched.** An attractive alternative was to have
+  searches try configured instances first and then fall back to the remaining
+  provider names, which would preserve reach while honouring priority. That
+  needs changes in `pkg/providers/multi.go`, which is rewritten by the parallel
+  fetch change, so it was left out to keep the two independent. Worth revisiting
+  once both have landed: it would remove the behaviour change flagged above.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -121,7 +121,7 @@ effort — it is not fully achievable autonomously.
 | Plex incoming webhook | ✅ | `POST /api/webhooks/plex` (`library.new`) |
 | External-Whisper URL/model/timeout config | ✅ | `whisper.transcribe_url` (native /asr), model, timeout |
 | Provider status / throttle view | ✅ | `/api/providers/status` computed on read (enabled/throttled/last success); no UI consumer yet |
-| Per-provider instance config (priority, tags, credentials) | 🔴 | `RegisterInstance` has **no production caller** — the instance layer is unreachable; searches always use the name fallback |
+| Per-provider enable/priority/tags from config | ✅ | `providers.LoadFromConfig` at server start + on settings save; no-op when unconfigured |
 
 ## Implementation plan (backend)
 

--- a/pkg/providers/config.go
+++ b/pkg/providers/config.go
@@ -1,0 +1,98 @@
+// file: pkg/providers/config.go
+// version: 1.0.0
+// guid: 1c179991-4713-46c7-8b56-052eea65030f
+// last-edited: 2026-07-30
+
+package providers
+
+import (
+	"sort"
+
+	"github.com/spf13/viper"
+)
+
+// LoadFromConfig populates the provider instance registry from configuration.
+//
+// # Why this exists
+//
+// The instance layer — per-provider enablement, priority, tags and throttle
+// state — had no production caller at all: nothing outside tests ever called
+// RegisterInstance, so Instances() was always empty on a real install. Every
+// search therefore fell through to the flat list of registered provider names,
+// and the provider settings the UI writes (POST /api/providers persists
+// providers.<name>.enabled into the config file) were read by nothing.
+//
+// # The safety property that governs the whole design
+//
+// On an install with no provider configuration, this MUST register zero
+// instances. Registering even one flips FetchFromAll out of its name-based
+// fallback and into "only the configured instances", silently cutting search
+// from every registered provider down to that one. There is a test asserting
+// exactly this, because the failure is invisible until subtitles stop being
+// found.
+//
+// That is why enablement is read with viper.InConfig rather than IsSet or
+// GetBool. cmd/root.go sets viper.SetDefault("providers.embedded.enabled",
+// true), so on a bare install GetBool and IsSet both report true for embedded
+// while nothing is configured — a loader keyed on those would register exactly
+// one instance and collapse search to embedded-only. InConfig reports whether
+// the key came from the config file itself, which is the question actually
+// being asked: "did the operator choose this?"
+//
+// # What it deliberately does not do
+//
+// Configuration is keyed by provider name (providers.<name>), so it can express
+// exactly one instance per provider. Several instances of the same provider
+// with distinct credentials — the thing the instance layer was built for —
+// needs a config schema that does not exist yet (a list, presumably). That is a
+// design decision for the operator, not one to invent here.
+func LoadFromConfig() {
+	type candidate struct {
+		name     string
+		priority int
+	}
+	var chosen []candidate
+
+	for _, name := range All() {
+		key := "providers." + name
+		// Only an explicit entry in the config file counts. See above.
+		if !viper.InConfig(key+".enabled") || !viper.GetBool(key+".enabled") {
+			continue
+		}
+		chosen = append(chosen, candidate{
+			name: name,
+			// Absent priority is 0; ties are broken by name in Instances(),
+			// so search order stays stable across restarts.
+			priority: viper.GetInt(key + ".priority"),
+		})
+	}
+
+	if len(chosen) == 0 {
+		// Nothing configured: leave the registry empty so searches keep using
+		// every registered provider. This is the default-install path.
+		SetInstances(nil)
+		return
+	}
+
+	sort.Slice(chosen, func(i, j int) bool {
+		if chosen[i].priority != chosen[j].priority {
+			return chosen[i].priority > chosen[j].priority
+		}
+		return chosen[i].name < chosen[j].name
+	})
+
+	insts := make([]Instance, 0, len(chosen))
+	for _, c := range chosen {
+		insts = append(insts, Instance{
+			// One instance per provider is what the config shape supports, so
+			// the provider name is a stable, meaningful instance ID. It also
+			// keeps backoff and status keys readable.
+			ID:       c.name,
+			Name:     c.name,
+			Enabled:  true,
+			Priority: c.priority,
+			Tags:     viper.GetStringSlice("providers." + c.name + ".tags"),
+		})
+	}
+	SetInstances(insts)
+}

--- a/pkg/providers/config_test.go
+++ b/pkg/providers/config_test.go
@@ -1,0 +1,249 @@
+// file: pkg/providers/config_test.go
+// version: 1.0.0
+// guid: 1739868a-7ed1-45e2-897c-ecc92a00e135
+// last-edited: 2026-07-30
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// useConfigFile points viper at a config file written from body, applying the
+// same defaults cmd/root.go sets, and restores global state afterwards.
+//
+// The defaults matter: they are what makes the "no configuration" case
+// dangerous, so a test that omits them is testing a situation that never
+// occurs in production.
+func useConfigFile(t *testing.T, body string) {
+	t.Helper()
+
+	instancesMu.Lock()
+	prevInsts := instances
+	instancesMu.Unlock()
+	t.Cleanup(func() {
+		instancesMu.Lock()
+		instances = prevInsts
+		instancesMu.Unlock()
+	})
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// Mirrors cmd/root.go.
+	viper.SetDefault("providers.embedded.enabled", true)
+	viper.SetDefault("providers.generic.api_url", "")
+	viper.SetDefault("providers.whisper.api_url", "http://localhost:9000")
+
+	if body != "" {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		viper.SetConfigFile(path)
+		if err := viper.ReadInConfig(); err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+	}
+}
+
+// TestLoadFromConfigRegistersNothingByDefault is the most important test in
+// this package.
+//
+// If loading produces even one instance on an unconfigured install,
+// FetchFromAll stops using its name-based fallback over every registered
+// provider and consults only that instance — search silently collapses from
+// ~55 providers to one, and nothing reports an error. Subtitles just stop
+// being found.
+//
+// The trap is concrete: cmd/root.go sets a default of
+// providers.embedded.enabled = true, so on a bare install both
+// viper.GetBool and viper.IsSet report true for embedded while the operator
+// has configured nothing at all. A loader keyed on either would register
+// embedded and collapse search to embedded-only. Enablement is therefore read
+// with viper.InConfig, which asks whether the key came from the config file.
+func TestLoadFromConfigRegistersNothingByDefault(t *testing.T) {
+	useConfigFile(t, "") // no config file at all: defaults only
+
+	// Precondition: the trap is real, not hypothetical.
+	if !viper.GetBool("providers.embedded.enabled") {
+		t.Fatal("precondition: the embedded default should read as true")
+	}
+	if !viper.IsSet("providers.embedded.enabled") {
+		t.Fatal("precondition: IsSet should also be fooled by the default")
+	}
+
+	LoadFromConfig()
+
+	if got := Instances(); len(got) != 0 {
+		t.Fatalf("loaded %d instances from an unconfigured install: %v\n"+
+			"search would be restricted to these instead of using every "+
+			"registered provider", len(got), got)
+	}
+}
+
+// TestLoadFromConfigHonoursExplicitConfig verifies an operator's explicit
+// choices are applied: only enabled providers become instances.
+func TestLoadFromConfigHonoursExplicitConfig(t *testing.T) {
+	useConfigFile(t, `
+providers:
+  opensubtitles:
+    enabled: true
+  podnapisi:
+    enabled: true
+  subscene:
+    enabled: false
+`)
+	LoadFromConfig()
+
+	got := Instances()
+	if len(got) != 2 {
+		t.Fatalf("got %d instances, want 2: %v", len(got), got)
+	}
+	names := map[string]bool{}
+	for _, i := range got {
+		names[i.Name] = true
+	}
+	if !names["opensubtitles"] || !names["podnapisi"] {
+		t.Errorf("enabled providers missing: %v", got)
+	}
+	if names["subscene"] {
+		t.Error("an explicitly disabled provider was registered")
+	}
+	// The default-only provider must not sneak in alongside real config.
+	if names["embedded"] {
+		t.Error("embedded registered from its default while it was never configured")
+	}
+}
+
+// TestLoadFromConfigOrderIsDeterministic guards against search order changing
+// between restarts.
+//
+// Configuration does not require a priority, so equal priorities are the
+// common case. Instances are held in a map, whose iteration order Go
+// randomises per process, and sort.Slice is not stable — without a tiebreak
+// the provider consulted first would differ on every restart, which is both
+// unreproducible for the operator and untestable.
+func TestLoadFromConfigOrderIsDeterministic(t *testing.T) {
+	cfg := `
+providers:
+  opensubtitles:
+    enabled: true
+  podnapisi:
+    enabled: true
+  napiprojekt:
+    enabled: true
+  gestdown:
+    enabled: true
+`
+	var first []string
+	for run := 0; run < 8; run++ {
+		useConfigFile(t, cfg)
+		LoadFromConfig()
+
+		var order []string
+		for _, i := range Instances() {
+			order = append(order, i.Name)
+		}
+		if run == 0 {
+			first = order
+			continue
+		}
+		for k := range order {
+			if order[k] != first[k] {
+				t.Fatalf("run %d ordered providers %v, first run had %v: "+
+					"search order is not reproducible across restarts", run, order, first)
+			}
+		}
+	}
+	// With no priorities set, the tiebreak is by ID, i.e. alphabetical.
+	want := []string{"gestdown", "napiprojekt", "opensubtitles", "podnapisi"}
+	for k := range want {
+		if first[k] != want[k] {
+			t.Fatalf("order = %v, want %v (ties broken by name)", first, want)
+		}
+	}
+}
+
+// TestLoadFromConfigAppliesPriority verifies configured priority wins over the
+// name tiebreak.
+func TestLoadFromConfigAppliesPriority(t *testing.T) {
+	useConfigFile(t, `
+providers:
+  zimuku:
+    enabled: true
+    priority: 100
+  gestdown:
+    enabled: true
+    priority: 1
+`)
+	LoadFromConfig()
+
+	got := Instances()
+	if len(got) != 2 {
+		t.Fatalf("got %d instances, want 2", len(got))
+	}
+	// Alphabetically gestdown sorts first; priority must override that.
+	if got[0].Name != "zimuku" {
+		t.Errorf("first provider = %q, want zimuku: configured priority is not applied", got[0].Name)
+	}
+}
+
+// TestLoadFromConfigReplacesRatherThanMerges verifies a provider removed from
+// configuration stops being consulted.
+//
+// RegisterInstance only adds or updates, so a loader built on it would leave a
+// disabled provider in the registry forever — it would keep being searched
+// after the operator turned it off, with the settings page showing it as
+// disabled.
+func TestLoadFromConfigReplacesRatherThanMerges(t *testing.T) {
+	useConfigFile(t, `
+providers:
+  opensubtitles:
+    enabled: true
+  podnapisi:
+    enabled: true
+`)
+	LoadFromConfig()
+	if len(Instances()) != 2 {
+		t.Fatalf("precondition: want 2 instances, got %d", len(Instances()))
+	}
+
+	// The operator turns podnapisi off and reloads.
+	useConfigFile(t, `
+providers:
+  opensubtitles:
+    enabled: true
+  podnapisi:
+    enabled: false
+`)
+	LoadFromConfig()
+
+	got := Instances()
+	if len(got) != 1 || got[0].Name != "opensubtitles" {
+		t.Fatalf("after disabling podnapisi, instances = %v; a removed provider "+
+			"is still registered and would still be searched", got)
+	}
+}
+
+// TestLoadFromConfigEmptiesRegistryWhenConfigCleared verifies going from
+// "some providers configured" back to none restores the fallback rather than
+// leaving a stale registry that restricts search.
+func TestLoadFromConfigEmptiesRegistryWhenConfigCleared(t *testing.T) {
+	useConfigFile(t, "providers:\n  opensubtitles:\n    enabled: true\n")
+	LoadFromConfig()
+	if len(Instances()) != 1 {
+		t.Fatalf("precondition: want 1 instance, got %d", len(Instances()))
+	}
+
+	useConfigFile(t, "")
+	LoadFromConfig()
+	if got := Instances(); len(got) != 0 {
+		t.Fatalf("clearing provider config left %v registered; search would stay "+
+			"restricted instead of returning to every provider", got)
+	}
+}

--- a/pkg/providers/instance.go
+++ b/pkg/providers/instance.go
@@ -64,6 +64,38 @@ func RegisterInstance(inst Instance) {
 	instances[inst.ID] = inst
 }
 
+// SetInstances replaces the entire instance registry.
+//
+// Reloading configuration needs replacement, not merging: RegisterInstance
+// only ever adds or updates, so a provider the operator has just disabled (or
+// deleted) in the config file would linger in the registry forever and keep
+// being consulted by searches. Passing nil empties the registry.
+func SetInstances(insts []Instance) {
+	instancesMu.Lock()
+	defer instancesMu.Unlock()
+	instances = make(map[string]Instance, len(insts))
+	for _, inst := range insts {
+		instances[inst.ID] = inst
+	}
+}
+
+// byPriority orders instances highest priority first, breaking ties by ID.
+//
+// The tiebreak is load-bearing, not cosmetic. sort.Slice is not stable and the
+// input comes from a map, whose iteration order Go randomises per process, so
+// equal-priority providers would be consulted in a different order on every
+// restart. Configuration does not require a priority — LoadFromConfig leaves it
+// at zero when unset — so equal priorities are the common case, not an edge
+// one.
+func byPriority(out []Instance) {
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].ID < out[j].ID
+	})
+}
+
 // Instances returns all registered provider instances ordered by priority.
 func Instances() []Instance {
 	instancesMu.RLock()
@@ -74,7 +106,7 @@ func Instances() []Instance {
 			out = append(out, inst)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Priority > out[j].Priority })
+	byPriority(out)
 	return out
 }
 
@@ -86,7 +118,7 @@ func ListInstances() []Instance {
 	for _, inst := range instances {
 		out = append(out, inst)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Priority > out[j].Priority })
+	byPriority(out)
 	return out
 }
 
@@ -150,6 +182,6 @@ func InstancesByTags(tm interface {
 			out = append(out, inst)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Priority > out[j].Priority })
+	byPriority(out)
 	return out, nil
 }

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/server.go
 // version: 1.5.0
 // guid: a3f02a01-bcb0-4d6e-a572-8138f7a6d720
-// last-edited: 2026-07-26
+// last-edited: 2026-07-30
 
 package webserver
 
@@ -31,6 +31,7 @@ import (
 	"github.com/jdfalk/subtitle-manager/pkg/maintenance"
 	"github.com/jdfalk/subtitle-manager/pkg/metrics"
 	"github.com/jdfalk/subtitle-manager/pkg/notifications"
+	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/radarr"
 	"github.com/jdfalk/subtitle-manager/pkg/security"
 	"github.com/jdfalk/subtitle-manager/pkg/selftest"
@@ -138,6 +139,11 @@ func setupHandler(db *sql.DB) http.Handler {
 
 // Handler returns an http.Handler that serves the embedded web UI.
 func Handler(db *sql.DB) (http.Handler, error) {
+	// Populate the provider instance registry from configuration before any
+	// request can be served. Without this the registry stays empty and every
+	// search ignores the operator's provider settings entirely.
+	providers.LoadFromConfig()
+
 	mux, _, err := newMux(db)
 	if err != nil {
 		return nil, err
@@ -1001,9 +1007,9 @@ func providersHandler() http.Handler {
 		switch r.Method {
 		case http.MethodGet:
 			// Get list of all available providers from the registry
-			providers := getAvailableProviders()
+			available := getAvailableProviders()
 			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(providers); err != nil {
+			if err := json.NewEncoder(w).Encode(available); err != nil {
 				http.Error(w, "Failed to encode providers", http.StatusInternalServerError)
 				return
 			}
@@ -1034,6 +1040,15 @@ func providersHandler() http.Handler {
 					return
 				}
 			}
+
+			// Re-read the registry so the change takes effect now rather than
+			// at the next restart. Saving settings that the running process
+			// never picks up is the failure mode this repo has already had
+			// twice (notification keys written under a namespace nothing read;
+			// routes that returned 200 from the SPA catch-all having done
+			// nothing) — a save that silently does nothing is worse than an
+			// error, because it reports success.
+			providers.LoadFromConfig()
 
 			w.WriteHeader(http.StatusNoContent)
 		default:


### PR DESCRIPTION
## The bug

`POST /api/providers` writes `providers.<name>.enabled` into the config file and persists it. **Nothing ever read it back.**

The provider *instance* registry — per-provider enablement, priority, tags, throttle state — had **no production caller**. Outside tests, nothing called `RegisterInstance`, so `Instances()` was empty on every install, every search fell through to the flat list of registered provider names, and enabling or disabling a provider in the UI did nothing at all.

> Third instance of this bug shape in this repo: settings that save successfully and are read by nobody. The others were notification keys written under a namespace the runtime didn't read (#2212), and API routes returning `200` from the SPA catch-all having done nothing (#2211). A save that silently does nothing is worse than an error — it reports success.

Config is now loaded at server start and re-loaded when provider settings are saved, so changes apply immediately rather than at next restart.

## ⚠️ Behaviour change — please read

**If your config file explicitly enables any provider, search will now use only those providers.** Previously the setting was inert and every registered provider was tried. This is what the setting is supposed to mean, and it matches Bazarr — but it's a real change for an existing config: a file enabling only `opensubtitles` now searches only `opensubtitles`.

If you haven't configured providers, nothing changes.

## The safety property this is built around

On an install with no provider config, loading registers **zero** instances, leaving search on the existing fallback across every provider. This is the one failure that would be invisible: registering even one instance flips the search path from "every provider" to "only configured ones", and subtitles just stop being found — no error, anywhere.

The trap is concrete. `cmd/root.go:271` sets `providers.embedded.enabled = true` as a **default**, so on a bare install both `viper.GetBool` and `viper.IsSet` report `true` for embedded while nothing is configured. A loader keyed on either registers exactly one instance and collapses search to embedded-only.

Enablement is therefore read with `viper.InConfig`, which asks whether the key came from the config *file*. I verified that empirically against the pinned viper (**v1.21.0**) rather than assuming it — nested-key behaviour has varied across versions:

```
InConfig(providers.embedded.enabled)      = false   <- default only
InConfig(providers.opensubtitles.enabled) = true    <- from the file
GetBool(providers.embedded.enabled)       = true    <- the trap
```

## Decisions worth reviewing

- **Search order is now deterministic.** Priority is optional, so equal priorities are the *common* case; instances live in a map (randomised iteration) and `sort.Slice` isn't stable — order would differ on every restart. Ties break by provider name. Set `providers.<name>.priority` to override.
- **Reload replaces the registry, not merges.** `RegisterInstance` only adds-or-updates, so a provider you disabled would linger and keep being searched. Added `SetInstances`.
- **One instance per provider.** Config is keyed by name, so it expresses exactly one. Multiple instances with distinct credentials — the instance layer's original purpose — needs a config schema that doesn't exist yet. That's a schema decision for you, not one to invent here.
- **`multi.go` untouched.** The attractive alternative was to try configured instances first and then fall back to remaining names — preserving reach *and* honouring priority, which would remove the behaviour change above. That needs `multi.go`, which #2214 rewrites, so I kept them independent. Worth revisiting once both land.

## Verification

Full suite green under `-race`. Each guard broken to confirm it catches the real failure:

| Break | Result |
|---|---|
| use `IsSet` instead of `InConfig` | ✅ fails — `loaded 1 instances from an unconfigured install: [{embedded ...}]` |
| remove the name tiebreak | ✅ fails — run 1 ordered `[opensubtitles podnapisi gestdown napiprojekt]`, run 0 `[gestdown napiprojekt opensubtitles podnapisi]` |
| merge instead of replace | ✅ fails — disabled provider still registered and would still be searched |

The determinism test loops 8 times because a single run of an unstable sort will often look fine.

## Relationship to the other open PRs

Touches `pkg/providers/{config,instance}.go` and `pkg/webserver/server.go`. **No conflict** with #2214 (`multi.go`) or #2215 (`status.go`) — though all three are in `pkg/providers`, so merge order matters for the trivial header/context lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH