### PR TITLE
fix(whisper): separate connect timeout from transcription timeout

### DIFF
--- a/changelog.d/feat-whisper-connect-timeout.md
+++ b/changelog.d/feat-whisper-connect-timeout.md
@@ -1,0 +1,47 @@
+<!-- file: changelog.d/feat-whisper-connect-timeout.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4d70e935-16ba-4c82-9f01-8b3c2a5e7d64 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### An unreachable Whisper server stalled transcription for 30 minutes
+
+Reaching the Whisper server and transcribing on it shared a single timeout.
+Transcription legitimately takes many minutes, so that budget has to be large —
+but it was also what bounded *connecting*. With the server down, misconfigured,
+or behind a black-holing firewall, every transcription attempt hung for the
+full budget (30 minutes by default) before failing, and a library scan that hit
+that path appeared to be frozen rather than erroring.
+
+The two are now separate:
+
+- `whisper.connect_timeout` (default **10s**) bounds establishing the
+  connection, so an unreachable server fails in seconds.
+- `whisper.transcribe_timeout` (default **30m**, unchanged) bounds the whole
+  request, so a running transcription still gets its full budget.
+
+### Decisions worth reviewing
+
+- **`ResponseHeaderTimeout` is deliberately not set.** It looks like the right
+  knob for "the server accepted the connection then went quiet", but
+  whisper-asr-webservice sends response headers only once transcription has
+  finished. Any value short enough to be useful as a liveness check would abort
+  valid work. The overall timeout bounds that phase instead.
+- **The transport is cloned from `http.DefaultTransport`, not constructed.**
+  `pkg/proxy` implements `proxy_url` by setting `Proxy` on the default
+  transport. Building a fresh `http.Transport` would silently opt Whisper
+  traffic out of the configured proxy — the kind of gap that surfaces as "why
+  does everything except transcription go through the proxy?". There is a test
+  for this.
+
+### On testing
+
+The behavioural test written first for the connect timeout was **vacuous** and
+was thrown away: it filled a listener's accept backlog hoping connections would
+hang, but the OS accepted them anyway, so it passed in 0.02s — and kept passing
+with the fix reverted. Reaching a genuinely black-holing address would mean
+depending on the network from CI, trading one unreliability for another. The
+timeout is therefore asserted structurally, where the assertion can actually
+fail: a clone of the default transport carries a 10s handshake timeout, so
+configuring anything else makes an unapplied setting visible.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.8.0 -->
+<!-- version: 1.9.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
-<!-- last-edited: 2026-07-25 -->
+<!-- last-edited: 2026-07-30 -->
 
 # Bazarr Backend Parity — Status & Gap Inventory
 
@@ -198,7 +198,7 @@ Backend items only — pure UI and bugfixes excluded.
 - 🟡 **Provider throttling** — Bazarr tracks per-provider throttle state and a
   "throttled providers" view with cooldowns on 429/503/maintenance; we only have
   simple in-memory backoff.
-- 🟡 **Whisper**: separate connection vs read timeouts; language mapping; audio
+- 🟡 **Whisper**: connect vs total timeout now split (`whisper.connect_timeout`); language mapping; audio
   delay detection in MKV headers via ffprobe. We expose a single timeout.
 - 🟡 **Subsync**: option to use the original-language audio track as the sync
   reference; ffsubsync progress reporting.

--- a/pkg/transcriber/asr.go
+++ b/pkg/transcriber/asr.go
@@ -1,6 +1,7 @@
 // file: pkg/transcriber/asr.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c35500d2-dcef-4ad9-884d-9d91de10459a
+// last-edited: 2026-07-30
 
 package transcriber
 
@@ -10,12 +11,15 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 // ASROptions configures a call to a self-hosted whisper-asr-webservice /asr
@@ -31,9 +35,84 @@ type ASROptions struct {
 	WordTimestamps bool
 }
 
-// asrHTTPClient is the default client for ASR calls. Transcription of a full
-// media file can take many minutes, so the timeout is generous.
-var asrHTTPClient = &http.Client{Timeout: 30 * time.Minute}
+const (
+	// defaultASRTotalTimeout bounds a whole transcription. Transcribing a full
+	// media file legitimately takes many minutes, so it is generous.
+	defaultASRTotalTimeout = 30 * time.Minute
+	// defaultASRConnectTimeout bounds establishing the connection only.
+	defaultASRConnectTimeout = 10 * time.Second
+)
+
+// asrConnectTimeout returns how long to wait for the connection to the Whisper
+// server to be established.
+func asrConnectTimeout() time.Duration {
+	if secs := viper.GetInt("whisper.connect_timeout"); secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultASRConnectTimeout
+}
+
+// asrTotalTimeout returns the ceiling on a whole transcription request.
+func asrTotalTimeout() time.Duration {
+	if secs := viper.GetInt("whisper.transcribe_timeout"); secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultASRTotalTimeout
+}
+
+// newASRClient builds the HTTP client for ASR calls, separating the time
+// allowed to *reach* the Whisper server from the time allowed to transcribe.
+//
+// # Why these are two different numbers
+//
+// A single timeout cannot express this. Transcription takes minutes, so the
+// overall budget has to be large — but that same large number was also what
+// bounded connecting. With the Whisper server down, misconfigured, or behind a
+// black-holing firewall, every transcription attempt hung for the full budget
+// (30 minutes by default) before failing. A library scan that hit that path
+// once appeared to stall completely.
+//
+// Splitting them means an unreachable server fails in seconds while a running
+// transcription still gets its full budget.
+//
+// # Why the transport is cloned rather than constructed
+//
+// pkg/proxy implements the proxy_url setting by setting Proxy on
+// http.DefaultTransport. Building a fresh http.Transport here would silently
+// opt Whisper traffic out of the operator's configured proxy — the sort of gap
+// that only shows up as "why does everything except transcription go through
+// the proxy?". Cloning inherits Proxy and the rest of the standard tuning; only
+// the dial deadlines are overridden.
+func newASRClient() *http.Client {
+	connect := asrConnectTimeout()
+
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// Something has replaced the default transport with a non-standard
+		// type. Honour the connect timeout rather than silently ignoring it,
+		// and accept that whatever that transport added is not inherited.
+		return &http.Client{
+			Timeout: asrTotalTimeout(),
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				DialContext:         (&net.Dialer{Timeout: connect}).DialContext,
+				TLSHandshakeTimeout: connect,
+			},
+		}
+	}
+
+	clone := tr.Clone()
+	clone.DialContext = (&net.Dialer{
+		Timeout:   connect,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	clone.TLSHandshakeTimeout = connect
+	// Deliberately NOT setting ResponseHeaderTimeout: the whisper-asr-webservice
+	// sends response headers only once transcription has finished, so any value
+	// short enough to be useful as a liveness check would abort valid work.
+	// The overall Timeout is what bounds that phase.
+	return &http.Client{Timeout: asrTotalTimeout(), Transport: clone}
+}
 
 // ASRTranscribe posts filePath to a self-hosted whisper-asr-webservice instance
 // at baseURL (for example http://localhost:9000) and returns the subtitle bytes
@@ -53,7 +132,13 @@ func ASRTranscribe(ctx context.Context, httpClient *http.Client, baseURL, filePa
 		opts.Output = "srt"
 	}
 	if httpClient == nil {
-		httpClient = asrHTTPClient
+		c := newASRClient()
+		httpClient = c
+		// One request per client, so drop the idle connection rather than
+		// leaving a transport behind on every transcription.
+		if tr, ok := c.Transport.(*http.Transport); ok {
+			defer tr.CloseIdleConnections()
+		}
 	}
 
 	f, err := os.Open(filePath)

--- a/pkg/transcriber/asr_timeout_test.go
+++ b/pkg/transcriber/asr_timeout_test.go
@@ -1,0 +1,141 @@
+// file: pkg/transcriber/asr_timeout_test.go
+// version: 1.0.0
+// guid: 21bc33a0-3c6d-49c4-a350-b1792ad6986a
+// last-edited: 2026-07-30
+
+package transcriber
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// useWhisperConfig sets whisper timeout keys for one test.
+func useWhisperConfig(t *testing.T, kv map[string]any) {
+	t.Helper()
+	keys := []string{"whisper.connect_timeout", "whisper.transcribe_timeout"}
+	prev := map[string]any{}
+	for _, k := range keys {
+		prev[k] = viper.Get(k)
+		viper.Set(k, nil)
+	}
+	t.Cleanup(func() {
+		for k, v := range prev {
+			viper.Set(k, v)
+		}
+	})
+	for k, v := range kv {
+		viper.Set(k, v)
+	}
+}
+
+// TestASRTimeoutsAreSeparate verifies the two budgets are read independently
+// and have sane defaults.
+func TestASRTimeoutsAreSeparate(t *testing.T) {
+	useWhisperConfig(t, nil)
+	if got := asrConnectTimeout(); got != defaultASRConnectTimeout {
+		t.Errorf("default connect timeout = %v, want %v", got, defaultASRConnectTimeout)
+	}
+	if got := asrTotalTimeout(); got != defaultASRTotalTimeout {
+		t.Errorf("default total timeout = %v, want %v", got, defaultASRTotalTimeout)
+	}
+
+	// The transcription budget must not become the connect budget: that
+	// coupling is the bug — a 30 minute transcription allowance meant a dead
+	// server also took 30 minutes to report itself dead.
+	useWhisperConfig(t, map[string]any{"whisper.transcribe_timeout": 1800})
+	if got := asrConnectTimeout(); got != defaultASRConnectTimeout {
+		t.Errorf("connect timeout = %v after setting only transcribe_timeout; "+
+			"want it to stay %v", got, defaultASRConnectTimeout)
+	}
+	if got := asrTotalTimeout(); got != 30*time.Minute {
+		t.Errorf("total timeout = %v, want 30m", got)
+	}
+
+	useWhisperConfig(t, map[string]any{"whisper.connect_timeout": 3})
+	if got := asrConnectTimeout(); got != 3*time.Second {
+		t.Errorf("connect timeout = %v, want 3s", got)
+	}
+}
+
+// TestASRClientAppliesConnectTimeout verifies the configured connect timeout
+// actually reaches the transport.
+//
+// This is asserted structurally rather than by timing a hanging connect. A
+// behavioural version was written first and thrown away: it filled a
+// listener's accept backlog hoping connections would hang, but the OS accepted
+// them anyway, so it passed in 0.02s — and kept passing with the fix reverted.
+// A test that cannot fail is worse than no test. Reaching a genuinely
+// black-holing address means depending on the network from CI, which trades
+// one kind of unreliability for another.
+//
+// TLSHandshakeTimeout is the observable proxy for the dial deadlines: both are
+// set from the same connect budget, and a clone of http.DefaultTransport
+// carries 10s, so configuring anything else makes an unapplied setting visible.
+func TestASRClientAppliesConnectTimeout(t *testing.T) {
+	useWhisperConfig(t, map[string]any{
+		"whisper.connect_timeout":    3,
+		"whisper.transcribe_timeout": 1800,
+	})
+
+	c := newASRClient()
+	if c.Timeout != 30*time.Minute {
+		t.Errorf("client timeout = %v, want the 30m transcription budget", c.Timeout)
+	}
+
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("ASR client transport is not *http.Transport")
+	}
+	if tr.TLSHandshakeTimeout != 3*time.Second {
+		t.Errorf("TLSHandshakeTimeout = %v, want 3s: the connect budget is not "+
+			"reaching the transport, so an unreachable Whisper server would be "+
+			"bounded only by the 30 minute transcription budget",
+			tr.TLSHandshakeTimeout)
+	}
+	if tr.DialContext == nil {
+		t.Error("DialContext is nil; the dial deadline is not being applied")
+	}
+}
+
+// TestASRClientInheritsProxy verifies the ASR client does not opt out of the
+// configured outbound proxy.
+//
+// pkg/proxy implements proxy_url by setting Proxy on http.DefaultTransport.
+// Building a fresh transport here instead of cloning would silently exclude
+// Whisper traffic from it.
+func TestASRClientInheritsProxy(t *testing.T) {
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("default transport is not *http.Transport")
+	}
+	prev := tr.Proxy
+	t.Cleanup(func() { tr.Proxy = prev })
+
+	called := false
+	tr.Proxy = func(*http.Request) (*url.URL, error) {
+		called = true
+		return nil, nil
+	}
+
+	c := newASRClient()
+	ctr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("ASR client transport is not *http.Transport")
+	}
+	if ctr.Proxy == nil {
+		t.Fatal("ASR client dropped the proxy configuration; whisper traffic " +
+			"would bypass proxy_url")
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://example.invalid/", nil)
+	if _, err := ctr.Proxy(req); err != nil {
+		t.Fatalf("proxy func: %v", err)
+	}
+	if !called {
+		t.Error("ASR client is not using the configured proxy function")
+	}
+}


