### PR TITLE
feat(subtitles): write downloads in the configured container format

### DIFF
--- a/changelog.d/feat-subtitle-format-conversion.md
+++ b/changelog.d/feat-subtitle-format-conversion.md
@@ -1,0 +1,35 @@
+### Added
+
+#### Write downloaded subtitles as WebVTT or ASS, not only SRT
+
+Downloads were always written as `.srt` regardless of what the provider sent or
+what the operator wanted. `subtitles.format` now selects the container —
+`srt` (default), `vtt` or `ass` — and applies to every subtitle the application
+writes: manual downloads, library scans and the monitoring loop all go through
+the same path.
+
+Details worth knowing:
+
+- **Format is detected from the bytes.** The download path has an anonymous
+  `[]byte` from a provider with no file name to go on, and astisub's readers
+  each require the format to be known before they are called, so a payload is
+  sniffed (`WEBVTT` signature, `[Script Info]`/`[V4+ Styles]` sections, or a
+  `-->` cue arrow) before being parsed.
+- **Payloads already in the target format are passed through untouched**
+  rather than parsed and re-serialised. A round trip through astisub is lossy
+  for anything it does not model, and there is no reason to pay that cost on
+  the default path.
+- **Bytes are normalised to UTF-8 before parsing.** A legacy-codepage payload
+  parsed as UTF-8 round-trips into mojibake that is then written into the new
+  container, where nothing downstream can tell it from correct text.
+- **A conversion failure falls back to SRT** and the output path is recomputed
+  to match, so a `.vtt` never holds SRT bytes and a subtitle astisub cannot
+  round-trip is still written rather than dropped.
+- **The "already downloaded" check follows the configured extension**, so
+  running with `vtt` does not re-download the whole library on every scan.
+
+`postprocess.EncodeUTF8` now delegates to `subtitles.EncodeUTF8`; the behaviour
+and the name callers use are unchanged.
+
+The setting is config-file only for now, matching its sibling
+`subtitles.single_language`, and the gRPC conversion path remains stubbed.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -110,7 +110,7 @@ effort — it is not fully achievable autonomously.
 | **Auto-sync after download** | ✅ | `postprocess.auto_sync` |
 | **Custom post-download script** | ✅ | `postprocess.custom_script` |
 | Custom post-processing script variables (score/provider) + threshold | ✅ | `SM_PROVIDER`/`SM_SCORE`; `postprocess.score_threshold` |
-| Format conversion on download (ASS/VTT) | 🟡 | astisub writer real but gRPC path stubbed; download emits `.srt` only |
+| Format conversion on download (ASS/VTT) | ✅ | `subtitles.format` (srt/vtt/ass) applied at the single write path — manual download, scan and monitor loop; falls back to SRT if a payload cannot be converted. Config-file only (like `subtitles.single_language`); gRPC path still stubbed |
 | Anti-captcha wired to providers | 🟡 | solver exists, never called (moot until providers are real) |
 | History retention/depth | ✅ | `history.retention_days` (`maintenance.PruneDownloadHistory`) |
 | Blacklist (per-subtitle) | ✅ | persisted w/ reason+expiry via `database.BlacklistStore` |

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -1,5 +1,5 @@
 <!-- file: docs/BAZARR_PARITY_STATUS.md -->
-<!-- version: 1.10.0 -->
+<!-- version: 1.11.0 -->
 <!-- guid: 2b9f4a1e-8c3d-4f76-9a05-1d7e6b2c4f88 -->
 <!-- last-edited: 2026-07-31 -->
 

--- a/pkg/postprocess/postprocess.go
+++ b/pkg/postprocess/postprocess.go
@@ -1,6 +1,7 @@
 // file: pkg/postprocess/postprocess.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e05a04c4-5ff1-4ed0-8c91-3b114e2a3d94
+// last-edited: 2026-07-31
 
 // Package postprocess implements the Bazarr-style post-processing pipeline that
 // runs on a subtitle after it is downloaded/written: UTF-8 re-encoding,

--- a/pkg/postprocess/postprocess.go
+++ b/pkg/postprocess/postprocess.go
@@ -23,33 +23,26 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"unicode/utf8"
 
 	"github.com/asticode/go-astisub"
 	"github.com/spf13/viper"
-	"golang.org/x/net/html/charset"
-	"golang.org/x/text/transform"
 
 	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
 	"github.com/jdfalk/subtitle-manager/pkg/syncer"
 )
-
-var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // EncodeUTF8 converts subtitle bytes to UTF-8. If the data is already valid
 // UTF-8 it is returned unchanged (minus any BOM). Otherwise the charset is
 // detected (e.g. Windows-1252, ISO-8859-1) and transcoded. On detection/decode
 // failure the original bytes are returned so a download is never lost.
+//
+// The implementation lives in pkg/subtitles because format conversion needs
+// the same normalisation and cannot import this package (postprocess already
+// depends on subtitles, not the other way round). This remains the name the
+// rest of the application calls.
 func EncodeUTF8(data []byte) []byte {
-	if utf8.Valid(data) {
-		return bytes.TrimPrefix(data, utf8BOM)
-	}
-	enc, _, _ := charset.DetermineEncoding(data, "")
-	out, _, err := transform.Bytes(enc.NewDecoder(), data)
-	if err != nil {
-		return data
-	}
-	return bytes.TrimPrefix(out, utf8BOM)
+	return subtitles.EncodeUTF8(data)
 }
 
 // EncodeUTF8IfEnabled applies EncodeUTF8 only when postprocess.utf8_encoding is

--- a/pkg/scanner/format_test.go
+++ b/pkg/scanner/format_test.go
@@ -1,0 +1,149 @@
+// file: pkg/scanner/format_test.go
+// version: 1.0.0
+// guid: 1f6b8043-3a29-4e57-9c8b-04d7e21a5f6c
+// last-edited: 2026-07-31
+
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asticode/go-astisub"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/mock"
+
+	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+)
+
+// srtFromProvider is what a provider hands back: SRT, regardless of what the
+// operator wants on disk.
+const srtFromProvider = "1\n00:00:01,000 --> 00:00:02,500\nFirst line\n\n" +
+	"2\n00:00:03,000 --> 00:00:04,500\nSecond line\n"
+
+// runProcessFile downloads srtFromProvider into a temp dir with
+// subtitles.format set to format, and returns the temp dir.
+func runProcessFile(t *testing.T, format string) string {
+	t.Helper()
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	if format != "" {
+		viper.Set("subtitles.format", format)
+	}
+	t.Cleanup(viper.Reset)
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte(srtFromProvider), nil)
+	if err := ProcessFile(context.Background(), vid, "en", "test", m, false, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	return dir
+}
+
+// TestProcessFileWritesConfiguredFormat is the end-to-end assertion.
+//
+// It checks the file name *and* re-parses the contents with the reader for
+// that format. Checking only the extension would pass even if SRT bytes were
+// written into a ".vtt" file — a file no player accepts, and exactly the kind
+// of quiet disagreement between two halves of the system that is invisible
+// until something is actually run.
+func TestProcessFileWritesConfiguredFormat(t *testing.T) {
+	for _, tc := range []struct {
+		format string
+		want   string
+		parse  func([]byte) (*astisub.Subtitles, error)
+	}{
+		{"", "movie.en.srt", func(b []byte) (*astisub.Subtitles, error) { return astisub.ReadFromSRT(bytes.NewReader(b)) }},
+		{"srt", "movie.en.srt", func(b []byte) (*astisub.Subtitles, error) { return astisub.ReadFromSRT(bytes.NewReader(b)) }},
+		{"vtt", "movie.en.vtt", func(b []byte) (*astisub.Subtitles, error) { return astisub.ReadFromWebVTT(bytes.NewReader(b)) }},
+		{"ass", "movie.en.ass", func(b []byte) (*astisub.Subtitles, error) { return astisub.ReadFromSSA(bytes.NewReader(b)) }},
+	} {
+		name := tc.format
+		if name == "" {
+			name = "unset(default)"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := runProcessFile(t, tc.format)
+
+			out := filepath.Join(dir, tc.want)
+			data, err := os.ReadFile(out)
+			if err != nil {
+				entries, _ := os.ReadDir(dir)
+				var names []string
+				for _, e := range entries {
+					names = append(names, e.Name())
+				}
+				t.Fatalf("expected %s; directory holds %v", tc.want, names)
+			}
+			sub, err := tc.parse(data)
+			if err != nil {
+				t.Fatalf("%s does not parse as %s: %v\n%s", tc.want, tc.format, err, data)
+			}
+			if len(sub.Items) != 2 {
+				t.Errorf("%s holds %d cues, want 2:\n%s", tc.want, len(sub.Items), data)
+			}
+		})
+	}
+}
+
+// TestProcessFileBadFormatFallsBackToSRT pins that a bad config entry does not
+// cost the download. Refusing to fetch subtitles because a preference string
+// is misspelled is the worse of the two failures.
+func TestProcessFileBadFormatFallsBackToSRT(t *testing.T) {
+	dir := runProcessFile(t, "definitely-not-a-format")
+	if _, err := os.Stat(filepath.Join(dir, "movie.en.srt")); err != nil {
+		entries, _ := os.ReadDir(dir)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected a fallback movie.en.srt; directory holds %v", names)
+	}
+}
+
+// TestProcessFileSkipsExistingInConfiguredFormat pins the "already have it"
+// check against the configured container.
+//
+// The check runs before the download, so it has to look for the extension the
+// operator actually uses. Looking for ".srt" while writing ".vtt" means every
+// scan re-downloads every subtitle it already has — no visible error, just a
+// provider hammered on every pass and an endlessly rewritten library.
+func TestProcessFileSkipsExistingInConfiguredFormat(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("subtitles.format", "vtt")
+	t.Cleanup(viper.Reset)
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	existing := filepath.Join(dir, "movie.en.vtt")
+	if err := os.WriteFile(existing, []byte("WEBVTT\n\nalready here\n"), 0644); err != nil {
+		t.Fatalf("create subtitle: %v", err)
+	}
+
+	// No Fetch expectation: reaching the provider at all is the failure.
+	m := providersmocks.NewMockProvider(t)
+	if err := ProcessFile(context.Background(), vid, "en", "test", m, false, nil); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	m.AssertExpectations(t)
+
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("read subtitle: %v", err)
+	}
+	if !bytes.Contains(data, []byte("already here")) {
+		t.Errorf("existing subtitle was overwritten: %q", data)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,6 +1,7 @@
 // file: pkg/scanner/scanner.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
+// last-edited: 2026-07-31
 package scanner
 
 import (

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -101,7 +101,8 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 
 	// Construct and validate the output path securely. When single-language
 	// naming is enabled the language code is omitted from the filename.
-	validatedOutputPath, err := security.ValidateSubtitleOutputPathWithOptions(path, lang, singleLanguageNaming())
+	outFormat := outputFormat()
+	validatedOutputPath, err := security.ValidateSubtitleOutputPathWithFormat(path, lang, singleLanguageNaming(), string(outFormat))
 	if err != nil {
 		logger.Warnf("invalid subtitle output path: %v", err)
 		return err
@@ -183,6 +184,22 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 	}
 	// Post-processing: optionally re-encode to UTF-8 before writing.
 	data = postprocess.EncodeUTF8IfEnabled(data)
+
+	// Convert into the configured container. A conversion that fails falls
+	// back to SRT, so the path is recomputed to match what is actually being
+	// written rather than what was asked for — a ".vtt" holding SRT bytes is
+	// exactly the kind of quiet disagreement that is invisible until a player
+	// refuses the file.
+	var wrote subtitleFormat
+	data, wrote = convertForOutput(data)
+	if wrote != outFormat {
+		validatedOutputPath, err = security.ValidateSubtitleOutputPathWithFormat(path, lang, singleLanguageNaming(), string(wrote))
+		if err != nil {
+			logger.Warnf("invalid subtitle output path: %v", err)
+			return err
+		}
+	}
+
 	if err := os.WriteFile(validatedOutputPath, data, 0644); err != nil {
 		logger.Warnf("write %s: %v", validatedOutputPath, err)
 
@@ -312,7 +329,12 @@ func ProcessFileWithProfile(ctx context.Context, path string, db *sql.DB, upgrad
 	}
 
 	// Construct and validate the output path securely using the actual language found
-	out, err := security.ValidateSubtitleOutputPathWithOptions(sanitizedPath, actualLang, singleLanguageNaming())
+	wantFormat := outputFormat()
+	data, wroteFormat := convertForOutput(data)
+	if wroteFormat != wantFormat {
+		logger.Debugf("falling back to %s for %s", wroteFormat, sanitizedPath)
+	}
+	out, err := security.ValidateSubtitleOutputPathWithFormat(sanitizedPath, actualLang, singleLanguageNaming(), string(wroteFormat))
 	if err != nil {
 		logger.Warnf("invalid subtitle output path: %v", err)
 		return err

--- a/pkg/scanner/scored.go
+++ b/pkg/scanner/scored.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/providers/opensubtitles"
 	"github.com/jdfalk/subtitle-manager/pkg/scoring"
@@ -34,7 +37,7 @@ func scoringEnabled() bool {
 // language code in the filename ("<base>.srt" rather than "<base>.<lang>.srt"),
 // matching Bazarr's single-language naming option.
 func singleLanguageNaming() bool {
-	return viper.GetBool("subtitles.single_language")
+	return subtitles.SingleLanguageNaming()
 }
 
 // scoredResult is a downloaded subtitle together with its computed score.
@@ -127,3 +130,40 @@ func priorMatchScore(store database.SubtitleStore, video, lang string) *float64 
 	}
 	return best
 }
+
+// outputFormat returns the container downloads are written as, from
+// "subtitles.format". An unset or unrecognised value falls back to SRT rather
+// than failing the download: a bad config entry should not stop subtitles from
+// being fetched, and SRT is what every existing installation already has.
+func outputFormat() subtitles.Format {
+	f, err := subtitles.ParseFormat(viper.GetString("subtitles.format"))
+	if err != nil {
+		logging.GetLogger("scanner").Warnf("%v; writing SRT instead", err)
+		return subtitles.DefaultFormat
+	}
+	return f
+}
+
+// convertForOutput re-encodes data into the configured container.
+//
+// A conversion failure returns the original bytes and the default format, so
+// a subtitle that astisub cannot round-trip is still written as the SRT it
+// already was rather than being dropped. Losing a working download to a
+// cosmetic preference is the worse outcome of the two.
+func convertForOutput(data []byte) ([]byte, subtitles.Format) {
+	want := outputFormat()
+	out, err := subtitles.Convert(data, want)
+	if err != nil {
+		logging.GetLogger("scanner").Warnf("convert to %s: %v; writing as-is", want, err)
+		return data, subtitles.DefaultFormat
+	}
+	return out, want
+}
+
+// subtitleFormat is a local alias so the write paths can name the format
+// without importing pkg/subtitles at every site.
+type subtitleFormat = subtitles.Format
+
+// OutputFormat reports the container downloads are written as, so callers
+// outside this package can name the file the scanner produced.
+func OutputFormat() subtitles.Format { return outputFormat() }

--- a/pkg/scanner/scored.go
+++ b/pkg/scanner/scored.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/scored.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9f2c8b41-6d0e-4a7c-b3f5-1e8a0c2d4b6a
-// last-edited: 2026-07-23
+// last-edited: 2026-07-31
 
 package scanner
 

--- a/pkg/security/formatpath_test.go
+++ b/pkg/security/formatpath_test.go
@@ -16,7 +16,7 @@ import (
 // allowlist. The value becomes a file-name suffix, so anything off the list
 // must be refused rather than sanitised into a path.
 func TestValidateSubtitleOutputPathWithFormatRejectsBadFormat(t *testing.T) {
-	dir := t.TempDir()
+	const dir = "/opt/media"
 	viper.Set("media_directory", dir)
 	defer viper.Reset()
 
@@ -40,18 +40,28 @@ func TestValidateSubtitleOutputPathWithFormatRejectsBadFormat(t *testing.T) {
 // CodeQL flags that call because it cannot see this constraint. Pinning it
 // here means the assumption breaks a test rather than breaking quietly.
 func TestValidateSubtitleOutputPathWithFormatConfinesPath(t *testing.T) {
-	dir := t.TempDir()
+	// A fixed path rather than t.TempDir(): ValidateAndSanitizePath
+	// unconditionally admits anything under os.TempDir(), so a temp-rooted
+	// media directory would not exercise the confinement being asserted here.
+	// See the note on that bypass in security.go.
+	const dir = "/opt/media"
 	viper.Set("media_directory", dir)
 	defer viper.Reset()
 
 	for _, escape := range []string{
 		dir + "/../../etc/passwd.mkv",
+		dir + "/../secrets/other.mkv",
 		"../../../../etc/shadow.mkv",
 		"/etc/passwd.mkv",
 	} {
 		got, err := ValidateSubtitleOutputPathWithFormat(escape, "en", false, "vtt")
-		if err == nil && !strings.HasPrefix(got, dir) {
-			t.Errorf("path escaped the sandbox: %q -> %q", escape, got)
+		if err == nil && !strings.HasPrefix(got, dir+"/") {
+			t.Errorf("path escaped the media directory: %q -> %q", escape, got)
 		}
+	}
+
+	// The in-bounds case must still work, or the test above passes vacuously.
+	if got, err := ValidateSubtitleOutputPathWithFormat(dir+"/movie.mkv", "en", false, "vtt"); err != nil || got != dir+"/movie.en.vtt" {
+		t.Errorf("in-bounds path rejected: %q, %v", got, err)
 	}
 }

--- a/pkg/security/formatpath_test.go
+++ b/pkg/security/formatpath_test.go
@@ -1,0 +1,57 @@
+// file: pkg/security/formatpath_test.go
+// version: 1.0.0
+// guid: 6d0a94f1-58c3-4e27-b91f-72e5c0846a3b
+// last-edited: 2026-07-31
+
+package security
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestValidateSubtitleOutputPathWithFormatRejectsBadFormat pins the format
+// allowlist. The value becomes a file-name suffix, so anything off the list
+// must be refused rather than sanitised into a path.
+func TestValidateSubtitleOutputPathWithFormatRejectsBadFormat(t *testing.T) {
+	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	video := dir + "/movie.mkv"
+	for _, bad := range []string{"../../etc/passwd", "srt/../../evil", "exe", "sub", "srt.exe"} {
+		if got, err := ValidateSubtitleOutputPathWithFormat(video, "en", false, bad); err == nil {
+			t.Errorf("format %q accepted, produced %q", bad, got)
+		}
+	}
+	for _, ok := range []string{"srt", "vtt", "ass", ".vtt", "VTT", ""} {
+		if _, err := ValidateSubtitleOutputPathWithFormat(video, "en", false, ok); err != nil {
+			t.Errorf("format %q rejected: %v", ok, err)
+		}
+	}
+}
+
+// TestValidateSubtitleOutputPathWithFormatConfinesPath pins that the video
+// path cannot escape the configured media directories.
+//
+// This is what makes the os.Stat in webserver.writtenSubtitlePath safe, and
+// CodeQL flags that call because it cannot see this constraint. Pinning it
+// here means the assumption breaks a test rather than breaking quietly.
+func TestValidateSubtitleOutputPathWithFormatConfinesPath(t *testing.T) {
+	dir := t.TempDir()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	for _, escape := range []string{
+		dir + "/../../etc/passwd.mkv",
+		"../../../../etc/shadow.mkv",
+		"/etc/passwd.mkv",
+	} {
+		got, err := ValidateSubtitleOutputPathWithFormat(escape, "en", false, "vtt")
+		if err == nil && !strings.HasPrefix(got, dir) {
+			t.Errorf("path escaped the sandbox: %q -> %q", escape, got)
+		}
+	}
+}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -281,6 +281,32 @@ func ValidateSubtitleOutputPath(videoPath, lang string) (string, error) {
 // in the download history. A single-language layout can only hold one subtitle
 // language per media file.
 func ValidateSubtitleOutputPathWithOptions(videoPath, lang string, singleLanguage bool) (string, error) {
+	return ValidateSubtitleOutputPathWithFormat(videoPath, lang, singleLanguage, "srt")
+}
+
+// ValidateSubtitleOutputPathWithFormat is ValidateSubtitleOutputPathWithOptions
+// with a caller-chosen container extension.
+//
+// ext reaches a file name joined onto a media directory, so it is checked
+// against an allowlist rather than sanitised: only the containers the
+// application can actually write are accepted, and anything else is an error.
+// Sanitising a caller-supplied path fragment invites the one case the filter
+// missed; refusing everything off a short list does not.
+func ValidateSubtitleOutputPathWithFormat(videoPath, lang string, singleLanguage bool, ext string) (string, error) {
+	switch strings.ToLower(strings.TrimPrefix(ext, ".")) {
+	case "srt", "vtt", "ass":
+		ext = strings.ToLower(strings.TrimPrefix(ext, "."))
+	case "":
+		ext = "srt"
+	default:
+		return "", fmt.Errorf("unsupported subtitle format: %s", ext)
+	}
+	return validateSubtitleOutputPath(videoPath, lang, singleLanguage, ext)
+}
+
+// validateSubtitleOutputPath builds and validates the output path. ext is
+// already known-good.
+func validateSubtitleOutputPath(videoPath, lang string, singleLanguage bool, ext string) (string, error) {
 	// Validate inputs
 	sanitizedVideoPath, err := ValidateAndSanitizePath(videoPath)
 	if err != nil {
@@ -301,9 +327,9 @@ func ValidateSubtitleOutputPathWithOptions(videoPath, lang string, singleLanguag
 		return "", fmt.Errorf("invalid characters in video filename")
 	}
 
-	name := base + "." + lang + ".srt"
+	name := base + "." + lang + "." + ext
 	if singleLanguage {
-		name = base + ".srt"
+		name = base + "." + ext
 	}
 	subtitlePath := filepath.Join(dir, name)
 	subtitlePath = filepath.Clean(subtitlePath)

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -1,6 +1,7 @@
 // file: pkg/security/security.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: efe90a08-389d-4157-a46e-8a57bfc1181a
+// last-edited: 2026-07-31
 package security
 
 import (

--- a/pkg/subtitles/format.go
+++ b/pkg/subtitles/format.go
@@ -1,0 +1,166 @@
+// file: pkg/subtitles/format.go
+// version: 1.0.0
+// guid: 7e51c9a3-2d84-4f60-b17c-8039e5a2461d
+// last-edited: 2026-07-31
+
+package subtitles
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/asticode/go-astisub"
+	"github.com/spf13/viper"
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/transform"
+)
+
+// Format identifies a subtitle container this application can write.
+type Format string
+
+// The formats a download may be written as.
+const (
+	FormatSRT Format = "srt"
+	FormatVTT Format = "vtt"
+	FormatASS Format = "ass"
+)
+
+// DefaultFormat is what a download is written as when nothing is configured.
+// SRT is the most widely supported container and is what every existing
+// installation already has on disk, so it stays the default.
+const DefaultFormat = FormatSRT
+
+// utf8BOM is stripped from decoded output.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// ParseFormat validates a caller-supplied format name.
+//
+// The result reaches a file name that is joined onto a media directory, so
+// this is an allowlist and unknown input is rejected rather than sanitised.
+// Sanitising a path fragment invites the one case the filter missed; refusing
+// anything not on a three-entry list does not.
+func ParseFormat(s string) (Format, error) {
+	switch f := Format(strings.ToLower(strings.TrimSpace(s))); f {
+	case "":
+		return DefaultFormat, nil
+	case FormatSRT, FormatVTT, FormatASS:
+		return f, nil
+	default:
+		return "", fmt.Errorf("unsupported subtitle format %q (want srt, vtt or ass)", s)
+	}
+}
+
+// Ext returns the file extension for f, leading dot included.
+func (f Format) Ext() string { return "." + string(f) }
+
+// EncodeUTF8 converts subtitle bytes to UTF-8. Data that is already valid
+// UTF-8 is returned unchanged, minus any BOM. Otherwise the charset is
+// detected (Windows-1252, ISO-8859-1 and friends) and transcoded. On a
+// detection or decode failure the original bytes are returned, so normalising
+// never loses a download.
+func EncodeUTF8(data []byte) []byte {
+	if utf8.Valid(data) {
+		return bytes.TrimPrefix(data, utf8BOM)
+	}
+	enc, _, _ := charset.DetermineEncoding(data, "")
+	out, _, err := transform.Bytes(enc.NewDecoder(), data)
+	if err != nil {
+		return data
+	}
+	return bytes.TrimPrefix(out, utf8BOM)
+}
+
+// DetectFormat identifies the container a subtitle payload is already in.
+//
+// Format is inferred from the bytes because the download path never has a file
+// name to go on: a provider hands back an anonymous []byte, and astisub's
+// readers each require the format to be known before they are called.
+func DetectFormat(data []byte) (Format, bool) {
+	head := data
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	lower := bytes.ToLower(bytes.TrimPrefix(head, utf8BOM))
+
+	// WebVTT is required to open with the WEBVTT signature.
+	if bytes.HasPrefix(bytes.TrimLeft(lower, " \t\r\n"), []byte("webvtt")) {
+		return FormatVTT, true
+	}
+	// SubStation Alpha carries section headers; both v4 and v4+ are read and
+	// written by astisub's SSA support.
+	if bytes.Contains(lower, []byte("[script info]")) ||
+		bytes.Contains(lower, []byte("[v4+ styles]")) ||
+		bytes.Contains(lower, []byte("[v4 styles]")) ||
+		bytes.Contains(lower, []byte("[events]")) {
+		return FormatASS, true
+	}
+	// Anything else with a cue arrow is SRT.
+	if bytes.Contains(head, []byte("-->")) {
+		return FormatSRT, true
+	}
+	return "", false
+}
+
+// Convert re-encodes a subtitle payload into want.
+//
+// Input that is already in the target format is returned untouched rather than
+// parsed and re-serialised. That is deliberate: a round trip through astisub
+// is lossy for anything it does not model — styling, positioning, unusual
+// cue metadata — and there is no reason to pay that cost on the default path,
+// where the requested format is the one the provider already sent.
+//
+// Bytes are normalised to UTF-8 first. Parsing has to happen on decoded text:
+// a Windows-1255 or 1252 payload fed to a parser expecting UTF-8 round-trips
+// into mojibake that is then written into the new container, where nothing
+// downstream can tell it from correctly converted text.
+func Convert(data []byte, want Format) ([]byte, error) {
+	if want == "" {
+		want = DefaultFormat
+	}
+	data = EncodeUTF8(data)
+
+	have, ok := DetectFormat(data)
+	if !ok {
+		return nil, fmt.Errorf("subtitles: unrecognised subtitle format")
+	}
+	if have == want {
+		return data, nil
+	}
+
+	var (
+		sub *astisub.Subtitles
+		err error
+	)
+	switch have {
+	case FormatSRT:
+		sub, err = astisub.ReadFromSRT(bytes.NewReader(data))
+	case FormatVTT:
+		sub, err = astisub.ReadFromWebVTT(bytes.NewReader(data))
+	case FormatASS:
+		sub, err = astisub.ReadFromSSA(bytes.NewReader(data))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("subtitles: read %s: %w", have, err)
+	}
+
+	buf := &bytes.Buffer{}
+	switch want {
+	case FormatSRT:
+		err = sub.WriteToSRT(buf)
+	case FormatVTT:
+		err = sub.WriteToWebVTT(buf)
+	case FormatASS:
+		err = sub.WriteToSSA(buf)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("subtitles: write %s: %w", want, err)
+	}
+	return buf.Bytes(), nil
+}
+
+// SingleLanguageNaming reports whether subtitles are written without the
+// language code in the file name ("<base>.srt" rather than
+// "<base>.<lang>.srt"), matching Bazarr's single-language naming option.
+func SingleLanguageNaming() bool { return viper.GetBool("subtitles.single_language") }

--- a/pkg/subtitles/format_test.go
+++ b/pkg/subtitles/format_test.go
@@ -1,0 +1,154 @@
+// file: pkg/subtitles/format_test.go
+// version: 1.0.0
+// guid: c8e2f45b-9037-41da-b6e8-2f0a71c5934e
+// last-edited: 2026-07-31
+
+package subtitles
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/asticode/go-astisub"
+)
+
+const srtSample = "1\n00:00:01,000 --> 00:00:02,500\nFirst line\n\n" +
+	"2\n00:00:03,000 --> 00:00:04,500\nSecond line\n"
+
+const vttSample = "WEBVTT\n\n00:00:01.000 --> 00:00:02.500\nFirst line\n\n" +
+	"00:00:03.000 --> 00:00:04.500\nSecond line\n"
+
+const assSample = "[Script Info]\nScriptType: v4.00+\n\n" +
+	"[V4+ Styles]\nFormat: Name\nStyle: Default\n\n" +
+	"[Events]\nFormat: Layer, Start, End, Style, Text\n" +
+	"Dialogue: 0,0:00:01.00,0:00:02.50,Default,First line\n" +
+	"Dialogue: 0,0:00:03.00,0:00:04.50,Default,Second line\n"
+
+// TestParseFormat pins the allowlist. The value reaches a file name joined
+// onto a media directory, so anything off the list must be an error rather
+// than something sanitised into a path.
+func TestParseFormat(t *testing.T) {
+	for in, want := range map[string]Format{
+		"srt": FormatSRT, "vtt": FormatVTT, "ass": FormatASS,
+		"SRT": FormatSRT, " vtt ": FormatVTT,
+		"": DefaultFormat,
+	} {
+		got, err := ParseFormat(in)
+		if err != nil || got != want {
+			t.Errorf("ParseFormat(%q) = %q, %v; want %q, nil", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"ssa/../../etc/passwd", "../../evil", "sub", "exe", "srt.exe", "."} {
+		if got, err := ParseFormat(bad); err == nil {
+			t.Errorf("ParseFormat(%q) = %q with no error; must be rejected", bad, got)
+		}
+	}
+}
+
+// TestDetectFormat pins the byte sniffer. It exists because the download path
+// has an anonymous []byte from a provider and no file name to infer from.
+func TestDetectFormat(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   string
+		want Format
+		ok   bool
+	}{
+		"srt":              {srtSample, FormatSRT, true},
+		"vtt":              {vttSample, FormatVTT, true},
+		"ass":              {assSample, FormatASS, true},
+		"vtt with bom":     {"\xef\xbb\xbf" + vttSample, FormatVTT, true},
+		"vtt beats arrows": {vttSample, FormatVTT, true},
+		"not a subtitle":   {"just some prose with no cues at all", "", false},
+		"empty":            {"", "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := DetectFormat([]byte(tc.in))
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("DetectFormat = %q,%v; want %q,%v", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestConvertProducesParseableOutput is the assertion that matters.
+//
+// It re-parses the output with the reader for the *target* format rather than
+// merely checking that a marker string appears. Writing SRT bytes into a file
+// named ".vtt" would satisfy any extension- or substring-level check while
+// producing a file no player accepts; only round-tripping through the target
+// reader catches that.
+func TestConvertProducesParseableOutput(t *testing.T) {
+	sources := map[Format]string{FormatSRT: srtSample, FormatVTT: vttSample, FormatASS: assSample}
+	readers := map[Format]func(*bytes.Reader) (*astisub.Subtitles, error){
+		FormatSRT: func(r *bytes.Reader) (*astisub.Subtitles, error) { return astisub.ReadFromSRT(r) },
+		FormatVTT: func(r *bytes.Reader) (*astisub.Subtitles, error) { return astisub.ReadFromWebVTT(r) },
+		FormatASS: func(r *bytes.Reader) (*astisub.Subtitles, error) { return astisub.ReadFromSSA(r) },
+	}
+
+	for from, src := range sources {
+		for to := range readers {
+			t.Run(string(from)+"->"+string(to), func(t *testing.T) {
+				out, err := Convert([]byte(src), to)
+				if err != nil {
+					t.Fatalf("convert: %v", err)
+				}
+				sub, err := readers[to](bytes.NewReader(out))
+				if err != nil {
+					t.Fatalf("output does not parse as %s: %v\n%s", to, err, out)
+				}
+				if len(sub.Items) != 2 {
+					t.Errorf("got %d cues, want 2 — conversion lost content:\n%s", len(sub.Items), out)
+				}
+				if got, _ := DetectFormat(out); got != to {
+					t.Errorf("output sniffs as %s, want %s", got, to)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertSameFormatIsUntouched pins the passthrough. Round-tripping
+// through astisub is lossy for styling it does not model, so the default path
+// — where the requested format is the one the provider already sent — must not
+// pay that cost.
+func TestConvertSameFormatIsUntouched(t *testing.T) {
+	out, err := Convert([]byte(srtSample), FormatSRT)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if string(out) != srtSample {
+		t.Errorf("same-format conversion rewrote the payload:\ngot  %q\nwant %q", out, srtSample)
+	}
+}
+
+// TestConvertNormalisesEncodingBeforeParsing pins the ordering.
+//
+// A legacy-codepage payload parsed as if it were UTF-8 round-trips into
+// mojibake that is then written into the new container, where nothing
+// downstream can distinguish it from correct text.
+func TestConvertNormalisesEncodingBeforeParsing(t *testing.T) {
+	// Windows-1252: "Ça va, mon frère ?" — invalid UTF-8.
+	legacy := []byte("1\n00:00:01,000 --> 00:00:02,500\n\xc7a va, mon fr\xe8re ?\n")
+
+	out, err := Convert(legacy, FormatVTT)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if !strings.Contains(string(out), "Ça va, mon frère ?") {
+		t.Errorf("text was not decoded before conversion: %q", out)
+	}
+	if _, err := astisub.ReadFromWebVTT(bytes.NewReader(out)); err != nil {
+		t.Errorf("output is not valid WebVTT: %v", err)
+	}
+}
+
+// TestConvertRejectsNonSubtitle pins that junk is an error rather than an
+// empty file written under a subtitle name.
+func TestConvertRejectsNonSubtitle(t *testing.T) {
+	for _, in := range []string{"OK", "<html><body>404</body></html>", ""} {
+		if out, err := Convert([]byte(in), FormatVTT); err == nil {
+			t.Errorf("Convert(%q) succeeded, returning %q", in, out)
+		}
+	}
+}

--- a/pkg/webserver/download.go
+++ b/pkg/webserver/download.go
@@ -1,6 +1,7 @@
 // file: pkg/webserver/download.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: d4467b2f-6653-4124-ab88-235fce8b0f77
+// last-edited: 2026-07-31
 
 package webserver
 

--- a/pkg/webserver/download.go
+++ b/pkg/webserver/download.go
@@ -136,8 +136,14 @@ func downloadHandler(db *sql.DB) http.Handler {
 			return
 		}
 
-		// Construct output path using validated inputs
-		out, outErr := security.ValidateSubtitleOutputPath(validatedPath, q.Lang)
+		// Construct output path using validated inputs.
+		//
+		// The extension depends on "subtitles.format", and the scanner falls
+		// back to SRT when a conversion fails — so resolve against what is
+		// actually on disk rather than reporting a .vtt that was never
+		// written. Reporting a file that does not exist is the same class of
+		// quiet disagreement this endpoint is meant to avoid.
+		out, outErr := writtenSubtitlePath(validatedPath, q.Lang)
 		if outErr != nil {
 			logger.WithFields(logrus.Fields{
 				"path":  validatedPath,

--- a/pkg/webserver/subtitlepath.go
+++ b/pkg/webserver/subtitlepath.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/subtitlepath.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: b30c5e94-1a76-4f28-8d51-6c02fa3719be
 // last-edited: 2026-07-31
 

--- a/pkg/webserver/subtitlepath.go
+++ b/pkg/webserver/subtitlepath.go
@@ -1,0 +1,47 @@
+// file: pkg/webserver/subtitlepath.go
+// version: 1.0.0
+// guid: b30c5e94-1a76-4f28-8d51-6c02fa3719be
+// last-edited: 2026-07-31
+
+package webserver
+
+import (
+	"os"
+
+	"github.com/jdfalk/subtitle-manager/pkg/scanner"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+	"github.com/jdfalk/subtitle-manager/pkg/subtitles"
+)
+
+// writtenSubtitlePath returns the subtitle file the scanner just wrote for
+// videoPath in lang.
+//
+// The extension follows "subtitles.format", but the scanner falls back to SRT
+// when a payload cannot be converted, so the configured format is a
+// preference rather than a guarantee. The configured path is preferred and
+// SRT is checked as a fallback; if neither exists the configured path is
+// returned so the caller still gets a sensible answer to report.
+func writtenSubtitlePath(videoPath, lang string) (string, error) {
+	format := scanner.OutputFormat()
+	single := subtitles.SingleLanguageNaming()
+
+	primary, err := security.ValidateSubtitleOutputPathWithFormat(videoPath, lang, single, string(format))
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(primary); statErr == nil {
+		return primary, nil
+	}
+	if format == subtitles.DefaultFormat {
+		return primary, nil
+	}
+
+	fallback, err := security.ValidateSubtitleOutputPathWithFormat(videoPath, lang, single, string(subtitles.DefaultFormat))
+	if err != nil {
+		return primary, nil
+	}
+	if _, statErr := os.Stat(fallback); statErr == nil {
+		return fallback, nil
+	}
+	return primary, nil
+}

--- a/pkg/webserver/subtitlepath.go
+++ b/pkg/webserver/subtitlepath.go
@@ -21,6 +21,16 @@ import (
 // preference rather than a guarantee. The configured path is preferred and
 // SRT is checked as a fallback; if neither exists the configured path is
 // returned so the caller still gets a sensible answer to report.
+//
+// CodeQL flags the os.Stat calls below as "uncontrolled data in a path
+// expression" because it cannot see through the validation. videoPath has
+// already passed security.ValidateAndSanitizePath, and
+// ValidateSubtitleOutputPathWithFormat re-validates the constructed path
+// against the allowed base directories and rejects the format outright unless
+// it is srt, vtt or ass. Both constraints are pinned by tests in pkg/security
+// (TestValidateSubtitleOutputPathWithFormatConfinesPath and
+// ...RejectsBadFormat), so the assumption breaks a test rather than breaking
+// quietly. The calls are read-only existence checks either way.
 func writtenSubtitlePath(videoPath, lang string) (string, error) {
 	format := scanner.OutputFormat()
 	single := subtitles.SingleLanguageNaming()


### PR DESCRIPTION
## What

Downloads were always written as `.srt`, regardless of what the provider sent
or what the operator wanted — the parity matrix's "format conversion on
download" gap. `subtitles.format` now selects the container: `srt` (default),
`vtt` or `ass`.

It applies at the single point every subtitle write goes through, so manual
`/api/download`, library scans and the monitoring loop all honour it.

## Design notes

**Format is sniffed from the bytes.** This is the constraint everything else
follows from: the download path holds an anonymous `[]byte` from a provider
with no file name, and astisub's readers (`ReadFromSRT` / `ReadFromWebVTT` /
`ReadFromSSA`) each require the input format to be known *before* they are
called. So a payload is detected by signature — `WEBVTT`, a
`[Script Info]`/`[V4+ Styles]` section, or a `-->` cue arrow — then parsed.

**Payloads already in the target format pass through untouched.** A round trip
through astisub is lossy for anything it does not model (styling, positioning,
unusual cue metadata), and there is no reason to pay that on the default path,
where the requested format is the one the provider already sent.

**UTF-8 normalisation happens before parsing.** A legacy-codepage payload
parsed as if it were UTF-8 round-trips into mojibake that then gets written
into the new container, where nothing downstream can distinguish it from
correctly converted text.

**Conversion failure falls back to SRT and recomputes the output path**, so a
`.vtt` never holds SRT bytes, and a subtitle astisub cannot round-trip is still
written rather than dropped. Losing a working download to a cosmetic preference
is the worse of the two failures.

**The "already downloaded" check uses the configured extension.** Without this,
running with `vtt` would look for `.srt`, find nothing, and re-download the
entire library on every scan — no error, just a provider hammered every pass.

**Format is validated against an allowlist, not sanitised.** The value reaches
a file name joined onto a media directory. `srt`/`vtt`/`ass` are accepted and
everything else is rejected; sanitising a caller-supplied path fragment invites
the one case the filter missed.

## Refactor

`postprocess.EncodeUTF8` now delegates to `subtitles.EncodeUTF8`. `postprocess`
already depends on `subtitles` and not the reverse, so the primitive belongs in
the lower package where conversion can also reach it. Behaviour and the name
callers use are unchanged.

## Verification

Tests assert on the **parsed structure** of the output, not on the file
extension or a substring — writing SRT bytes into a `.vtt` file would satisfy
any extension-level check while producing a file no player accepts.

- all 9 source→target combinations round-trip and re-parse with the *target*
  format's reader, with the cue count preserved
- `ProcessFile` end-to-end: for each of unset/`srt`/`vtt`/`ass`, the expected
  file name exists on disk **and** its contents parse with that format's reader

Non-vacuity, by breaking each behaviour and confirming the matching test fails:

| Broken | Test that failed |
|---|---|
| scanner skips conversion (SRT bytes into `.vtt`) | `TestProcessFileWritesConfiguredFormat` |
| exists-check ignores `subtitles.format` | `TestProcessFileSkipsExistingInConfiguredFormat` |
| `Convert` skips UTF-8 normalisation | `TestConvertNormalisesEncodingBeforeParsing` |
| `Convert` always re-serialises (no passthrough) | `TestConvertSameFormatIsUntouched` |

The first pass at the exists-check assertion was vacuous — the fallback
recompute masked it — which is what prompted adding that test specifically.

`go build ./...`, `go test -race ./...` and `go test -tags sqlite` on the
touched packages all pass.

## Scope

The setting is config-file only for now, matching its sibling
`subtitles.single_language`, which is also not surfaced in Settings. The gRPC
conversion path noted in the parity matrix remains stubbed; this is the HTTP
path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3