### PR TITLE
fix(webserver): key media profile assignments on the whole path

### DIFF
--- a/changelog.d/fix-media-profile-path-key.md
+++ b/changelog.d/fix-media-profile-path-key.md
@@ -1,0 +1,36 @@
+<!-- file: changelog.d/fix-media-profile-path-key.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5c8e1f42-9a37-4b6d-8e21-3f0d7a1c9b45 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+#### Per-item language profile assignments no longer collide
+
+Assigning a language profile to one media file reassigned it for every other
+file in the library.
+
+The web UI identifies a media item by its file path, percent-encoded into the
+URL: `PUT /api/media/profile/%2Fmedia%2FShow%2FS01E01.mkv`. `net/http` decodes
+the request target before a handler runs, so by then those `%2F` separators are
+indistinguishable from real ones, and the handler took only the *first* path
+segment as the identifier. Every file under `/media` therefore stored its
+assignment under the key `media`, and each new assignment overwrote the last.
+
+The handler now takes the whole remainder of the path as the identifier, via a
+new `pathRest` helper alongside the existing `pathSegment`. The identifier is
+also `filepath.Clean`ed before use: the CLI looks up the cleaned absolute path
+that `security.ValidateAndSanitizePath` returns, so without normalising here an
+assignment made in the UI would be invisible to
+`subtitle-manager profiles show <path>` and vice versa.
+
+Nothing caught this because every test used an identifier like `42` or
+`some-id`, which has no slash to split on. Two regression tests now assign
+profiles to two slash-bearing paths and assert they resolve independently, and
+assert that a key written through the handler is readable at the cleaned path
+the CLI uses.
+
+Any existing `media_profiles` row is keyed on a truncated segment and becomes
+unreachable after this change. Those rows recorded a collision rather than a
+usable assignment, so they are left in place rather than migrated; re-assign
+affected items in the UI.

--- a/pkg/webserver/basepath.go
+++ b/pkg/webserver/basepath.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/basepath.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: eb46ab64-f28e-4adb-9677-ac932a044fdd
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package webserver
 
@@ -96,4 +96,31 @@ func pathSegment(r *http.Request, route string) string {
 		return ""
 	}
 	return segs[0]
+}
+
+// pathRest returns everything following route as a single string, with the
+// base-URL prefix already removed and any leading slash preserved. It returns
+// "" when the request path does not lie under route or carries nothing after
+// it.
+//
+// # Why this is not pathSegment
+//
+// Some routes carry an identifier that is itself a filesystem path. The web UI
+// sends one percent-encoded — /api/media/profile/%2Fmedia%2FFilm.mkv — but
+// net/http decodes the request target before a handler sees it, so r.URL.Path
+// is "/api/media/profile//media/Film.mkv" and the %2F separators are
+// indistinguishable from real ones. pathSegment then splits on them and
+// returns "media", the first component, as the identifier.
+//
+// The effect is not a truncated key, it is a shared one: every media file
+// under /media collapses onto the same identifier, so assigning a language
+// profile to one episode silently reassigns it for the whole library. Every
+// test used an identifier like "42" or "some-id", which has no slashes to
+// split on, so nothing caught it.
+func pathRest(r *http.Request, route string) string {
+	p := apiPath(r)
+	if !strings.HasPrefix(p, route) {
+		return ""
+	}
+	return strings.TrimPrefix(p, route)
 }

--- a/pkg/webserver/basepath_test.go
+++ b/pkg/webserver/basepath_test.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/basepath_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d58f16de-9d4f-4e6b-8a95-8a3d53f5dbcd
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package webserver
 
@@ -84,6 +84,41 @@ func TestPathSegment(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			if got := pathSegment(r, tc.route); got != tc.want {
 				t.Errorf("pathSegment(%q) with base_url %q = %q, want %q",
+					tc.path, tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPathRest covers identifiers that are themselves paths, which pathSegment
+// silently truncates to their first component. The percent-encoded cases are
+// what the web UI actually sends; net/http decodes them before a handler runs,
+// so by then the encoded separators look exactly like real ones.
+func TestPathRest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		base, path, route, want string
+	}{
+		"plain id": {
+			"", "/api/media/profile/42", "/api/media/profile/", "42"},
+		"encoded absolute path": {
+			"", "/api/media/profile/%2Fmedia%2FShow%2FS01E01.mkv",
+			"/api/media/profile/", "/media/Show/S01E01.mkv"},
+		"encoded absolute path under a base url": {
+			"/sm", "/sm/api/media/profile/%2Fmedia%2FShow%2FS01E01.mkv",
+			"/api/media/profile/", "/media/Show/S01E01.mkv"},
+		"path with spaces": {
+			"", "/api/media/profile/%2Fmedia%2FThe%20Show.mkv",
+			"/api/media/profile/", "/media/The Show.mkv"},
+		"nothing after the route": {
+			"", "/api/media/profile/", "/api/media/profile/", ""},
+		"path outside the route": {
+			"/sm", "/sm/api/other/42", "/api/media/profile/", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			useBaseURL(t, tc.base)
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if got := pathRest(r, tc.route); got != tc.want {
+				t.Errorf("pathRest(%q) with base_url %q = %q, want %q",
 					tc.path, tc.base, got, tc.want)
 			}
 		})

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/profiles.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package webserver
 
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -246,7 +247,15 @@ func handleSetDefaultProfile(w http.ResponseWriter, r *http.Request, db *sql.DB,
 func mediaProfilesHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse URL path: /api/media/profile/{id}
-		mediaID := pathSegment(r, "/api/media/profile/")
+		//
+		// The identifier is a media file path, so it must be taken whole
+		// rather than as a first segment — see pathRest for what splitting
+		// it on slashes did. It is normalised the same way the CLI
+		// normalises the path it looks up (cmd/profiles.go runs it through
+		// security.ValidateAndSanitizePath, whose output is a cleaned
+		// absolute path), so an assignment made in the UI is readable from
+		// the CLI and vice versa.
+		mediaID := normalizeMediaID(pathRest(r, "/api/media/profile/"))
 		if mediaID == "" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
@@ -263,6 +272,27 @@ func mediaProfilesHandler(db *sql.DB) http.Handler {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	})
+}
+
+// normalizeMediaID canonicalises a media identifier so that the same file
+// yields the same storage key regardless of which entry point wrote it.
+//
+// Media identifiers are file paths, and the three entry points that touch them
+// each cleaned differently — the CLI via security.ValidateAndSanitizePath, the
+// scanner via filepath.Clean, the web handler not at all. Two spellings of one
+// path ("/media//Film.mkv", "/media/./Film.mkv") would therefore land on two
+// different rows, and a lookup from one entry point would miss what another
+// wrote. filepath.Clean is what ValidateAndSanitizePath returns for any path
+// it accepts, so cleaning here makes the web key agree with both others.
+//
+// Identifiers that are not paths pass through unchanged: Clean("42") is "42".
+// The empty identifier is preserved as empty rather than becoming Clean's ".",
+// so callers can still reject it.
+func normalizeMediaID(mediaID string) string {
+	if mediaID == "" {
+		return ""
+	}
+	return filepath.Clean(mediaID)
 }
 
 // handleGetMediaProfile returns the profile assigned to a media item.

--- a/pkg/webserver/profiles_test.go
+++ b/pkg/webserver/profiles_test.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/profiles_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1b0c9d8e-7f6e-2a3b-5c4d-8f7e9a0b1c2d
-// last-edited: 2026-07-25
+// last-edited: 2026-08-01
 
 package webserver
 
@@ -10,10 +10,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/jdfalk/subtitle-manager/pkg/database"
 	"github.com/jdfalk/subtitle-manager/pkg/profiles"
 	"github.com/spf13/viper"
 )
@@ -190,6 +192,141 @@ func TestMediaProfilesHandler(t *testing.T) {
 	if rr.Code >= 500 {
 		t.Errorf("unassigned media returned server error %d (body: %s)",
 			rr.Code, rr.Body.String())
+	}
+}
+
+// createTestProfile posts a profile through the collection handler and returns
+// its server-assigned ID.
+func createTestProfile(t *testing.T, name, lang string) string {
+	t.Helper()
+	body, err := json.Marshal(profiles.LanguageProfile{
+		Name:        name,
+		Languages:   []profiles.LanguageConfig{{Language: lang, Priority: 1}},
+		CutoffScore: 75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	profilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/api/profiles", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create profile %q: got %d (body: %s)", name, rr.Code, rr.Body.String())
+	}
+	var created profiles.LanguageProfile
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create profile %q: %v", name, err)
+	}
+	if created.ID == "" {
+		t.Fatalf("create profile %q: server returned no ID", name)
+	}
+	return created.ID
+}
+
+// mediaProfileURL builds the URL the web UI builds: the media file path,
+// percent-encoded whole, appended to the route.
+func mediaProfileURL(mediaPath string) string {
+	return "/api/media/profile/" + url.PathEscape(mediaPath)
+}
+
+// TestMediaProfilesHandlerDistinctPaths pins that two media files receive two
+// independent profile assignments.
+//
+// They did not. The UI sends the media file path as the identifier
+// (MediaDetails.jsx percent-encodes it), net/http decodes it before the
+// handler runs, and the handler took only the first path segment — so every
+// file under /media keyed as "media" and each assignment overwrote the last.
+// Assigning a profile to one episode silently reassigned the entire library.
+//
+// The bug survived because every other test here uses an identifier like "123"
+// or "some-id", which has no slash to split on. Only a slash-bearing path
+// exercises it.
+func TestMediaProfilesHandlerDistinctPaths(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	english := createTestProfile(t, "English", "en")
+	spanish := createTestProfile(t, "Spanish", "es")
+
+	const (
+		ep1 = "/media/Show/Show.S01E01.mkv"
+		ep2 = "/media/Show/Show.S01E02.mkv"
+	)
+
+	handler := mediaProfilesHandler(nil)
+
+	assign := func(mediaPath, profileID string) {
+		t.Helper()
+		body := bytes.NewReader([]byte(`{"profile_id":"` + profileID + `"}`))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPut, mediaProfileURL(mediaPath), body))
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("assign %s: got %d (body: %s)", mediaPath, rr.Code, rr.Body.String())
+		}
+	}
+
+	assigned := func(mediaPath string) profiles.LanguageProfile {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, mediaProfileURL(mediaPath), nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("get %s: got %d (body: %s)", mediaPath, rr.Code, rr.Body.String())
+		}
+		var got profiles.LanguageProfile
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("get %s: %v (body: %s)", mediaPath, err, rr.Body.String())
+		}
+		return got
+	}
+
+	assign(ep1, english)
+	assign(ep2, spanish)
+
+	if got := assigned(ep1); got.ID != english {
+		t.Errorf("%s resolved to profile %q (%s), want English (%s) — the second "+
+			"assignment overwrote the first, so both files share one key",
+			ep1, got.Name, got.ID, english)
+	}
+	if got := assigned(ep2); got.ID != spanish {
+		t.Errorf("%s resolved to profile %q (%s), want Spanish (%s)",
+			ep2, got.Name, got.ID, spanish)
+	}
+}
+
+// TestMediaProfilesHandlerKeyMatchesCLI pins that the key the handler stores is
+// the media path itself, normalised the way the CLI normalises it, so a UI
+// assignment is visible to `subtitle-manager profiles show <path>` and vice
+// versa. Storing a raw, uncleaned path would be invisible to the CLI, which
+// looks up security.ValidateAndSanitizePath's cleaned output.
+func TestMediaProfilesHandlerKeyMatchesCLI(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	english := createTestProfile(t, "English", "en")
+	handler := mediaProfilesHandler(nil)
+
+	// Assign through an uncleaned spelling of the path...
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPut,
+		mediaProfileURL("/media/Show/../Show/Show.S01E01.mkv"),
+		bytes.NewReader([]byte(`{"profile_id":"`+english+`"}`))))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("assign: got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	// ...and read it back through the cleaned one the CLI would use.
+	store, err := database.GetSharedStore()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	got, err := store.GetMediaProfile("/media/Show/Show.S01E01.mkv")
+	if err != nil {
+		t.Fatalf("lookup by cleaned path: %v", err)
+	}
+	if got.ID != english {
+		t.Errorf("cleaned path resolved to profile %q (%s), want English (%s) — "+
+			"the handler stored an unnormalised key the CLI cannot find",
+			got.Name, got.ID, english)
 	}
 }
 


### PR DESCRIPTION
## What was wrong

Assigning a language profile to one media file reassigned it for **every** file in the library.

The web UI identifies a media item by its file path, percent-encoded into the URL:

```
PUT /api/media/profile/%2Fmedia%2FShow%2FShow.S01E01.mkv
```

`net/http` percent-decodes the request target before a handler runs, so by the time `mediaProfilesHandler` sees it, `r.URL.Path` is `/api/media/profile//media/Show/Show.S01E01.mkv` and the `%2F` separators are indistinguishable from real ones. The handler used `pathSegment`, which returns the **first** segment — so every file under `/media` stored its assignment under the key `media`, and each new assignment overwrote the last.

Confirmed against a running instance before fixing: assigning ProbeB to episode 2 made episode 1 read back as ProbeB.

## The fix

- New `pathRest(r, route)` helper alongside `pathSegment`, returning the whole remainder of the path with the base-URL prefix stripped and the leading slash preserved.
- `normalizeMediaID` runs `filepath.Clean` on the identifier. This half matters as much as the first: the CLI (`subtitle-manager profiles show <path>`) looks up the cleaned absolute path that `security.ValidateAndSanitizePath` returns, so an unnormalised key written by the UI would be invisible to the CLI and vice versa. Non-path identifiers pass through unchanged (`Clean("42") == "42"`); the empty identifier stays empty so it can still be rejected with 400.

## Why nothing caught it

Every existing test used an identifier like `42`, `123` or `some-id` — none has a slash to split on. That is the entire reason this survived. The new tests use slash-bearing paths:

- `TestMediaProfilesHandlerDistinctPaths` — two episodes get two profiles, asserts they resolve independently.
- `TestMediaProfilesHandlerKeyMatchesCLI` — assigns via an uncleaned spelling, reads back at the cleaned path the CLI uses.
- `TestPathRest` — table cases for percent-encoded paths, with and without `base_url`, including spaces.

**Non-vacuity check:** reverted the handler to the old `pathSegment` call and confirmed both new handler tests fail with the collision, then restored.

## Verification

- `go build ./...`, `go test -race ./...` — clean.
- `go test -tags sqlite ./pkg/webserver/... ./pkg/database/... ./pkg/profiles/...` — clean. (CI does not build this tag.)
- Live: built with `-tags sqlite`, ran a throwaway instance, assigned two profiles to two episodes and read both back correctly; a sibling under the same first segment correctly falls through to the default. A first attempt at this was invalidated by an orphaned binary already holding the port — the reported run is one where the listening PID was confirmed to be mine.

## Decisions worth disagreeing with

- **Normalisation is `filepath.Clean`, not `security.ValidateAndSanitizePath`.** Using the latter would also reject paths outside `allowed_base_dirs`, changing a keying fix into a security-policy change and breaking assignment for media outside the configured roots. `Clean` is exactly what `ValidateAndSanitizePath` returns for any path it accepts, so the keys agree without the added rejection.
- **Existing rows are not migrated.** Any `media_profiles` row written before this change is keyed on a truncated segment and becomes unreachable. Those rows recorded a collision rather than a usable assignment, so migrating them would propagate wrong data. Affected items need re-assigning in the UI.

## Related findings, not fixed here

Recorded for follow-up rather than bundled in:

1. **Profile assignments are write-only.** There are two `media_profiles` implementations sharing a table name. The UI and CLI write path-keyed rows through `database.SubtitleStore`; the download path (`pkg/providers/profiles.go` → `pkg/profiles.Service`) reads integer-keyed rows out of a raw `*sql.DB`, resolving `media_items.path → id` first. Different key, and under pebble/postgres a different database. Separately, `scanner.ProcessFileWithProfile` has no non-test callers — every real download path (web scan, monitor, watcher, webhooks, scheduler, *arr) calls `scanner.ProcessFile` with a single language. So even with this PR, an assigned profile never influences a download.
2. **The last language profile cannot be deleted.** With no profile explicitly marked default, `GetDefaultLanguageProfile` returns the first profile in the list, and `handleDeleteProfile` refuses to delete the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3