### PR TITLE
fix(cmd): remove duplicate command registrations

### DIFF
--- a/changelog.d/fix-duplicate-command-registration.md
+++ b/changelog.d/fix-duplicate-command-registration.md
@@ -1,0 +1,22 @@
+<!-- file: changelog.d/fix-duplicate-command-registration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c4e91a37-6b02-4d58-9e13-af7025c8b6d4 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### `--help` listed five commands twice
+
+`batch`, `fetch`, `radarr`, `sonarr` and `rename` were registered both in
+`cmd/root.go`'s setup block and in their own file's `init()`, so cobra held two
+entries for each and printed them twice in the command list.
+
+Nothing was functionally broken, which is why it survived — but a help listing
+that repeats itself reads as an unfinished tool, and it is among the first
+things anyone sees. The duplicates are removed from `root.go`; each of those
+commands keeps the self-registration in its own file, which is the pattern the
+other ~25 commands already follow. The five commands that only `root.go`
+registers (`convert`, `merge`, `translate`, `queue`, `profile`) stay there.
+
+Found by building the binary and running `--help`, not by reading the code.
+Added a test that fails if any command is registered more than once.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -207,15 +207,16 @@ func init() {
 		rootCmd.PersistentFlags().Bool("storage-backup-history", false, "enable cloud backup of history data")
 		viper.BindPFlag("storage.backup_history", rootCmd.PersistentFlags().Lookup("storage-backup-history"))
 
+		// Only commands that do NOT register themselves belong here.
+		//
+		// fetch, batch, sonarr, radarr and rename were listed here as well as
+		// in their own files' init(), so cobra held two entries for each and
+		// `--help` printed them twice. Every other command in cmd/ follows the
+		// self-registration pattern; these five now do too.
 		rootCmd.AddCommand(convertCmd)
 		rootCmd.AddCommand(mergeCmd)
 		rootCmd.AddCommand(translateCmd)
 		rootCmd.AddCommand(queueCmd)
-		rootCmd.AddCommand(fetchCmd)
-		rootCmd.AddCommand(batchCmd)
-		rootCmd.AddCommand(sonarrCmd)
-		rootCmd.AddCommand(radarrCmd)
-		rootCmd.AddCommand(renameCmd)
 		rootCmd.AddCommand(profileCmd)
 	})
 }

--- a/cmd/root_commands_test.go
+++ b/cmd/root_commands_test.go
@@ -1,0 +1,32 @@
+// file: cmd/root_commands_test.go
+// version: 1.0.0
+// guid: 5b8e1074-2c93-4a6f-b015-7e2d94c3a681
+// last-edited: 2026-07-30
+
+package cmd
+
+import "testing"
+
+// TestNoDuplicateCommands guards against a command being registered twice.
+//
+// Five commands were listed both in root.go's setup block and in their own
+// file's init(), so cobra held two entries for each and `--help` printed
+// batch, fetch, radarr, sonarr and rename twice. Nothing broke functionally —
+// which is why it survived — but a help listing that repeats itself reads as
+// an unfinished tool, and it is the kind of thing a user notices in the first
+// thirty seconds of evaluating the software.
+func TestNoDuplicateCommands(t *testing.T) {
+	seen := map[string]int{}
+	for _, c := range rootCmd.Commands() {
+		seen[c.Name()]++
+	}
+	for name, n := range seen {
+		if n > 1 {
+			t.Errorf("command %q is registered %d times; it will appear %d times "+
+				"in --help. Register it in its own file's init() only.", name, n, n)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("no commands registered; this guard would pass vacuously")
+	}
+}


### PR DESCRIPTION
## What

`--help` listed **five commands twice**:

```
  batch            Translate multiple subtitle files concurrently
  batch            Translate multiple subtitle files concurrently
  ...
  fetch            Download subtitles using all providers
  fetch            Download subtitles using all providers
```

`batch`, `fetch`, `radarr`, `sonarr` and `rename` were registered in **both** `cmd/root.go`'s setup block and their own file's `init()`, so cobra held two entries for each.

Nothing was functionally broken — which is exactly why it survived. But a help listing that repeats itself reads as an unfinished tool, and it's among the first things anyone sees when evaluating the software.

## The fix

Removed the five duplicates from `root.go`. Each keeps the self-registration in its own file, matching the pattern the other ~25 commands already follow. The five that *only* `root.go` registers (`convert`, `merge`, `translate`, `queue`, `profile`) stay there — I checked each one rather than deleting the whole block.

## How I found it

By **building the binary and running `--help`**, not by reading the code. I'd been through `cmd/root.go` before without noticing; a doubled line in a 40-line listing is invisible until you see the output.

Added a guard that fails if any command is registered more than once — verified non-vacuous by re-adding a duplicate:

```
command "fetch" is registered 2 times; it will appear 2 times in --help.
```

## Conflicts

Touches `cmd/root.go` and adds `cmd/root_commands_test.go`. No overlap with any of #2211–#2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH