### PR TITLE
fix(languages): make the fallback language configurable

### DIFF
--- a/changelog.d/fix-configurable-default-language.md
+++ b/changelog.d/fix-configurable-default-language.md
@@ -1,0 +1,51 @@
+<!-- file: changelog.d/fix-configurable-default-language.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9b3e57a2-4c81-4d06-a9f3-2e70b8146dc5 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### Non-English libraries silently got English subtitles
+
+Several paths that need a language but have no profile to consult hardcoded
+`"en"`, with no setting anywhere to change it:
+
+- the **Sonarr** and **Radarr** import webhooks — everything imported through
+  them was fetched in English;
+- **`FetchWithProfile`'s fallback**, taken whenever a media item has no
+  language profile assigned, which is the common case since profiles are not
+  auto-assigned to new items;
+- the same fallback in the tag-filtered variant;
+- `GetLanguagesFromProfile`'s error path.
+
+The Plex webhook was the only one with a setting (`webhooks.plex.language`),
+and even that fell back to English.
+
+All of these now resolve through `profiles.DefaultLanguage()`:
+
+1. `languages.default` — the explicit setting.
+2. The first entry of `languages.preferred`, if configured. Someone who has
+   stated an ordered preference has already answered this question; requiring
+   them to state it twice is a way to end up with the two disagreeing.
+3. `"en"` — unchanged from the previous hardcoded behaviour, so an install that
+   configures nothing downloads exactly what it did before.
+
+### What this does *not* fix
+
+The Sonarr and Radarr handlers still use a single default language rather than
+the **language profile assigned to that series or movie**, which is what Bazarr
+does on import. The handlers receive a file path and have no database handle to
+resolve a profile with, so wiring that up means threading a dependency through
+the webhook constructors — a larger change than making the language
+configurable, and a separate one. This closes the "no setting at all" half of
+the gap; the profile-aware half remains open and is recorded in the parity
+matrix.
+
+### On testing
+
+The guard in `pkg/webhooks` is a source-level check that no hardcoded language
+literal reaches `ProcessFile`, rather than a behavioural test. That is
+deliberate: with no provider configured nothing is downloaded whatever language
+is requested, so a behavioural assertion in that package passes with the bug
+present. The behavioural tests for how the default resolves live in
+`pkg/profiles`, where they can actually observe the answer.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.8.0 -->
+<!-- version: 1.9.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-25 -->
+<!-- last-edited: 2026-07-30 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -71,7 +71,7 @@ effort — it is not fully achievable autonomously.
 | Monitored-only mode | ✅ | `arr.Filters.MonitoredOnly` |
 | Excluded tags / series types | ✅ | `arr.Filters` excluded tags/series-types |
 | Path mappings (arr↔local) applied | ✅ | `arr.Filters.PathMappings` |
-| Webhook on import → search | 🟡 | Sonarr/Radarr/custom + Plex; still hardcoded `en` |
+| Webhook on import → search | 🟡 | Sonarr/Radarr/custom + Plex; language now configurable (`languages.default`), still not per-series profile |
 | Notify *arr to rescan after download | ✅ | `pkg/arrnotify`; id resolved from path at event time (see note below) |
 
 ### Search / download / upgrade engine

--- a/pkg/profiles/defaultlang.go
+++ b/pkg/profiles/defaultlang.go
@@ -1,0 +1,54 @@
+// file: pkg/profiles/defaultlang.go
+// version: 1.0.0
+// guid: b412735d-d6e2-44a9-9f39-e338af25e137
+// last-edited: 2026-07-30
+
+package profiles
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// FallbackLanguage is used when no default language has been configured.
+//
+// English is the fallback of last resort rather than a policy: it is what the
+// code hardcoded before this was configurable, so keeping it preserves
+// behaviour for anyone who has not set a preference.
+const FallbackLanguage = "en"
+
+// DefaultLanguage returns the language to download when nothing more specific
+// applies.
+//
+// "Nothing more specific" means: no language profile is assigned to the media
+// item, or the code path in question never had one to consult — the Sonarr and
+// Radarr import webhooks, for instance, receive a file path and nothing else.
+//
+// Before this existed, every such site hardcoded "en", so a non-English library
+// fetched English subtitles on import and on any profile miss, with no setting
+// anywhere to change it. That is the gap this closes.
+//
+// Resolution order:
+//
+//  1. languages.default — the explicit setting.
+//  2. The first entry of languages.preferred, if that list is configured. A
+//     user who has expressed an ordered preference has already answered this
+//     question; making them state it twice is a way to end up with the two
+//     disagreeing.
+//  3. "en", preserving the previous hardcoded behaviour.
+//
+// This is deliberately *not* a substitute for language profiles, which remain
+// the right mechanism for per-series and per-movie language choices. It is the
+// answer for paths that have no profile to consult.
+func DefaultLanguage() string {
+	if lang := strings.TrimSpace(viper.GetString("languages.default")); lang != "" {
+		return lang
+	}
+	for _, lang := range viper.GetStringSlice("languages.preferred") {
+		if lang = strings.TrimSpace(lang); lang != "" {
+			return lang
+		}
+	}
+	return FallbackLanguage
+}

--- a/pkg/profiles/defaultlang_test.go
+++ b/pkg/profiles/defaultlang_test.go
@@ -1,0 +1,81 @@
+// file: pkg/profiles/defaultlang_test.go
+// version: 1.0.0
+// guid: a81b0a4c-2e73-42e5-8e67-ed6180c2c91f
+// last-edited: 2026-07-30
+
+package profiles
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// useLangConfig sets language keys for one test and restores them after.
+func useLangConfig(t *testing.T, kv map[string]any) {
+	t.Helper()
+	keys := []string{"languages.default", "languages.preferred"}
+	prev := map[string]any{}
+	for _, k := range keys {
+		prev[k] = viper.Get(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range prev {
+			viper.Set(k, v)
+		}
+	})
+	for _, k := range keys {
+		viper.Set(k, nil)
+	}
+	for k, v := range kv {
+		viper.Set(k, v)
+	}
+}
+
+// TestDefaultLanguage covers the resolution order.
+//
+// The behaviour that matters most is the last case: with nothing configured
+// the answer must still be "en". Every call site hardcoded English before this
+// was configurable, so any other default would silently change what an existing
+// install downloads.
+func TestDefaultLanguage(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg  map[string]any
+		want string
+	}{
+		"explicit default wins": {
+			map[string]any{
+				"languages.default":   "de",
+				"languages.preferred": []string{"fr", "es"},
+			}, "de"},
+		"preferred list is used when no explicit default": {
+			map[string]any{"languages.preferred": []string{"fr", "es"}}, "fr"},
+		"unconfigured preserves the previous hardcoded behaviour": {
+			map[string]any{}, "en"},
+		"blank explicit default falls through": {
+			map[string]any{
+				"languages.default":   "   ",
+				"languages.preferred": []string{"pt-BR"},
+			}, "pt-BR"},
+		"blank entries in the preferred list are skipped": {
+			map[string]any{"languages.preferred": []string{"", " ", "nl"}}, "nl"},
+		"empty preferred list falls back": {
+			map[string]any{"languages.preferred": []string{}}, "en"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			useLangConfig(t, tc.cfg)
+			if got := DefaultLanguage(); got != tc.want {
+				t.Errorf("DefaultLanguage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultLanguageTrimsWhitespace guards against a config value with stray
+// spaces becoming a language code no provider recognises.
+func TestDefaultLanguageTrimsWhitespace(t *testing.T) {
+	useLangConfig(t, map[string]any{"languages.default": "  es  "})
+	if got := DefaultLanguage(); got != "es" {
+		t.Errorf("DefaultLanguage() = %q, want %q", got, "es")
+	}
+}

--- a/pkg/providers/profiles.go
+++ b/pkg/providers/profiles.go
@@ -1,6 +1,7 @@
 // file: pkg/providers/profiles.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
+// last-edited: 2026-07-30
 
 package providers
 
@@ -26,11 +27,12 @@ func FetchWithProfile(ctx context.Context, db *sql.DB, mediaPath, key string) ([
 	profile, err := service.GetMediaProfileByPath(mediaPath)
 	if err != nil {
 		// Fallback to default fetch if no profile found
-		data, provider, fetchErr := FetchFromAll(ctx, mediaPath, "en", key)
+		lang := profiles.DefaultLanguage()
+		data, provider, fetchErr := FetchFromAll(ctx, mediaPath, lang, key)
 		if fetchErr != nil {
 			return nil, "", "", fmt.Errorf("failed to get profile (%v) and fallback fetch failed: %w", err, fetchErr)
 		}
-		return data, provider, "en", nil
+		return data, provider, lang, nil
 	}
 
 	// Sort languages by priority (lower number = higher priority)
@@ -109,11 +111,12 @@ func FetchWithProfileTagged(ctx context.Context, db *sql.DB, mediaPath, key stri
 	profile, err := service.GetMediaProfileByPath(mediaPath)
 	if err != nil {
 		// Fallback to default tagged fetch if no profile found
-		data, provider, fetchErr := FetchFromTagged(ctx, mediaPath, "en", key, tags, tm)
+		lang := profiles.DefaultLanguage()
+		data, provider, fetchErr := FetchFromTagged(ctx, mediaPath, lang, key, tags, tm)
 		if fetchErr != nil {
 			return nil, "", "", fmt.Errorf("failed to get profile (%v) and fallback fetch failed: %w", err, fetchErr)
 		}
-		return data, provider, "en", nil
+		return data, provider, lang, nil
 	}
 
 	// Sort languages by priority (lower number = higher priority)
@@ -147,7 +150,10 @@ func GetLanguagesFromProfile(ctx context.Context, db *sql.DB, mediaPath string) 
 
 	profile, err := service.GetMediaProfileByPath(mediaPath)
 	if err != nil {
-		return []string{"en"}, err // fallback to English
+		// No profile: fall back to the configured default language rather than
+		// assuming English, which is what this returned before the default was
+		// configurable.
+		return []string{profiles.DefaultLanguage()}, err
 	}
 
 	// Sort languages by priority

--- a/pkg/webhooks/handlers.go
+++ b/pkg/webhooks/handlers.go
@@ -1,6 +1,7 @@
 // file: pkg/webhooks/handlers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 123e4567-e89b-12d3-a456-426614174002
+// last-edited: 2026-07-30
 
 package webhooks
 
@@ -12,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
 	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/scanner"
 	"github.com/jdfalk/subtitle-manager/pkg/security"
@@ -136,9 +138,16 @@ func (h *SonarrWebhookHandler) Handle(ctx context.Context, payload []byte, heade
 
 	h.logger.Infof("Processing Sonarr download: %s", filePath)
 
-	// Process file for subtitle download
-	// Use default language (English) and let the system determine provider
-	if err := scanner.ProcessFile(ctx, filePath, "en", "", nil, true, nil); err != nil {
+	// Process file for subtitle download, letting the system pick the provider.
+	//
+	// The language was hardcoded to English here, so a non-English library
+	// fetched English subtitles for everything imported through Sonarr with no
+	// setting anywhere to change it. It now follows the configured default.
+	//
+	// This is still not the language *profile* assigned to the series — the
+	// handler receives a file path and has no database to resolve one — which
+	// is the remaining half of this gap and is tracked separately.
+	if err := scanner.ProcessFile(ctx, filePath, profiles.DefaultLanguage(), "", nil, true, nil); err != nil {
 		h.logger.Warnf("Failed to process file from Sonarr webhook: %v", err)
 		return fmt.Errorf("processing failed: %v", err)
 	}
@@ -177,9 +186,10 @@ func (h *RadarrWebhookHandler) Handle(ctx context.Context, payload []byte, heade
 
 	h.logger.Infof("Processing Radarr download: %s", filePath)
 
-	// Process file for subtitle download
-	// Use default language (English) and let the system determine provider
-	if err := scanner.ProcessFile(ctx, filePath, "en", "", nil, true, nil); err != nil {
+	// Process file for subtitle download. See the Sonarr handler above for why
+	// this follows the configured default language rather than a hardcoded
+	// English, and what the remaining gap is.
+	if err := scanner.ProcessFile(ctx, filePath, profiles.DefaultLanguage(), "", nil, true, nil); err != nil {
 		h.logger.Warnf("Failed to process file from Radarr webhook: %v", err)
 		return fmt.Errorf("processing failed: %v", err)
 	}

--- a/pkg/webhooks/handlers_test.go
+++ b/pkg/webhooks/handlers_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -245,5 +247,48 @@ func TestCustomHandlerHandleErrors(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
+	}
+}
+
+// TestNoHardcodedLanguage guards against a hardcoded language literal
+// returning to the webhook handlers.
+//
+// A behavioural test here would be vacuous: with no provider configured
+// nothing is downloaded whatever language is requested, so an assertion on the
+// handler's result passes with the bug present. The property that actually
+// matters is that these call sites ask for the configured default rather than
+// a literal, and that is visible in the source.
+//
+// pkg/profiles carries the real behavioural tests for how the default is
+// resolved.
+func TestNoHardcodedLanguage(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	// ProcessFile(ctx, path, <literal>, ...) — the shape that pinned every
+	// import to English regardless of configuration.
+	bad := regexp.MustCompile(`ProcessFile\([^)]*,\s*"[a-z]{2}(-[A-Za-z]{2,4})?"`)
+
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			if bad.MatchString(line) {
+				t.Errorf("%s:%d passes a hardcoded language to ProcessFile; a "+
+					"non-English library would silently get English subtitles. "+
+					"Use profiles.DefaultLanguage():\n\t%s",
+					f, i+1, strings.TrimSpace(line))
+			}
+		}
 	}
 }

--- a/pkg/webhooks/plex.go
+++ b/pkg/webhooks/plex.go
@@ -1,7 +1,7 @@
 // file: pkg/webhooks/plex.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d6b1f39c-4e07-4a52-9c8b-2f0a7d54e916
-// last-edited: 2026-07-23
+// last-edited: 2026-07-30
 
 package webhooks
 
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
 )
 
 // plexPayload is the subset of a Plex webhook payload we care about. Plex sends
@@ -83,9 +84,11 @@ func PlexHandler() http.Handler {
 			return
 		}
 
+		// Plex already had its own language setting; fall back to the global
+		// default rather than English so all three webhook sources agree.
 		lang := viper.GetString("webhooks.plex.language")
 		if lang == "" {
-			lang = "en"
+			lang = profiles.DefaultLanguage()
 		}
 
 		handle(w, r, event{Path: file, Lang: lang})


### PR DESCRIPTION
## The bug

Several paths that need a language but have no profile to consult hardcoded `"en"`, with **no setting anywhere to change it**:

- the **Sonarr** and **Radarr** import webhooks — everything imported through them was fetched in English
- **`FetchWithProfile`'s fallback**, taken whenever a media item has no language profile assigned — which is the *common* case, since profiles aren't auto-assigned to new items
- the same fallback in the tag-filtered variant
- `GetLanguagesFromProfile`'s error path

The Plex webhook was the only one with a setting, and even that fell back to English.

So a German or Spanish library got English subtitles on import and on every profile miss, with nothing to configure. I went looking for the one known gap ("webhook language hardcoded `en`") and found five sites.

## The fix

All resolve through `profiles.DefaultLanguage()`:

1. `languages.default` — explicit setting
2. first entry of `languages.preferred`, if configured — someone who's stated an ordered preference has already answered this; making them state it twice invites the two disagreeing
3. `"en"` — unchanged from before, so **an install that configures nothing behaves exactly as it did**

## What this deliberately does *not* fix

The *arr handlers still use a single default language rather than the **language profile assigned to that series or movie**, which is what Bazarr does on import. They receive a file path and have no database handle, so resolving a profile means threading a dependency through the webhook constructors — a larger change, and a separate one.

This closes the "no setting at all" half. The parity matrix entry stays 🟡 with the remaining half named, rather than being marked done.

## On the tests

The `pkg/webhooks` guard is a **source-level** check that no hardcoded language literal reaches `ProcessFile`, not a behavioural test. That's deliberate: with no provider configured nothing is downloaded whatever language is requested, so any behavioural assertion in that package passes with the bug present — I wrote one first, realised it was vacuous, and threw it away. The behavioural tests live in `pkg/profiles`, where the answer is actually observable.

| Break | Result |
|---|---|
| reinstate hardcoded `"en"` in the Sonarr handler | ✅ fails, naming `handlers.go:150` |
| make the unset default resolve to something other than `en` | ✅ fails — `DefaultLanguage() = "fr", want "en"` |

That second one guards the compatibility promise: it's the test that would catch someone "improving" the fallback and silently changing what existing installs download.

Full suite green under `-race`.

## Conflicts

Touches `pkg/profiles/defaultlang.go` (new), `pkg/providers/profiles.go`, `pkg/webhooks/{handlers,plex}.go`. No overlap with #2214 (`multi.go`), #2215 (`status.go`), #2216 (`config.go`/`instance.go`), or #2217 (`pkg/webserver`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH