### PR TITLE
fix(webserver): parse API paths relative to base_url

### DIFF
--- a/changelog.d/fix-base-url-path-parsing.md
+++ b/changelog.d/fix-base-url-path-parsing.md
@@ -1,0 +1,45 @@
+<!-- file: changelog.d/fix-base-url-path-parsing.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c4a2f61-38d9-4b05-9e72-6f0b1a83d5e4 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### Seven API endpoints were dead when running under a `base_url`
+
+Routes are mounted at `prefix + "/api/..."`, where `prefix` comes from
+`base_url`. Seven handlers that pull an ID out of the request path were written
+as if that prefix were always empty:
+
+```go
+strings.TrimPrefix(r.URL.Path, "/api/media/profile/")
+```
+
+Behind a base URL the incoming path is `/sm/api/media/profile/42`, which that
+literal does not match. `TrimPrefix` returns the path unchanged, the following
+`Split` yields `""` as the first segment, and the handler carries on with an
+empty ID — straight into a database lookup rather than a rejection. These
+endpoints were not degraded behind a subpath, they were **dead**:
+
+- media profile assignment (get / assign / remove)
+- profile lookup by ID
+- user management by ID
+- tag lookup, tag-to-user assignment, tag-to-media assignment
+
+Path parsing now goes through `apiPath` / `pathSegment` / `pathSegments`, which
+strip the configured prefix first. The prefix is only stripped on a whole path
+segment, so a `base_url` of `/sm` does not mangle a request to `/small/...`.
+
+The helpers also return nothing rather than an empty first element when the
+path does not match the expected route, so "this is not the path I expected" is
+a case the handler must handle instead of an empty ID silently flowing into a
+lookup.
+
+#### Why nothing caught it
+
+Every test constructs requests with an empty `base_url`, where the literal
+prefix happens to match — so a handler with this defect passes its tests and
+fails only on a real deployment behind a subpath. That is why this change also
+adds a source-level guard (`TestNoRawAPIPathParsing`) that fails the build for
+any handler parsing `r.URL.Path` against an `/api` literal. Seven had already
+drifted into the pattern; catching the eighth by eye is not a plan.

--- a/pkg/webserver/basepath.go
+++ b/pkg/webserver/basepath.go
@@ -1,0 +1,99 @@
+// file: pkg/webserver/basepath.go
+// version: 1.0.0
+// guid: eb46ab64-f28e-4adb-9677-ac932a044fdd
+// last-edited: 2026-07-30
+
+package webserver
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// basePrefix returns the configured base-URL prefix, normalised the same way
+// newMux normalises it when mounting routes: either empty, or a leading slash
+// with no trailing one.
+//
+// It is derived from configuration on each call rather than captured at mount
+// time because the handlers that need it are constructed without access to the
+// mux. base_url is not reloadable at runtime, so re-reading it is a lookup, not
+// a correctness risk.
+func basePrefix() string {
+	prefix := strings.Trim(viper.GetString("base_url"), "/")
+	if prefix == "" {
+		return ""
+	}
+	return "/" + prefix
+}
+
+// apiPath returns the request path with the base-URL prefix removed, so a
+// handler can match against the literal route it was mounted for.
+//
+// # Why this exists
+//
+// Routes are mounted at prefix+"/api/...", where prefix comes from base_url.
+// Handlers that pull an ID out of the path were written as if the prefix were
+// always empty:
+//
+//	strings.TrimPrefix(r.URL.Path, "/api/media/profile/")
+//
+// Behind a base URL the incoming path is "/sm/api/media/profile/42", which
+// that literal does not match. TrimPrefix returns the string unchanged, the
+// subsequent Split yields "" as the first segment, and the handler proceeds
+// with an empty ID — so it answers "not found" or "bad request" for every
+// request. The feature is not degraded behind a subpath, it is dead.
+//
+// Nothing caught this because every test constructs requests with an empty
+// prefix, where the literal happens to match. Seven handlers had the same
+// defect: media profiles, profile lookup, users, tags, tag-to-user and
+// tag-to-media assignment.
+func apiPath(r *http.Request) string {
+	p := r.URL.Path
+	prefix := basePrefix()
+	if prefix == "" {
+		return p
+	}
+	// Only strip a prefix that is a whole path segment: "/sm" must match
+	// "/sm/api/..." but not "/small/api/...".
+	if p == prefix {
+		return "/"
+	}
+	if strings.HasPrefix(p, prefix+"/") {
+		return strings.TrimPrefix(p, prefix)
+	}
+	return p
+}
+
+// pathSegments returns the path segments following route, with the base-URL
+// prefix already removed. It returns nil when the request path does not lie
+// under route.
+//
+// Handlers used to inline strings.Split(strings.TrimPrefix(r.URL.Path, ...)),
+// which silently produced a slice whose first element was "" whenever the
+// literal did not match — an empty ID that then flowed into a database lookup
+// instead of being rejected. Returning nil makes "this path is not what I
+// expected" a case the handler has to handle, rather than something it
+// discovers as a mysterious miss further down.
+func pathSegments(r *http.Request, route string) []string {
+	p := apiPath(r)
+	if !strings.HasPrefix(p, route) {
+		return nil
+	}
+	rest := strings.Trim(strings.TrimPrefix(p, route), "/")
+	if rest == "" {
+		return nil
+	}
+	return strings.Split(rest, "/")
+}
+
+// pathSegment returns the first path segment following route, or "" when the
+// path does not lie under route or carries no further segment.
+func pathSegment(r *http.Request, route string) string {
+	segs := pathSegments(r, route)
+	if len(segs) == 0 {
+		return ""
+	}
+	return segs[0]
+}

--- a/pkg/webserver/basepath_test.go
+++ b/pkg/webserver/basepath_test.go
@@ -1,0 +1,161 @@
+// file: pkg/webserver/basepath_test.go
+// version: 1.0.0
+// guid: d58f16de-9d4f-4e6b-8a95-8a3d53f5dbcd
+// last-edited: 2026-07-30
+
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// useBaseURL sets base_url for one test and restores it afterwards.
+func useBaseURL(t *testing.T, v string) {
+	t.Helper()
+	prev := viper.Get("base_url")
+	viper.Set("base_url", v)
+	t.Cleanup(func() { viper.Set("base_url", prev) })
+}
+
+// TestAPIPath covers prefix stripping, including the boundary cases that make
+// a naive strings.TrimPrefix wrong.
+func TestAPIPath(t *testing.T) {
+	for name, tc := range map[string]struct {
+		base, path, want string
+	}{
+		"no base url is a passthrough": {
+			"", "/api/media/profile/42", "/api/media/profile/42"},
+		"base url is stripped": {
+			"/sm", "/sm/api/media/profile/42", "/api/media/profile/42"},
+		"base url without slashes is normalised": {
+			"sm", "/sm/api/tags/7", "/api/tags/7"},
+		"trailing slash on the config value is tolerated": {
+			"/sm/", "/sm/api/users/3", "/api/users/3"},
+		// Only whole segments may match: "/sm" must not strip "/small".
+		"a longer sibling segment is not stripped": {
+			"/sm", "/small/api/tags/7", "/small/api/tags/7"},
+		"bare prefix becomes root": {
+			"/sm", "/sm", "/"},
+		"unrelated path is untouched": {
+			"/sm", "/api/tags/7", "/api/tags/7"},
+		"nested base url": {
+			"/a/b", "/a/b/api/tags/7", "/api/tags/7"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			useBaseURL(t, tc.base)
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if got := apiPath(r); got != tc.want {
+				t.Errorf("apiPath(%q) with base_url %q = %q, want %q",
+					tc.path, tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPathSegment covers ID extraction, which is where the base_url defect
+// actually bit.
+func TestPathSegment(t *testing.T) {
+	for name, tc := range map[string]struct {
+		base, path, route, want string
+	}{
+		"no base url": {
+			"", "/api/media/profile/42", "/api/media/profile/", "42"},
+		"under a base url": {
+			"/sm", "/sm/api/media/profile/42", "/api/media/profile/", "42"},
+		"extra segments are ignored": {
+			"/sm", "/sm/api/media/profile/42/extra", "/api/media/profile/", "42"},
+		"trailing slash means no id": {
+			"/sm", "/sm/api/media/profile/", "/api/media/profile/", ""},
+		"missing id": {
+			"", "/api/media/profile/", "/api/media/profile/", ""},
+		"path outside the route": {
+			"/sm", "/sm/api/other/42", "/api/media/profile/", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			useBaseURL(t, tc.base)
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if got := pathSegment(r, tc.route); got != tc.want {
+				t.Errorf("pathSegment(%q) with base_url %q = %q, want %q",
+					tc.path, tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMediaProfileRejectsMissingIDUnderBaseURL is the end-to-end guard.
+//
+// It asserts the *rejection* path rather than the success path, because that
+// is what can be observed without a database — and it is a genuine
+// discriminator. The old code did
+// strings.TrimPrefix(r.URL.Path, "/api/media/profile/") and checked the result
+// for emptiness. Behind a base URL the path is "/sm/api/media/profile/", the
+// literal does not match, TrimPrefix returns the whole path, the emptiness
+// check passes, and the handler proceeds into a database lookup with an ID of
+// "" instead of rejecting the request.
+//
+// So under base_url the broken version does NOT return 400 here, and the fixed
+// one does. Verified by reverting the fix and watching this fail.
+func TestMediaProfileRejectsMissingIDUnderBaseURL(t *testing.T) {
+	useBaseURL(t, "/sm")
+
+	rr := httptest.NewRecorder()
+	mediaProfilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodGet, "/sm/api/media/profile/", nil))
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("got %d for a path carrying no media ID, want 400: the path was "+
+			"not parsed relative to base_url, so an empty ID reached the lookup "+
+			"(body %q)", rr.Code, strings.TrimSpace(rr.Body.String()))
+	}
+}
+
+// TestNoRawAPIPathParsing is a source-level guard against this defect
+// reappearing.
+//
+// The bug is invisible in review and in tests: every test builds requests with
+// an empty base_url, where the literal prefix happens to match, so a handler
+// that strips r.URL.Path directly looks correct everywhere except on a real
+// deployment behind a subpath. Seven handlers had drifted into it. Rather than
+// rely on catching the eighth by eye, this fails the build for any new one.
+//
+// If a handler genuinely needs the raw path, it should say so explicitly
+// rather than reaching for r.URL.Path with an /api literal.
+func TestNoRawAPIPathParsing(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	// Matches TrimPrefix/HasPrefix/Split against r.URL.Path with an "/api"
+	// literal — the shape that ignores base_url.
+	bad := regexp.MustCompile(`(TrimPrefix|HasPrefix|TrimSuffix)\(\s*r\.URL\.Path\s*,\s*"/api`)
+
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") || f == "basepath.go" {
+			continue // basepath.go documents the anti-pattern in a comment
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			if bad.MatchString(line) {
+				t.Errorf("%s:%d parses r.URL.Path against an /api literal, which "+
+					"ignores base_url and makes the route dead behind a subpath. "+
+					"Use apiPath/pathSegment/pathSegments instead:\n\t%s",
+					f, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/profiles.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
-// last-edited: 2026-07-25
+// last-edited: 2026-07-30
 
 package webserver
 
@@ -29,7 +29,7 @@ import (
 func profilesHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse URL path: /api/profiles or /api/profiles/{id} or /api/profiles/{id}/default
-		path := strings.TrimPrefix(r.URL.Path, "/api/profiles")
+		path := strings.TrimPrefix(apiPath(r), "/api/profiles")
 
 		if path == "" || path == "/" {
 			// Handle collection operations
@@ -246,13 +246,11 @@ func handleSetDefaultProfile(w http.ResponseWriter, r *http.Request, db *sql.DB,
 func mediaProfilesHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse URL path: /api/media/profile/{id}
-		path := strings.TrimPrefix(r.URL.Path, "/api/media/profile/")
-		if path == "" {
+		mediaID := pathSegment(r, "/api/media/profile/")
+		if mediaID == "" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-
-		mediaID := strings.Split(path, "/")[0]
 
 		switch r.Method {
 		case http.MethodGet:

--- a/pkg/webserver/tags.go
+++ b/pkg/webserver/tags.go
@@ -1,4 +1,7 @@
 // file: pkg/webserver/tags.go
+// version: 1.1.0
+// guid: 5321afeb-275b-4923-a773-52d629dfa245
+// last-edited: 2026-07-30
 package webserver
 
 import (
@@ -6,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/tagging"
@@ -82,7 +84,7 @@ func tagsHandler(db *sql.DB) http.Handler {
 // tagItemHandler updates or deletes a tag by ID with enhanced metadata support.
 func tagItemHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		idStr := strings.TrimPrefix(r.URL.Path, "/api/tags/")
+		idStr := pathSegment(r, "/api/tags/")
 		id, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -142,7 +144,7 @@ func tagItemHandler(db *sql.DB) http.Handler {
 func universalTagsHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse URL: /api/{entityType}/{id}/tags
-		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/"), "/")
+		parts := pathSegments(r, "/api/")
 		if len(parts) < 3 || parts[2] != "tags" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -246,7 +248,7 @@ func bulkTagsHandler(db *sql.DB) http.Handler {
 // userTagsHandler manages tag assignments for a user (legacy compatibility wrapper).
 func userTagsHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/users/"), "/")
+		parts := pathSegments(r, "/api/users/")
 		if len(parts) < 2 || parts[1] != "tags" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -317,7 +319,7 @@ func userTagsHandler(db *sql.DB) http.Handler {
 // mediaTagsHandler manages tag assignments for a media item (legacy compatibility wrapper).
 func mediaTagsHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/media/"), "/")
+		parts := pathSegments(r, "/api/media/")
 		if len(parts) < 2 || parts[1] != "tags" {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/pkg/webserver/users.go
+++ b/pkg/webserver/users.go
@@ -1,3 +1,8 @@
+// file: pkg/webserver/users.go
+// version: 1.1.0
+// guid: 3f14cff3-19b6-461e-9c49-592a737c1a7d
+// last-edited: 2026-07-30
+
 package webserver
 
 import (
@@ -40,7 +45,7 @@ func userResetHandler(db *sql.DB) http.Handler {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/users/"), "/")
+		parts := pathSegments(r, "/api/users/")
 		if len(parts) != 2 || parts[1] != "reset" {
 			w.WriteHeader(http.StatusNotFound)
 			return


### PR DESCRIPTION
## The bug

Routes mount at `prefix + "/api/..."`, where `prefix` comes from `base_url`. **Seven** handlers pulled IDs out of the path with a literal that assumed the prefix was always empty:

```go
strings.TrimPrefix(r.URL.Path, "/api/media/profile/")
```

Behind a base URL the incoming path is `/sm/api/media/profile/42`. The literal doesn't match, `TrimPrefix` returns the path unchanged, the following `Split` yields `""` as the first segment, and an **empty ID flows into a database lookup** instead of being rejected.

These endpoints weren't degraded behind a subpath — they were **dead**:

- media profile assignment (get / assign / remove)
- profile lookup by ID
- user management by ID
- tag lookup, tag→user assignment, tag→media assignment

I found this while fixing the same bug in my own new handler in #2212 and noted it then; the sweep turned up six more.

## The fix

Parsing goes through `apiPath` / `pathSegment` / `pathSegments`, which strip the configured prefix first. Two details that matter:

- **Whole-segment matching.** A `base_url` of `/sm` must not mangle a request to `/small/...`. The naive `TrimPrefix` turns it into `all/api/tags/7`.
- **Nothing, not empty.** The helpers return `nil`/`""` when the path doesn't lie under the expected route, so "not the path I expected" is a case the handler must handle — rather than an empty ID silently reaching a lookup, which is exactly how the original failed.

## Why nothing caught it, and what stops the eighth

Every test constructs requests with an empty `base_url`, where the literal happens to match. A handler with this defect passes its tests and fails only on a real deployment behind a subpath. Seven had already drifted into the pattern, so catching the next one by eye isn't a plan.

Added `TestNoRawAPIPathParsing`, a source-level guard that fails for any handler parsing `r.URL.Path` against an `/api` literal, in the same spirit as the existing `route_coverage_test.go`.

## Verification

Full suite green under `-race`.

| Break | Result |
|---|---|
| revert `mediaProfilesHandler` to raw path parsing | ✅ fails — `got 500 ... (body "Database error")`, proving the empty ID reached the lookup |
| drop whole-segment matching from `apiPath` | ✅ fails — `apiPath("/small/api/tags/7")` returns `"all/api/tags/7"` |
| reintroduce the anti-pattern in a compiling form | ✅ guard fails, naming `profiles.go:249` |

Worth noting: my **first** version of the end-to-end test was vacuous. It asserted "not 400" for a well-formed path, which passed even with the bug — because an unparsed ID produces a 500 from the DB layer, not a 400. I rewrote it to assert the *rejection* path under `base_url`, where the broken code returns 500 and the fixed code returns 400. That's a genuine discriminator, confirmed by reverting.

## Conflicts

Touches `pkg/webserver/{basepath,profiles,users,tags}.go`. No overlap with #2214 (`multi.go`), #2215 (`status.go`) or #2216 (`config.go`, `instance.go`, `server.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH