### PR TITLE
fix(scanner): honor assigned language profiles during library scans

### DIFF
--- a/changelog.d/feat-wire-profiles-to-scan.md
+++ b/changelog.d/feat-wire-profiles-to-scan.md
@@ -1,0 +1,62 @@
+<!-- file: changelog.d/feat-wire-profiles-to-scan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c1e94a05-3b72-4d68-8f31-5a06e2c7b943 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+#### Library scans now honor an assigned language profile
+
+Assigning a language profile to a media item had no effect on what was
+downloaded. Nothing read the assignment at download time: the web UI and CLI
+write path-keyed rows through `database.SubtitleStore`, while the only code
+that consumed a profile (`pkg/profiles.Service`, reached from
+`providers.FetchWithProfile`) read integer-keyed rows out of a raw `*sql.DB`
+after resolving `media_items.path → id` — under the pebble or postgres backends
+not even the same database. Separately, `scanner.ProcessFileWithProfile` had no
+callers at all; every download path called `scanner.ProcessFile` with a single
+language.
+
+A library scan now checks each video file for an assigned profile and, when it
+has one, downloads every language that profile asks for in priority order
+instead of the single language the scan was started with. Resolution goes
+through the same store and the same `filepath.Clean`-ed path key the web
+handler writes.
+
+`ProcessFileWithProfile` was rewritten to delegate to `ProcessFile` once per
+language rather than fetching and writing inline. Its old implementation
+bypassed score gating, the Whisper fallback, UTF-8 re-encoding, chmod,
+auto-sync, the custom post-download script, the *arr rescan event and
+download-history persistence — everything the ordinary download path does
+around the fetch.
+
+Scope is deliberately limited to user-initiated library scans. The monitor
+loop, watcher, webhooks, scheduler and Sonarr/Radarr paths still download a
+single language, because `MonitoredItem.Languages` is a second, independent
+desired-languages mechanism and deciding which one wins is a product decision
+rather than a bug fix.
+
+Three behaviours worth knowing:
+
+- A file whose profile resolves to the *default* profile is treated as
+  unassigned. `GetMediaProfile` falls back to the default rather than reporting
+  a miss, so honouring that would silently switch every file in the library to
+  profile-driven downloading as soon as any default existed. The consequence is
+  real rather than cosmetic: a file explicitly assigned the default profile is
+  indistinguishable from an unassigned one and is scanned with the scan's own
+  language, not that profile's language list. Telling the two apart needs a
+  store method reporting whether an assignment row exists, separate from which
+  profile governs the file. Until then, assign a non-default profile to get
+  profile-driven languages.
+- With `subtitles.single_language` enabled, only the highest-priority language
+  is fetched, since every language would otherwise write to the same
+  `video.srt` and overwrite the last.
+- Scanning never creates a profile as a side effect. `PebbleStore`'s
+  `GetDefaultLanguageProfile` *writes* a profile with ID `default` when the
+  store is empty, and `GetMediaProfile` falls back to it on a miss — so
+  consulting profiles per file would have made a first scan on a fresh install
+  conjure a profile row that then cannot be deleted (`handleDeleteProfile`
+  refuses to remove the default). Profile resolution is skipped entirely when
+  no profiles exist, and the default is identified by reading the list rather
+  than through `GetDefaultLanguageProfile`. That also makes the behaviour
+  identical on `SQLStore`, which neither falls back nor creates.

--- a/pkg/scanner/profile.go
+++ b/pkg/scanner/profile.go
@@ -1,0 +1,168 @@
+// file: pkg/scanner/profile.go
+// version: 1.0.0
+// guid: 4f7c2a91-8d05-4e63-b7a2-90c1e5d3846b
+// last-edited: 2026-08-01
+
+package scanner
+
+import (
+	"context"
+	"sort"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/providers"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+)
+
+// defaultProfileID returns the ID of the profile marked default (or "" when
+// none is) and whether any profiles exist at all.
+//
+// It reads the list and looks for the flag rather than calling
+// GetDefaultLanguageProfile, which the backends disagree about: PebbleStore
+// falls back to the first profile when none is flagged and *writes a new
+// "default" profile* when the store is empty, while SQLStore strictly requires
+// is_default and reports a miss. A scan must not create rows as a side effect
+// of looking something up — especially not a profile that then cannot be
+// deleted — and it must behave the same on either backend.
+//
+// The "any profiles at all" answer matters for the same reason: GetMediaProfile
+// itself falls back to GetDefaultLanguageProfile on a miss, so on an empty
+// store even a plain lookup would create the row. Callers skip profile
+// resolution entirely when there are none.
+func defaultProfileID(store database.SubtitleStore) (string, bool) {
+	list, err := store.ListLanguageProfiles()
+	if err != nil || len(list) == 0 {
+		return "", false
+	}
+	for _, p := range list {
+		if p.IsDefault {
+			return p.ID, true
+		}
+	}
+	return "", true
+}
+
+// assignedProfileLanguages returns the language codes a media file's assigned
+// language profile asks for, highest priority first, and whether the file has
+// an assignment at all. defaultID is the ID from defaultProfileID, hoisted out
+// of the caller's per-file loop.
+//
+// # Why "assigned" is not the same as "has a profile"
+//
+// GetMediaProfile falls back to the default profile when a file has no
+// assignment of its own, so it never reports a miss. That is the right answer
+// for "which profile governs this file", but the wrong one for deciding
+// whether to change how a scan behaves: it would silently switch every file in
+// the library to profile-driven downloading the moment any default exists.
+//
+// A file is therefore treated as assigned only when the profile it resolves to
+// is not the default one.
+//
+// This has a real consequence, not a cosmetic one: a file the user explicitly
+// assigned the *default* profile is indistinguishable from an unassigned file,
+// and will be scanned with the scan's own language rather than that profile's
+// language list. Telling the two apart needs a store method that reports
+// whether a row exists, separate from which profile governs the file. Until
+// then, assigning a non-default profile is the way to get profile-driven
+// languages.
+//
+// The lookup uses the *sanitized* path. ProcessFile sanitizes before doing
+// anything, and the web handler stores a filepath.Clean-ed key, so looking up
+// a raw path here would miss what the UI wrote — the same key disagreement
+// that made per-item assignment collide before.
+func assignedProfileLanguages(path string, store database.SubtitleStore, defaultID string) ([]string, bool) {
+	logger := logging.GetLogger("scanner")
+
+	if store == nil {
+		var err error
+		store, err = database.GetSharedStore()
+		if err != nil {
+			logger.Debugf("no store for profile lookup: %v", err)
+			return nil, false
+		}
+	}
+
+	sanitized, err := security.ValidateAndSanitizePath(path)
+	if err != nil {
+		return nil, false
+	}
+
+	profile, err := store.GetMediaProfile(sanitized)
+	if err != nil || profile == nil {
+		return nil, false
+	}
+
+	// A resolved profile that is merely the default means "no assignment".
+	if defaultID != "" && profile.ID == defaultID {
+		return nil, false
+	}
+
+	ordered := make([]struct {
+		code     string
+		priority int
+	}, 0, len(profile.Languages))
+	for _, l := range profile.Languages {
+		if l.Language == "" {
+			continue
+		}
+		ordered = append(ordered, struct {
+			code     string
+			priority int
+		}{l.Language, l.Priority})
+	}
+	if len(ordered) == 0 {
+		return nil, false
+	}
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].priority < ordered[j].priority })
+
+	codes := make([]string, 0, len(ordered))
+	for _, o := range ordered {
+		codes = append(codes, o.code)
+	}
+
+	// Single-language naming writes every language to the same <video>.srt, so
+	// fetching more than one would have each overwrite the last and leave only
+	// whichever finished second. Honour the highest-priority language alone.
+	if singleLanguageNaming() && len(codes) > 1 {
+		logger.Debugf("single-language naming: %s limited to %s of %d profile languages",
+			sanitized, codes[0], len(codes))
+		codes = codes[:1]
+	}
+
+	return codes, true
+}
+
+// processWithAssignedProfile downloads every language the file's assigned
+// profile asks for, in priority order, through the ordinary ProcessFile
+// pipeline — so scoring, the Whisper fallback, post-processing, format
+// conversion and download-history persistence all apply exactly as they do to
+// a single-language download. The provider selection the scan was started with
+// is carried through unchanged — only the language varies per iteration.
+//
+// Every language is attempted even if an earlier one fails: a profile lists
+// languages that are all wanted, not alternatives to each other. The call
+// succeeds if any language was obtained, and reports the first failure only
+// when none were.
+func processWithAssignedProfile(ctx context.Context, path string, langs []string,
+	providerName string, p providers.Provider, upgrade bool, store database.SubtitleStore) error {
+	logger := logging.GetLogger("scanner")
+
+	var firstErr error
+	got := 0
+	for _, lang := range langs {
+		if err := ProcessFile(ctx, path, lang, providerName, p, upgrade, store); err != nil {
+			logger.Debugf("profile language %s for %s: %v", lang, path, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		got++
+	}
+
+	if got > 0 {
+		return nil
+	}
+	return firstErr
+}

--- a/pkg/scanner/profile_test.go
+++ b/pkg/scanner/profile_test.go
@@ -1,0 +1,230 @@
+// file: pkg/scanner/profile_test.go
+// version: 1.0.0
+// guid: 9e2b6c74-51af-4d38-a0e6-7b3c8f1d20a5
+// last-edited: 2026-08-01
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
+	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+)
+
+// profileTestStore opens a throwaway Pebble store. Pebble is used rather than
+// SQLite so these tests run without the sqlite build tag, which CI does not
+// set.
+func profileTestStore(t *testing.T) database.SubtitleStore {
+	t.Helper()
+	store, err := database.OpenStore(filepath.Join(t.TempDir(), "db"), "pebble")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// newProfile stores a language profile and returns its ID.
+func newProfile(t *testing.T, store database.SubtitleStore, name string, isDefault bool, langs ...profiles.LanguageConfig) string {
+	t.Helper()
+	id := name + "-id"
+	if err := store.CreateLanguageProfile(&database.LanguageProfile{
+		ID:          id,
+		Name:        name,
+		Languages:   langs,
+		CutoffScore: 75,
+		IsDefault:   isDefault,
+	}); err != nil {
+		t.Fatalf("create profile %s: %v", name, err)
+	}
+	if isDefault {
+		if err := store.SetDefaultLanguageProfile(id); err != nil {
+			t.Fatalf("set default %s: %v", name, err)
+		}
+	}
+	return id
+}
+
+// TestScanUsesAssignedProfileLanguages is the point of the whole change: a file
+// with its own language profile must be downloaded for the languages that
+// profile asks for, in priority order, instead of the single language the scan
+// was started with.
+//
+// Before this, no download path consulted a profile at all — ProcessFile was
+// always called with one language, and scanner.ProcessFileWithProfile (which
+// did iterate a profile) had no callers and read its assignment from a
+// different database under a different key.
+func TestScanUsesAssignedProfileLanguages(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	newProfile(t, store, "default", true,
+		profiles.LanguageConfig{Language: "en", Priority: 1})
+	assigned := newProfile(t, store, "assigned", false,
+		profiles.LanguageConfig{Language: "fr", Priority: 2},
+		profiles.LanguageConfig{Language: "es", Priority: 1})
+
+	if err := store.AssignProfileToMedia(vid, assigned); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+
+	// The scan is started with "en". The profile asks for es then fr, so those
+	// are what the provider must be asked for — and "en" must not be.
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "es").Return([]byte("es-sub"), nil).Once()
+	m.On("Fetch", mock.Anything, mock.Anything, "fr").Return([]byte("fr-sub"), nil).Once()
+
+	if err := ScanDirectoryProgress(context.Background(), dir, "en", "test", m, false, 1, store, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	m.AssertExpectations(t)
+
+	for _, lang := range []string{"es", "fr"} {
+		if _, err := os.Stat(filepath.Join(dir, "movie."+lang+".srt")); err != nil {
+			t.Errorf("no %s subtitle written: %v", lang, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "movie.en.srt")); err == nil {
+		t.Error("wrote an en subtitle: the scan language was used despite an assigned profile")
+	}
+}
+
+// TestScanIgnoresDefaultProfile pins that an unassigned file is left alone.
+//
+// GetMediaProfile falls back to the default profile rather than reporting a
+// miss, so treating any resolved profile as an assignment would silently
+// switch every file in the library to profile-driven downloading the moment a
+// default existed. That is a behaviour change nobody asked for.
+func TestScanIgnoresDefaultProfile(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	newProfile(t, store, "default", true,
+		profiles.LanguageConfig{Language: "de", Priority: 1})
+
+	// No assignment for vid. The scan language must win, not the default
+	// profile's "de".
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("en-sub"), nil).Once()
+
+	if err := ScanDirectoryProgress(context.Background(), dir, "en", "test", m, false, 1, store, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	m.AssertExpectations(t)
+}
+
+// TestAssignedProfileLanguagesOrdersByPriority covers the ordering and the
+// single-language-naming interaction directly.
+func TestAssignedProfileLanguagesOrdersByPriority(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	newProfile(t, store, "default", true, profiles.LanguageConfig{Language: "en", Priority: 1})
+	assigned := newProfile(t, store, "assigned", false,
+		profiles.LanguageConfig{Language: "fr", Priority: 3},
+		profiles.LanguageConfig{Language: "es", Priority: 1},
+		profiles.LanguageConfig{Language: "de", Priority: 2})
+	if err := store.AssignProfileToMedia(vid, assigned); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+
+	got, ok := assignedProfileLanguagesForTest(vid, store)
+	if !ok {
+		t.Fatal("assignment not seen")
+	}
+	want := []string{"es", "de", "fr"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (priority order not honoured)", got, want)
+		}
+	}
+
+	// Single-language naming writes every language to the same file, so only
+	// the highest-priority one is fetched.
+	viper.Set("subtitles.single_language", true)
+	got, ok = assignedProfileLanguagesForTest(vid, store)
+	if !ok {
+		t.Fatal("assignment not seen with single-language naming")
+	}
+	if len(got) != 1 || got[0] != "es" {
+		t.Errorf("got %v with single-language naming, want [es]: every language "+
+			"would otherwise write to the same file and overwrite the last", got)
+	}
+}
+
+// TestScanCreatesNoProfileRows pins that scanning a library with no profiles
+// configured leaves the profile table empty.
+//
+// PebbleStore.GetDefaultLanguageProfile *writes* a new profile with ID
+// "default" when the store is empty. Because a scan now consults profiles per
+// file, calling it would mean a first scan on a fresh install silently
+// conjures a profile row — one that cannot then be deleted, since
+// handleDeleteProfile refuses to remove the default. defaultProfileID reads
+// the list instead, which also makes the behaviour identical on SQLStore,
+// where GetDefaultLanguageProfile does not fall back or create.
+func TestScanCreatesNoProfileRows(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("en-sub"), nil).Once()
+
+	if err := ScanDirectoryProgress(context.Background(), dir, "en", "test", m, false, 1, store, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	list, err := store.ListLanguageProfiles()
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	if len(list) != 0 {
+		names := make([]string, 0, len(list))
+		for _, p := range list {
+			names = append(names, p.ID+"/"+p.Name)
+		}
+		t.Errorf("scanning created %d profile(s) %v; a lookup must not write rows", len(list), names)
+	}
+}
+
+// assignedProfileLanguagesForTest resolves the default once and calls through,
+// mirroring what the scan loop does.
+func assignedProfileLanguagesForTest(path string, store database.SubtitleStore) ([]string, bool) {
+	id, _ := defaultProfileID(store)
+	return assignedProfileLanguages(path, store, id)
+}

--- a/pkg/scanner/progress.go
+++ b/pkg/scanner/progress.go
@@ -1,6 +1,7 @@
 // file: pkg/scanner/progress.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 30d76902-4260-48c3-8dbb-acbbdc9bcea7
+// last-edited: 2026-08-01
 package scanner
 
 import (
@@ -30,6 +31,17 @@ func ScanDirectoryProgress(ctx context.Context, dir, lang, providerName string,
 		logger.Warnf("invalid path: %v", err)
 		return err
 	}
+	// Resolved once: the default profile is the same for every file, and
+	// looking it up per file would mean a second full profile-list scan per
+	// file per worker.
+	var (
+		defaultID       string
+		profilesDefined bool
+	)
+	if store != nil {
+		defaultID, profilesDefined = defaultProfileID(store)
+	}
+
 	work := pool.New().WithErrors().WithMaxGoroutines(workers)
 	err = filepath.WalkDir(sanitizedDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -43,6 +55,29 @@ func ScanDirectoryProgress(ctx context.Context, dir, lang, providerName string,
 		}
 		f := path
 		work.Go(func() error {
+			// A file with its own language profile is downloaded for every
+			// language that profile asks for, in priority order, instead of
+			// the single lang this scan was started with. Files without an
+			// assignment are untouched by this — see
+			// assignedProfileLanguages for why "assigned" excludes the
+			// default profile.
+			//
+			// The profilesDefined guard is a separate statement rather than
+			// part of the condition below: an if-statement's init clause runs
+			// before the condition is evaluated, so folding it in would still
+			// perform the lookup — and GetMediaProfile creates a default
+			// profile as a side effect on an empty Pebble store.
+			if profilesDefined {
+				if langs, ok := assignedProfileLanguages(f, store, defaultID); ok {
+					logger.Debugf("process %s with assigned profile (%v)", f, langs)
+					if err := processWithAssignedProfile(ctx, f, langs, providerName, p, upgrade, store); err == nil {
+						if cb != nil {
+							cb(f)
+						}
+					}
+					return nil
+				}
+			}
 			logger.Debugf("process %s", f)
 			if err := ProcessFile(ctx, f, lang, providerName, p, upgrade, store); err == nil {
 				if cb != nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/scanner.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
-// last-edited: 2026-07-31
+// last-edited: 2026-08-01
 package scanner
 
 import (
@@ -311,59 +311,48 @@ func ScanDirectoryWithProfiles(ctx context.Context, dir string, db *sql.DB, upgr
 	return nil
 }
 
-// ProcessFileWithProfile downloads subtitles using the language profile assigned to the media file.
+// ProcessFileWithProfile downloads subtitles for path using the language
+// profile assigned to it, covering every language the profile asks for in
+// priority order.
+//
+// It delegates to ProcessFile once per language rather than fetching and
+// writing itself. The previous implementation called providers.FetchWithProfile
+// and then wrote the file inline, which meant it silently skipped everything
+// ProcessFile does around the download — score gating, the Whisper fallback,
+// UTF-8 re-encoding, chmod, auto-sync, the custom post-download script, the
+// *arr rescan event and download-history persistence. It also read its
+// assignment through pkg/profiles.Service, which keys media_profiles on a
+// media_items row id in a raw *sql.DB, while the UI and CLI write path-keyed
+// rows through the SubtitleStore — so it could not have found a UI assignment
+// even when it was reached. It had no callers.
+//
+// db is retained for signature compatibility and is unused: the profile is
+// resolved through store (or the shared store) so that this path and the web
+// UI agree on both the database and the key.
 func ProcessFileWithProfile(ctx context.Context, path string, db *sql.DB, upgrade bool, store database.SubtitleStore) error {
 	logger := logging.GetLogger("scanner")
 
-	// Validate path
 	sanitizedPath, err := security.ValidateAndSanitizePath(path)
 	if err != nil {
 		logger.Warnf("invalid path: %v", err)
 		return err
 	}
 
-	// Use profile-based fetch to get subtitles
-	data, providerName, actualLang, err := providers.FetchWithProfile(ctx, db, sanitizedPath, "")
-	if err != nil {
-		logger.Warnf("fetch with profile %s: %v", sanitizedPath, err)
-		return err
-	}
-
-	// Construct and validate the output path securely using the actual language found
-	wantFormat := outputFormat()
-	data, wroteFormat := convertForOutput(data)
-	if wroteFormat != wantFormat {
-		logger.Debugf("falling back to %s for %s", wroteFormat, sanitizedPath)
-	}
-	out, err := security.ValidateSubtitleOutputPathWithFormat(sanitizedPath, actualLang, singleLanguageNaming(), string(wroteFormat))
-	if err != nil {
-		logger.Warnf("invalid subtitle output path: %v", err)
-		return err
-	}
-
-	if !upgrade {
-		if _, err := os.Stat(out); err == nil {
-			logger.Debugf("subtitle already exists: %s", out)
-			return nil
+	lookupStore := store
+	if lookupStore == nil {
+		var serr error
+		if lookupStore, serr = database.GetSharedStore(); serr != nil {
+			return serr
 		}
 	}
-
-	if upgrade {
-		if oldData, err := os.ReadFile(out); err == nil {
-			if len(data) <= len(oldData) {
-				logger.Debugf("existing subtitle %s is higher quality", out)
-				return nil
-			}
-		}
+	defaultID, profilesDefined := defaultProfileID(lookupStore)
+	if !profilesDefined {
+		return fmt.Errorf("no language profile assigned to %s", sanitizedPath)
+	}
+	langs, ok := assignedProfileLanguages(sanitizedPath, lookupStore, defaultID)
+	if !ok {
+		return fmt.Errorf("no language profile assigned to %s", sanitizedPath)
 	}
 
-	if err := os.WriteFile(out, data, 0644); err != nil {
-		logger.Warnf("write: %v", err)
-		return err
-	}
-	logger.Infof("downloaded %s subtitle %s using profile", actualLang, out)
-	if store != nil {
-		_ = store.InsertDownload(&database.DownloadRecord{File: out, VideoFile: sanitizedPath, Provider: providerName, Language: actualLang})
-	}
-	return nil
+	return processWithAssignedProfile(ctx, sanitizedPath, langs, "", nil, upgrade, store)
 }

--- a/pkg/webserver/profile_scan_test.go
+++ b/pkg/webserver/profile_scan_test.go
@@ -1,0 +1,108 @@
+// file: pkg/webserver/profile_scan_test.go
+// version: 1.0.0
+// guid: 6a41d8b3-7e29-4c50-9f18-2b5d0c7a3e64
+// last-edited: 2026-08-01
+
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
+	"github.com/jdfalk/subtitle-manager/pkg/scanner"
+)
+
+// TestProfileAssignedInUIIsSeenByScanner is the cross-entry-point guard.
+//
+// Assigning a language profile in the UI and reading it back in the UI proves
+// only that the web handler agrees with itself. The defect this feature had
+// was precisely that it did not agree with anyone else: the handler wrote a
+// path-keyed row through the SubtitleStore while the download path read an
+// integer-keyed row out of a different database, so an assignment made in the
+// UI could never influence a download.
+//
+// So the write here goes through the real HTTP handler and the read goes
+// through the scanner's own resolution, with nothing shared but the store.
+//
+// The assertion is on which error comes back rather than on a successful
+// download: no subtitle provider is configured in a test, so the fetch is
+// expected to fail. What matters is that it fails *at the fetch*, having found
+// the assignment — not at the lookup with "no language profile assigned",
+// which is what a key or database disagreement produces.
+func TestProfileAssignedInUIIsSeenByScanner(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	mediaDir := t.TempDir()
+	video := filepath.Join(mediaDir, "Show.S01E01.mkv")
+	if err := os.WriteFile(video, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	prevMedia := viper.GetString("media_directory")
+	viper.Set("media_directory", mediaDir)
+	t.Cleanup(func() { viper.Set("media_directory", prevMedia) })
+
+	// A default profile, so the assignment has to be distinguishable from it.
+	defaultID := createTestProfile(t, "Default", "en")
+	store, err := database.GetSharedStore()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.SetDefaultLanguageProfile(defaultID); err != nil {
+		t.Fatalf("set default: %v", err)
+	}
+
+	// Create the assigned profile with two languages, through the handler.
+	body, err := json.Marshal(profiles.LanguageProfile{
+		Name: "Iberian",
+		Languages: []profiles.LanguageConfig{
+			{Language: "pt", Priority: 2},
+			{Language: "es", Priority: 1},
+		},
+		CutoffScore: 75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	profilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/api/profiles", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create profile: %d (%s)", rr.Code, rr.Body.String())
+	}
+	var created profiles.LanguageProfile
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assign it to the video the way the UI does: the file path,
+	// percent-encoded into the URL.
+	rr = httptest.NewRecorder()
+	mediaProfilesHandler(nil).ServeHTTP(rr, httptest.NewRequest(http.MethodPut,
+		"/api/media/profile/"+url.PathEscape(video),
+		bytes.NewReader([]byte(`{"profile_id":"`+created.ID+`"}`))))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("assign profile: %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	// Now resolve it from the scanner side.
+	err = scanner.ProcessFileWithProfile(t.Context(), video, nil, false, store)
+	if err == nil {
+		return // a download somehow succeeded; the assignment was certainly found
+	}
+	if strings.Contains(err.Error(), "no language profile assigned") {
+		t.Fatalf("the scanner did not see the profile the UI assigned: %v — the "+
+			"write and read paths disagree on the key or the database", err)
+	}
+}

--- a/pkg/webserver/scan.go
+++ b/pkg/webserver/scan.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/scan.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c025a40c-894d-401d-a68d-a27b7f66c3b6
-// last-edited: 2026-07-25
+// last-edited: 2026-08-01
 
 package webserver
 
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
 	"github.com/jdfalk/subtitle-manager/pkg/metadata"
 	"github.com/jdfalk/subtitle-manager/pkg/providers"
 	"github.com/jdfalk/subtitle-manager/pkg/radarr"
@@ -161,14 +162,21 @@ func scanHandler() http.Handler {
 				}
 			}
 
-			// Open database store for download tracking
+			// Store for download tracking and language-profile resolution.
+			//
+			// This must be the shared store, not a per-request
+			// database.OpenStore: Pebble takes an exclusive lock, so a second
+			// open fails while the server is running and the error here was
+			// swallowed — leaving store nil and the scan unable to record
+			// downloads or see a media item's assigned language profile. The
+			// same defect was fixed elsewhere in the server; this call site
+			// was missed. The shared store is never closed by its users.
 			var store database.SubtitleStore
-			if dbPath := viper.GetString("db_path"); dbPath != "" {
-				backend := viper.GetString("db_backend")
-				if s, err := database.OpenStore(dbPath, backend); err == nil {
-					store = s
-					defer s.Close()
-				}
+			if s, err := database.GetSharedStore(); err == nil {
+				store = s
+			} else {
+				logging.GetLogger("webserver").Warnf(
+					"scan running without a database store: %v", err)
 			}
 
 			return scanner.ScanDirectoryProgress(ctx, q.Directory, q.Lang, q.Provider, p, false, 2, store, cb)


### PR DESCRIPTION
Follows #2230 (which fixed the assignment key) and #2231 (which corrected the parity matrix). This is the one that makes language profiles actually do something.

## What was wrong

Assigning a language profile to a media item had **no effect on what was downloaded**. Two separate problems:

1. **Two `media_profiles` implementations share a table name.** The web UI and CLI write path-keyed rows through `database.SubtitleStore`. `pkg/profiles.Service` — reached only from `providers.FetchWithProfile` — reads *integer*-keyed rows out of a raw `*sql.DB` after resolving `media_items.path → id`. Under pebble or postgres that is not even the same database.
2. **`scanner.ProcessFileWithProfile` had no callers.** Every real download path — web scan, monitor loop, watcher, webhooks, scheduler, Sonarr/Radarr — called `scanner.ProcessFile` with a single language. `FetchWithProfile` was reachable only from `subtitle-manager fetch --use-profile`.

So a profile's language list, priority order, cutoff score and Forced/HI flags were inert.

## What changed

- A library scan resolves each file's assigned profile through the **same store and the same `filepath.Clean`-ed key** the web handler writes, and downloads every language the profile asks for in priority order.
- `ProcessFileWithProfile` now delegates to `ProcessFile` once per language instead of fetching and writing inline. Its old body bypassed score gating, the Whisper fallback, UTF-8 re-encoding, chmod, auto-sync, the custom post-download script, the *arr rescan event and download-history persistence.
- **`pkg/webserver/scan.go` now uses `database.GetSharedStore()`.** It was calling `database.OpenStore(dbPath, backend)`; Pebble holds an exclusive lock, so that open fails while the server is running and the error was swallowed by `if ... err == nil`, leaving `store` nil. The shared-store fix landed elsewhere in the server (PR #2209) and this call site was missed. **Without this, the feature passes every test and does nothing in production** — see the verification note below.

## Scope

Deliberately limited to **user-initiated library scans**. The monitor loop, watcher, webhooks, scheduler and *arr paths still download a single language.

`MonitoredItem.Languages` is a second, independent desired-languages mechanism. Making those paths profile-driven means deciding which of the two wins, on a running system — a product decision, not a bug fix. Raise it and I'll do it.

## Three behaviours worth disagreeing with

- **A file assigned the *default* profile is treated as unassigned.** `GetMediaProfile` falls back to the default rather than reporting a miss, so honouring every resolved profile would silently switch the whole library to profile-driven downloading the moment any default existed. The cost is real, not cosmetic: explicitly assigning the default profile gets you the scan's language, not that profile's list. Distinguishing them needs a store method reporting whether an assignment *row* exists — deferred as an interface + 3 implementations + mocks.
- **Single-language naming fetches only the highest-priority language.** With `subtitles.single_language`, every language writes to the same `video.srt`, so a multi-language loop would just overwrite itself.
- **Scanning never creates a profile as a side effect.** `PebbleStore.GetDefaultLanguageProfile` *writes* a profile with ID `default` on an empty store, and `GetMediaProfile` falls back to it on a miss — so consulting profiles per file would make a first scan on a fresh install conjure a profile row that then can't be deleted. Profile resolution is skipped entirely when no profiles exist, and the default is found by reading the list. That also makes behaviour identical on `SQLStore`, which neither falls back nor creates.

## Verification

**Live, on the real production path** — this is the part that matters. An instance running on pebble, a media item assigned a `pt`(2)/`es`(1) profile, scan triggered via `POST /api/scan` with `"lang":"en"`:

```
downloaded subtitle .../Show.S01E01.es.srt
downloaded subtitle .../Show.S01E01.pt.srt
```

Real 31 KB and 42 KB subtitles from actual providers, in priority order, **no `.en.srt`**. That run is also what exercised the nil-store bug: before the `scan.go` fix the same scan would have produced `Show.S01E01.en.srt` with a fully green test suite.

**Tests**, each proven non-vacuous by breaking the code and watching them fail:

| Test | Pins | Broken by |
|---|---|---|
| `TestScanUsesAssignedProfileLanguages` | scan uses profile languages, not the scan language | disabling the wiring → `(string=en) != (string=es)` |
| `TestProfileAssignedInUIIsSeenByScanner` | cross-entry-point: UI writes, scanner reads | perturbing the lookup key → "no language profile assigned" |
| `TestScanCreatesNoProfileRows` | a lookup writes no rows | caught a real side effect while being written |
| `TestScanIgnoresDefaultProfile` | unassigned files keep the scan language | |
| `TestAssignedProfileLanguagesOrdersByPriority` | priority order + single-language truncation | |

`TestScanUsesAssignedProfileLanguages` also caught a defect in my own first draft: I dropped the provider when calling `ProcessFile`, so it fell through to a live network fetch — visible as a 69-second "pass" before the assertion failed.

`go build ./...`, `go test -race ./...` and `go test -tags sqlite ./pkg/webserver/... ./pkg/scanner/... ./pkg/database/...` all clean. CI does not build the sqlite tag.

## Still open

Profiles remain unwired for the monitor/watcher/webhook/scheduler paths (scope, above), and the undeletable-last-profile bug from #2231 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3