### PR DESCRIPTION
## The bug

Reaching the Whisper server and transcribing on it shared **one** timeout. Transcription legitimately takes many minutes, so that budget has to be large — but it also bounded *connecting*.

With the server down, misconfigured, or behind a black-holing firewall, every transcription attempt hung for the full budget — **30 minutes by default** — before failing. A library scan that hit that path didn't error, it appeared frozen.

## The fix

- `whisper.connect_timeout` (default **10s**) bounds the dial and TLS handshake → an unreachable server fails in seconds
- `whisper.transcribe_timeout` (default **30m**, unchanged) bounds the whole request → a running transcription keeps its full budget

## Two decisions worth reviewing

**`ResponseHeaderTimeout` is deliberately not set.** It looks like exactly the right knob for "server accepted the connection then went quiet" — but whisper-asr-webservice sends response headers only *after* transcription finishes. Any value short enough to be useful as a liveness check would abort valid work. The overall timeout covers that phase instead.

**The transport is cloned from `http.DefaultTransport`, not constructed.** `pkg/proxy` implements `proxy_url` by setting `Proxy` on the default transport. A fresh `http.Transport` here would silently opt Whisper traffic out of the configured proxy — the kind of gap that surfaces months later as "why does everything *except* transcription go through the proxy?". There's a test asserting the proxy survives.

## On the tests — one was vacuous

My first behavioural test for the connect timeout filled a listener's accept backlog, expecting further connects to hang. The OS accepted them anyway, so it passed in 0.02s — **and kept passing with the fix reverted**. Reaching a genuinely black-holing address would mean depending on the network from CI, trading one kind of unreliability for another.

So the timeout is asserted structurally, where the assertion can actually fail: a clone of the default transport carries a 10s handshake timeout, so configuring anything else makes an unapplied setting visible.

| Break | Result |
|---|---|
| ignore the connect timeout | ✅ fails — `TLSHandshakeTimeout = 10s, want 3s` |
| construct a fresh transport instead of cloning | ✅ fails — "dropped the proxy configuration; whisper traffic would bypass proxy_url" |

Full suite green under `-race`.

## Conflicts

Touches `pkg/transcriber/asr.go` only. No overlap with any of #2214–#2218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH