### PR TITLE
fix(providers): accept subtitles in legacy non-UTF-8 encodings

### DIFF
--- a/changelog.d/fix-validate-legacy-encodings.md
+++ b/changelog.d/fix-validate-legacy-encodings.md
@@ -1,0 +1,20 @@
+### Fixed
+
+#### Stop discarding subtitles that are not encoded in UTF-8
+
+Provider response validation required the downloaded bytes to be valid UTF-8.
+Subtitles are routinely distributed in legacy single-byte codepages instead —
+Windows-1255 for Hebrew, 1251 for Cyrillic, 1252 for Western European — so
+every one of those was rejected as "not a subtitle".
+
+The loss was silent. A rejected response is recorded as a provider *failure*,
+so the search moved on to the next provider and nothing was written: a working
+provider serving a real subtitle was indistinguishable from a dead one.
+
+Validation now keys on structure rather than character encoding. The markers it
+looks for (`-->` for SRT/WebVTT, `[Script Info]`/`[Events]`/`Dialogue:` for
+SubStation Alpha) are pure ASCII and survive any 8-bit codepage intact, so
+coverage is unchanged; binary payloads are still rejected, now by a NUL-byte
+test rather than a UTF-8 validity test. Converting to UTF-8 remains
+`postprocess.EncodeUTF8`'s job, downstream of validation and gated on
+`postprocess.utf8_encoding` as before.

--- a/pkg/providers/validate.go
+++ b/pkg/providers/validate.go
@@ -1,14 +1,13 @@
 // file: pkg/providers/validate.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6bafd75-4871-464c-adce-fb0e0890cf03
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package providers
 
 import (
 	"bytes"
 	"errors"
-	"unicode/utf8"
 )
 
 // ErrNotSubtitle reports that a provider returned something that is not a
@@ -44,17 +43,31 @@ func looksLikeSubtitle(data []byte) bool {
 	if len(data) < minSubtitleBytes {
 		return false
 	}
-	// A subtitle is text. Binary payloads are archives that should already have
-	// been extracted, or error pages that happen to be long.
-	if !utf8.Valid(data) {
-		return false
-	}
-
 	// Only the head needs inspecting; markers appear early in every format.
 	head := data
 	if len(head) > 4096 {
 		head = head[:4096]
 	}
+
+	// A subtitle is text. Binary payloads are archives that should already have
+	// been extracted, or images an error page served instead.
+	//
+	// The test is a NUL byte, deliberately *not* utf8.Valid: subtitles are
+	// routinely distributed in legacy single-byte codepages rather than UTF-8
+	// — Windows-1255 for Hebrew, 1251 for Cyrillic, 1252 for Western European.
+	// Those bytes are invalid UTF-8, so a validity check discarded perfectly
+	// good subtitles as junk, and did so silently: the fetch was recorded as a
+	// provider failure, so the search moved on and the file was never written.
+	// Transcoding to UTF-8 is postprocess.EncodeUTF8's job, downstream of here.
+	//
+	// Rejecting on NUL costs nothing in coverage, because every marker below is
+	// pure ASCII and therefore survives any 8-bit codepage intact. UTF-16 text
+	// is excluded, but it always was: its markers are interleaved with NULs and
+	// never matched the byte comparisons either way.
+	if bytes.IndexByte(head, 0) >= 0 {
+		return false
+	}
+
 	lower := bytes.ToLower(head)
 
 	// SRT and WebVTT.

--- a/pkg/providers/validate_test.go
+++ b/pkg/providers/validate_test.go
@@ -1,7 +1,7 @@
 // file: pkg/providers/validate_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3e7d1b96-0c45-4a28-95f1-8b60e2a4c7d3
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package providers
 
@@ -82,5 +82,67 @@ func TestFetchRejectsNonSubtitleAndContinues(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "-->") {
 		t.Errorf("data = %q, want a real subtitle", data)
+	}
+}
+
+// hebrewCP1255SRT is the opening of a real subtitle downloaded from
+// wizdom.xyz. It is a valid SRT whose text is Hebrew encoded in Windows-1255,
+// so the bytes are *not* valid UTF-8 — the shape most of the world's
+// non-English subtitles actually arrive in.
+var hebrewCP1255SRT = []byte("1\r\n00:00:54,542 --> 00:00:59,323\r\n" +
+	"-\xe7\xe5\xee\xe5\xfa \xf9\xec \xfa\xf7\xe5\xe5\xe4-\r\n\r\n" +
+	"2\r\n00:00:59,671 --> 00:01:11,600\r\n" +
+	"\xf1\xe5\xf0\xeb\xf8\xef \xec\xe2\xe9\xf8\xf1\xe0 \xe6\xe0\xfa \xf2\"\xe9\r\n")
+
+// TestLooksLikeSubtitleAcceptsLegacyEncodings guards the rule that validation
+// keys on structure, not on character encoding.
+//
+// Requiring valid UTF-8 here silently discarded every subtitle distributed in
+// a legacy single-byte codepage — Windows-1255 Hebrew, 1251 Cyrillic, 1252
+// Western European. The loss was invisible: the fetch was recorded as a
+// provider failure and the search simply moved on to the next provider, so a
+// working provider looked like a dead one. Transcoding belongs downstream in
+// postprocess.EncodeUTF8; this function only decides "is this a subtitle".
+func TestLooksLikeSubtitleAcceptsLegacyEncodings(t *testing.T) {
+	// Windows-1252: "Ça va, mon frère?" — invalid UTF-8, unmistakably an SRT.
+	frenchCP1252 := []byte("1\n00:00:01,000 --> 00:00:02,000\n\xc7a va, mon fr\xe8re ?\n")
+	// Windows-1251 Cyrillic inside an ASS Dialogue line.
+	russianCP1251 := []byte("[Script Info]\nTitle: x\n\n[Events]\n" +
+		"Dialogue: 0,0:00:01.00,0:00:02.00,Default,,\xcf\xf0\xe8\xe2\xe5\xf2\n")
+
+	for name, in := range map[string][]byte{
+		"windows-1255 hebrew srt from wizdom": hebrewCP1255SRT,
+		"windows-1252 french srt":             frenchCP1252,
+		"windows-1251 russian ass":            russianCP1251,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !looksLikeSubtitle(in) {
+				t.Errorf("looksLikeSubtitle rejected a valid non-UTF-8 subtitle (% x...)", in[:16])
+			}
+		})
+	}
+}
+
+// TestLooksLikeSubtitleRejectsBinary pins the replacement for the UTF-8 check.
+// Dropping utf8.Valid must not let archives or images through: a ZIP that was
+// never extracted, or a PNG an error page served, would otherwise be written
+// next to the media as a subtitle.
+func TestLooksLikeSubtitleRejectsBinary(t *testing.T) {
+	// A ZIP local-file header whose stored name happens to contain "-->",
+	// so only the NUL check can reject it.
+	zipWithMarker := append([]byte("PK\x03\x04\x14\x00\x00\x00\x00\x00"),
+		[]byte("a-->b.srt\x00\x00\x00padding to clear the length floor")...)
+	png := append([]byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"),
+		[]byte("\x00\x00\x01\x00\x00\x00\x01\x00\x08\x06--> not a cue\x00\x00")...)
+
+	for name, in := range map[string][]byte{
+		"zip archive": zipWithMarker,
+		"png image":   png,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if looksLikeSubtitle(in) {
+				t.Errorf("looksLikeSubtitle accepted binary data (% x...)", in[:8])
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Provider response validation (`looksLikeSubtitle`) gated on `utf8.Valid(data)`.
Subtitles are routinely distributed in legacy single-byte codepages rather than
UTF-8 — Windows-1255 Hebrew, 1251 Cyrillic, 1252 Western European — so every
one of those was rejected as "not a subtitle".

## Why it mattered

The failure was silent, which is the worse half. A rejected response is recorded
as a provider **failure**, so the search moved on to the next provider and
nothing was written to disk. A working provider serving a genuine subtitle was
indistinguishable from a dead one.

## How

Validate on structure, not on character encoding. The markers already used
(`-->` for SRT/WebVTT, `[Script Info]` / `[Events]` / `Dialogue:` for
SubStation Alpha) are pure ASCII and survive any 8-bit codepage intact, so
coverage against junk is unchanged. Binary payloads are still rejected — now by
a NUL-byte test instead of a UTF-8 validity test.

UTF-16 text is excluded, but it always was: its markers are interleaved with
NULs and never matched the byte comparisons either way.

Transcoding to UTF-8 is unchanged and stays where it belongs — downstream in
`postprocess.EncodeUTF8`, gated on `postprocess.utf8_encoding`.

## Evidence

The Hebrew fixture in the test is the literal opening of a real subtitle
downloaded from `wizdom.xyz`, which is how the bug was found.

Both halves of the change were checked for non-vacuity by breaking them:

- restoring the `utf8.Valid` gate → `TestLooksLikeSubtitleAcceptsLegacyEncodings`
  fails on all three codepages
- removing the NUL guard → `TestLooksLikeSubtitleRejectsBinary` fails on both
  the ZIP and the PNG

`go build ./...` and `go test ./pkg/providers/... ./pkg/postprocess/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3