### PR TITLE
fix(test): give the scan poll a realistic budget

### DIFF
--- a/changelog.d/fix-flaky-scan-poll.md
+++ b/changelog.d/fix-flaky-scan-poll.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/fix-flaky-scan-poll.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6a91c73e-25b8-4f04-8d16-e3b7025fa9c1 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### Flaky scan-handler test under `-tags sqlite`
+
+`TestScanHandlers` polled for one second (ten 100ms ticks) and then declared
+"scan did not finish". The scan contacts subtitle providers over the network,
+so that ceiling was always tight; it tipped over once provider responses began
+being validated, because a stub answering `200` with junk no longer counts as a
+hit and the scan works through more providers before concluding.
+
+The symptom was misleading: it passed in isolation and failed in a full package
+run, which reads as cross-test pollution rather than a scan that needs more
+than a second. The poll now runs to a 30s deadline and still exits as soon as
+the scan reports itself finished, so the normal case is no slower.

--- a/pkg/webserver/server_test.go
+++ b/pkg/webserver/server_test.go
@@ -366,8 +366,17 @@ func TestScanHandlers(t *testing.T) {
 	if err != nil || resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("scan start: %v %d", err, resp.StatusCode)
 	}
-	// poll status until not running
-	for i := 0; i < 10; i++ {
+	// Poll until the scan reports itself finished.
+	//
+	// The budget is generous on purpose. The scan contacts subtitle providers
+	// over the network, and provider responses are now validated — a stub
+	// answering 200 with junk no longer counts as a hit, so the scan works
+	// through more providers before concluding rather than stopping at the
+	// first bogus success. The previous one-second ceiling was already tight
+	// and became a coin flip: this passed alone and failed in a full package
+	// run, which reads as cross-test pollution rather than a slow scan.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
 		time.Sleep(100 * time.Millisecond)
 		req2, _ := http.NewRequest("GET", srv.URL+"/api/scan/status", nil)
 		req2.Header.Set("X-API-Key", keyObj.GetId())


### PR DESCRIPTION
Main is red under `-tags sqlite`: `TestScanHandlers` reports "scan did not finish".

It polled for **one second** (ten 100ms ticks). The scan contacts subtitle providers over the network, so that ceiling was always tight — and it tipped over once provider responses began being validated, because a stub answering `200` with junk no longer counts as a hit and the scan works through more providers before concluding.

The symptom was misleading: it **passed in isolation and failed in a full package run**, which reads as cross-test pollution rather than a scan that needs more than a second. I bisected pairs before spotting that every pairing failed identically — the giveaway that it was duration, not interference.

The poll now runs to a 30s deadline and still exits as soon as the scan reports itself finished, so the passing case is no slower.

Both suites green: `go test -race ./...` and `-tags sqlite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kv3vTm1uBM6TwNvmUTHGH