### PR TITLE
test(providers): remove data race in the context timeout test

### DIFF
--- a/changelog.d/fix-flaky-context-race-test.md
+++ b/changelog.d/fix-flaky-context-race-test.md
@@ -1,0 +1,41 @@
+<!-- file: changelog.d/fix-flaky-context-race-test.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8f2c614b-95a7-4e30-b8d1-c0a3572e94f6 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### Flaky data race in the provider context test
+
+`TestProviderContextHandling/context_timeout` reddened CI intermittently on
+unrelated pull requests. It was a genuine data race, not a slow-runner
+artefact.
+
+The test built a context with `WithTimeout(ctx, 1*time.Millisecond)` and slept
+2ms. A *pending* deadline is delivered by the context package's own timer
+goroutine, which writes to the context's internals when it fires. testify's
+mock formats every argument with `fmt.Sprintf` when recording a call, and
+formatting a context reads those same internals by reflection. When the timer
+fired while the mock was formatting, the race detector tripped:
+
+```
+Write at ... context.(*timerCtx).cancel   <- WithDeadlineCause.func2
+Previous read at ... testify/mock.callString -> fmt.Sprintf
+```
+
+The 2ms sleep usually let the timer win, which is why this passed locally and
+failed only under load.
+
+The fix uses a deadline that has **already passed**. `context.WithDeadline`
+cancels synchronously on the calling goroutine in that case, so no timer
+goroutine is ever created and nothing concurrent touches the context. Waiting
+on `ctx.Done()` was considered and rejected: it shrinks the window but does not
+close it, since `cancel()` is still unlocking the context's mutex as the test
+proceeds.
+
+The test still asserts what it did before — that a matcher sees an expired
+context and the timeout error propagates.
+
+> Honest note: this could not be reproduced locally, including at
+> `-count=800` under deliberate CPU contention. The diagnosis and fix come from
+> the race detector's stack trace in CI, which names both sides precisely.

--- a/pkg/providers/search_functionality_test.go
+++ b/pkg/providers/search_functionality_test.go
@@ -346,11 +346,33 @@ func TestProviderContextHandling(t *testing.T) {
 	})
 
 	t.Run("context_timeout", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		// An ALREADY-PASSED deadline, so no timer goroutine is ever created.
+		//
+		// This test used context.WithTimeout(ctx, 1ms) and then slept 2ms.
+		// That leaves a real race, not merely a slow-machine artefact: a
+		// pending deadline is delivered by context's own timer goroutine,
+		// which writes to the context's internals when it fires, while
+		// testify's mock formats every argument with fmt.Sprintf when
+		// recording the call — and formatting a context reads those same
+		// internals by reflection. CI caught exactly that:
+		//
+		//	Write at ... context.(*timerCtx).cancel  <- WithDeadlineCause.func2
+		//	Previous read at ... testify/mock.callString -> fmt.Sprintf
+		//
+		// The 2ms sleep usually let the timer win the race, which is why this
+		// passed locally and reddened CI intermittently. Waiting on Done()
+		// would shrink the window but not close it — cancel() is still
+		// unlocking the context's mutex as the test proceeds.
+		//
+		// context.WithDeadline cancels synchronously, on the calling
+		// goroutine, when the deadline has already passed. Nothing concurrent
+		// ever touches this context, so there is no window to lose.
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
 		defer cancel()
 
-		// Sleep a bit to ensure timeout
-		time.Sleep(2 * time.Millisecond)
+		if ctx.Err() == nil {
+			t.Fatal("precondition: a past deadline should already be expired")
+		}
 
 		mockProvider.On("Fetch", mock.MatchedBy(func(ctx context.Context) bool {
 			select {


### PR DESCRIPTION
## Why

`TestProviderContextHandling/context_timeout` has been reddening CI intermittently on **unrelated** pull requests — it failed my Whisper PR (#2219), which touches only `pkg/transcriber`. It's a genuine data race, not a slow-runner artefact.

## The race

The test built `context.WithTimeout(ctx, 1*time.Millisecond)` and slept 2ms.

A *pending* deadline is delivered by the context package's own timer goroutine, which writes to the context's internals when it fires. testify's mock formats every argument with `fmt.Sprintf` when recording a call — and formatting a context reads those same internals by reflection. When the timer fires mid-format:

```
Write at 0x00c000040160 by goroutine 49:
  context.(*timerCtx).cancel()
  context.WithDeadlineCause.func2()          <- the deadline firing

Previous read at 0x00c000040160 by goroutine 47:
  fmt.Sprintf()
  testify/mock.callString()
  testify/mock.(*Mock).MethodCalled()        <- recording the call
```

The 2ms sleep usually let the timer win, which is why this passed locally and failed only under CI load. The visible symptom was a confusing matcher diff (`not matched by func(context.Context) bool`); the race was the actual cause.

## The fix

Use a deadline that has **already passed**. `context.WithDeadline` cancels *synchronously, on the calling goroutine* when the deadline is in the past, so no timer goroutine is ever created and nothing concurrent touches the context.

**I rejected the more obvious fix** of waiting on `<-ctx.Done()` before calling the mock: it shrinks the window but doesn't close it, because `cancel()` is still unlocking the context's mutex as the test proceeds — and the mutex is exactly what the race report points at.

The test asserts the same thing it did before: a matcher sees an expired context, and the timeout error propagates.

## Honest caveat

**I could not reproduce this locally** — `-count=800` under deliberate CPU contention, clean every time. The window depends on the timer firing during testify's `Sprintf` under Linux/amd64 scheduling.

So the diagnosis rests on the race detector's stack trace from CI, which names both sides precisely, and on the fix removing the racing goroutine outright rather than making it less likely. I'd rather say that plainly than imply I'd verified it empirically.

## Conflicts

Touches `pkg/providers/search_functionality_test.go` only. No overlap with #2214 (`multi.go`), #2215 (`status.go`) or #2216 (`config.go`/`instance.go`), though all are in `pkg/providers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH