### PR TITLE
fix(webserver): mount /api/providers/available

### DIFF
--- a/changelog.d/fix-providers-available-route.md
+++ b/changelog.d/fix-providers-available-route.md
@@ -1,0 +1,43 @@
+<!-- file: changelog.d/fix-providers-available-route.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b58c07f2-4a1d-4e93-8067-c1f9d3a25e40 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### `/api/providers/available` was answered by the tag handler
+
+`ProviderConfigDialog.jsx` has always called this endpoint and no handler was
+registered for it. The interesting part is what that meant in practice: the
+request did **not** fall through to the single-page-app catch-all, because
+`/api/providers/` is registered as a subtree for the universal tag handler — so
+the *tag* handler answered it. The dialog assigned that response to state and
+crashed on `availableProviders.map is not a function`, which reads as a React
+bug rather than a routing one.
+
+It now has a handler returning the provider list that `getAvailableProviders`
+already builds. An exact pattern beats a subtree in `http.ServeMux`, so
+registering it is sufficient — no reordering required.
+
+### Added
+
+#### A route guard that derives its list from the web UI
+
+`route_coverage_test.go` checks a **hand-maintained** list of frontend paths.
+That only ever catches paths somebody remembered to add, and it is why this gap
+survived: nobody listed `/api/providers/available`.
+
+`TestDiscoveredFrontendPathsAreMounted` scans `webui/src` for `/api/...`
+literals and asserts each resolves to a route, so a new call to an endpoint that
+was never mounted fails without anyone updating a list. It self-checks, failing
+if the scan returns implausibly few paths rather than passing vacuously, and it
+skips `__tests__` and `mockApi.js` — a development double whose
+`urlPath.includes('/api/library')` is a prefix match, not an endpoint.
+
+**What it cannot catch, stated plainly:** it asserts a path matches *some*
+pattern, not the *right* one. This very bug is the example — the path resolved
+happily to a neighbouring subtree, so both this guard and the curated one would
+have called it mounted. A path swallowed by an adjacent subtree still needs a
+test of the endpoint's actual behaviour, which is why
+`TestAvailableProvidersReturnsAList` asserts a JSON array comes back rather than
+trusting the routing.

--- a/pkg/webserver/route_discovery_test.go
+++ b/pkg/webserver/route_discovery_test.go
@@ -1,0 +1,165 @@
+// file: pkg/webserver/route_discovery_test.go
+// version: 1.0.0
+// guid: 9c4b7e21-58f3-4a06-b9d7-2e150c8a4f63
+// last-edited: 2026-07-30
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestDiscoveredFrontendPathsAreMounted scans the web UI source for the API
+// paths it calls and asserts each one resolves to a real handler.
+//
+// # Why this exists alongside route_coverage_test.go
+//
+// That file checks a hand-maintained list, which only ever catches paths
+// somebody remembered to add. This one derives the list from the frontend, so a
+// new call to an endpoint that was never mounted fails here without anyone
+// updating anything.
+//
+// # What this cannot catch, and why that matters
+//
+// It asserts a path matches *some* pattern, not the *right* one. That is a real
+// gap, and /api/providers/available is the example: "/api/providers/" is
+// registered as a subtree for universalTagsHandler, so before that endpoint
+// existed the path resolved happily — to the tag handler. Both this guard and
+// the curated one would have called it mounted.
+//
+// A path swallowed by a neighbouring subtree therefore still needs to be caught
+// by a test of the endpoint's actual behaviour. What this guard does cover is
+// the more common case: a path with no matching pattern at all, which the SPA
+// catch-all answers with index.html and a 200.
+func TestDiscoveredFrontendPathsAreMounted(t *testing.T) {
+	root := filepath.Join("..", "..", "webui", "src")
+	if _, err := os.Stat(root); err != nil {
+		t.Skipf("web UI source not present: %v", err)
+	}
+
+	paths, err := discoverAPIPaths(root)
+	if err != nil {
+		t.Fatalf("scan web UI: %v", err)
+	}
+	if len(paths) < 10 {
+		t.Fatalf("only discovered %d API paths (%v); the scanner is probably "+
+			"broken and this guard would pass vacuously", len(paths), paths)
+	}
+
+	mux, prefix, err := newMux(nil)
+	if err != nil {
+		t.Fatalf("newMux: %v", err)
+	}
+	catchAll := prefix + "/"
+
+	for _, p := range paths {
+		if _, skip := knownMissingAPIPaths[p]; skip {
+			continue
+		}
+		req := httptest.NewRequest(http.MethodGet, prefix+p, nil)
+		_, pattern := mux.Handler(req)
+		if pattern == catchAll || pattern == "" {
+			t.Errorf("%s is called by the web UI but matches no route (pattern %q). "+
+				"It will return index.html with a 200 from the SPA catch-all, so the "+
+				"caller sees a success and then fails parsing HTML as JSON. Mount it, "+
+				"or record it in knownMissingAPIPaths with the reason.", p, pattern)
+		}
+	}
+}
+
+// apiPathPattern matches a string literal beginning with /api/ in the web UI
+// source, whether passed to fetch, apiFetch or apiService.
+var apiPathPattern = regexp.MustCompile(`['"` + "`" + `](/api/[a-zA-Z0-9._/-]*)`)
+
+// discoverAPIPaths collects the distinct /api/ paths referenced under root.
+//
+// Template literals are truncated at the first interpolation — "/api/tags/${id}"
+// yields "/api/tags/", which is enough to tell a mounted subtree from an
+// unmounted one, and avoids inventing IDs the handler might reject.
+func discoverAPIPaths(root string) ([]string, error) {
+	seen := map[string]bool{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Tests describe paths they mock, which are not necessarily paths
+			// the application calls.
+			if info.Name() == "__tests__" || info.Name() == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".js" && ext != ".jsx" {
+			return nil
+		}
+		// mockApi.js is a development double that prefix-matches paths
+		// (`urlPath.includes('/api/library')`). Those are not endpoints the
+		// application calls, and treating them as such reports routes that do
+		// not need to exist.
+		if strings.Contains(filepath.Base(path), "mockApi") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range apiPathPattern.FindAllStringSubmatch(string(src), -1) {
+			p := strings.TrimSuffix(m[1], "/")
+			if p == "" || p == "/api" {
+				continue
+			}
+			seen[p] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// TestAvailableProvidersReturnsAList asserts the endpoint's behaviour, not just
+// that it routes somewhere.
+//
+// Routing alone cannot express this. Before the endpoint existed,
+// /api/providers/available resolved to the "/api/providers/" subtree — the
+// universal tag handler — so every pattern-based check called it mounted while
+// the UI received a shape it could not use and crashed on
+// "availableProviders.map is not a function". The property that actually
+// matters is that a JSON array comes back.
+func TestAvailableProvidersReturnsAList(t *testing.T) {
+	rr := httptest.NewRecorder()
+	availableProvidersHandler().ServeHTTP(rr,
+		httptest.NewRequest(http.MethodGet, "/api/providers/available", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not a JSON array (%v); the dialog does "+
+			"availableProviders.map over this and would crash: %s",
+			err, rr.Body.String())
+	}
+	if len(got) == 0 {
+		t.Error("no providers returned; the add-provider dialog would be empty")
+	}
+	if _, ok := got[0]["name"]; !ok {
+		t.Errorf("entries lack a name field: %v", got[0])
+	}
+}

--- a/pkg/webserver/route_discovery_test.go
+++ b/pkg/webserver/route_discovery_test.go
@@ -117,6 +117,11 @@ func discoverAPIPaths(root string) ([]string, error) {
 			if p == "" || p == "/api" {
 				continue
 			}
+			// Prose, not endpoints. Comments and docs refer to paths as
+			// "/api/..." or "/api/foo/…"; a real path has no run of dots.
+			if strings.Contains(p, "..") || strings.HasSuffix(p, ".") {
+				continue
+			}
 			seen[p] = true
 		}
 		return nil

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -252,6 +252,20 @@ func newMux(db *sql.DB) (*http.ServeMux, string, error) {
 	mux.Handle(prefix+"/api/search/history", authMiddleware(db, "basic", searchHistoryHandler(db)))
 	// New API endpoints for modern UI
 	mux.Handle(prefix+"/api/providers", authMiddleware(db, "basic", providersHandler()))
+	// The provider-selection list for the "add provider" dialog.
+	//
+	// ProviderConfigDialog.jsx has always called this, and there was no handler
+	// for it. Note what that actually meant: the path did NOT fall through to
+	// the single-page-app catch-all, because "/api/providers/" is registered as
+	// a subtree for universalTagsHandler — so the request was answered by the
+	// *tag* handler. The dialog assigned that response to state and crashed on
+	// "availableProviders.map is not a function", which reads as a React bug
+	// rather than a routing one.
+	//
+	// This must stay registered before/independent of that subtree: an exact
+	// pattern wins over a subtree in http.ServeMux, which is what makes this
+	// one line sufficient.
+	mux.Handle(prefix+"/api/providers/available", authMiddleware(db, "basic", availableProvidersHandler()))
 	mux.Handle(prefix+"/api/library/browse", authMiddleware(db, "basic", libraryBrowseHandler()))
 	mux.Handle(prefix+"/api/library/tags", authMiddleware(db, "basic", libraryTagsHandler(db)))
 	mux.Handle(prefix+"/api/library/scan", authMiddleware(db, "basic", libraryScanHandler(db)))
@@ -1115,6 +1129,25 @@ type Subtitle struct {
 	Language string `json:"language"`
 	Path     string `json:"path"`
 	Format   string `json:"format"`
+}
+
+// availableProvidersHandler returns every provider the system knows about, for
+// the UI's provider-selection list.
+//
+// Separate from providersHandler, which serves the same data on GET /api/providers
+// but also accepts POST to save configuration. The frontend asks for these at
+// different moments and the split keeps the selection list a plain read.
+func availableProvidersHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(getAvailableProviders()); err != nil {
+			http.Error(w, "Failed to encode providers", http.StatusInternalServerError)
+		}
+	})
 }
 
 // getAvailableProviders returns a slice of every provider known to the system


### PR DESCRIPTION
## The bug, stated correctly

`ProviderConfigDialog.jsx` has always called `/api/providers/available` and no handler was registered for it.

**But it did not return `index.html`.** `/api/providers/` is registered as a subtree for the *universal tag handler*, so an exact-match miss resolved there — the **tag handler answered a provider request**. The dialog assigned that to state and crashed on `availableProviders.map is not a function`, which reads as a React bug rather than a routing one.

I verified this by probing the mux on `origin/main`:

```
/api/providers/available  -> pattern "/api/providers/"      <- the tag subtree
/api/providers/status     -> pattern "/api/providers/status"
```

*(I initially described this as falling through to the SPA catch-all, in this branch and in #2223. That was wrong, and the difference matters — see below.)*

## The fix

A handler returning the list `getAvailableProviders()` already builds. An exact pattern beats a subtree in `http.ServeMux`, so registering it is sufficient — no reordering needed.

## Why the existing guard missed it

`route_coverage_test.go` checks a **hand-maintained** list of frontend paths. Nobody listed this one. A guard that depends on remembering isn't much of a guard — I said as much when I built it, and this is the proof.

**`TestDiscoveredFrontendPathsAreMounted`** now scans `webui/src` for `/api/...` literals and asserts each resolves to a route, so a new call to an unmounted endpoint fails without anyone updating a list. It self-checks (fails if the scan returns implausibly few paths, rather than passing vacuously) and skips `__tests__` and `mockApi.js` — a dev double whose `urlPath.includes('/api/library')` is a prefix match, not an endpoint.

## The limitation I'm not glossing over

**The new guard would not have caught this bug either.**

It asserts a path matches *some* pattern, not the *right* one — and this path matched a neighbouring subtree perfectly happily. I found that out by breaking the fix to check the test was non-vacuous: unmounting the route produced **no failure**. That's what led me back to the mux probe and the corrected diagnosis above.

So `TestAvailableProvidersReturnsAList` asserts the endpoint's actual behaviour — that a JSON array comes back — because routing alone provably cannot express it.

| Break | Result |
|---|---|
| unmount the route | ❌ **no failure** — the subtree absorbs it (this is the limitation) |
| make the scanner match nothing | ✅ fails — "only discovered 0 API paths… would pass vacuously" |
| endpoint returns a non-array | ✅ caught by the behavioural test |

Full suite green under `-race`.

## Conflicts

Touches `pkg/webserver/server.go`, which #2216 also modifies (an unrelated call site). Small, mechanical overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH