### PR TITLE
docs: refresh the next-session prompt after the language-profile work

### DIFF
--- a/changelog.d/docs-next-session-2026-08-01.md
+++ b/changelog.d/docs-next-session-2026-08-01.md
@@ -1,0 +1,16 @@
+<!-- file: changelog.d/docs-next-session-2026-08-01.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2d6f83b1-40c5-4a97-b2e8-7130fa5c9d64 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Changed
+
+#### Next-session prompt refreshed after the language-profile work
+
+Records what #2230/#2231/#2232 changed, moves mass-edit back to the top now
+that profile assignments actually affect downloads, and lists the bugs left
+open (default-profile assignment indistinguishable from unassigned, the
+undeletable last profile, `cmd/profiles.go` hardcoding pebble, and the Whisper
+server speaking `/transcribe` rather than `/asr`). Adds a working note to
+confirm which process answered a live verification, after an orphaned binary
+holding a port made a working fix look broken.

--- a/docs/NEXT_SESSION_PROMPT.md
+++ b/docs/NEXT_SESSION_PROMPT.md
@@ -1,7 +1,7 @@
 <!-- file: docs/NEXT_SESSION_PROMPT.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 3a7f21c8-64b9-4e05-9d3a-8f1e07b26c54 -->
-<!-- last-edited: 2026-07-31 -->
+<!-- last-edited: 2026-08-01 -->
 
 # Next-session prompt
 
@@ -29,54 +29,91 @@ silently lost two fix commits that way once.
 
 `origin/main` is green: `go build ./...`, `go test -race ./...`,
 `go test -tags sqlite ./...` (**CI does not build this tag — run it locally,
-it has caught post-merge breakage twice**), and the frontend suite
-(25 files / 59 tests). A running instance for evaluation lives at
-`~/subtitle-manager-preview/` (`sh start.sh` → http://127.0.0.1:8080,
-`admin` / `evaluate-me-2026`).
+it has caught post-merge breakage twice**), and the frontend suite.
+A running instance for evaluation lives at `~/subtitle-manager-preview/`
+(`sh start.sh` → http://127.0.0.1:8080, `admin` / `evaluate-me-2026`).
 
 Read `docs/BAZARR_PARITY_STATUS.md` for the full matrix and
 `docs/PROVIDER_BUILDOUT_PROMPT.md` for the provider plan. **Verify claims in
-both against the code before acting on them** — several have been wrong.
+both against the code before acting on them** — several have been wrong, most
+recently three ✅ rows claiming language profiles were wired to downloads when
+nothing read them.
+
+## What the last session (2026-08-01) did
+
+Started on mass-edit, found the underlying feature was broken, and fixed that
+instead. Three PRs, all merged:
+
+- **#2230** — per-item profile assignment collided on one key. The UI
+  percent-encodes the media path into the URL; `net/http` decodes it before the
+  handler runs, so the handler's first-segment extraction made every file under
+  `/media` share the key `media`. New `pathRest` helper + `filepath.Clean`
+  normalisation.
+- **#2231** — corrected three parity rows and recorded the findings.
+- **#2232** — library scans now honour an assigned language profile, resolved
+  through the same store and key the UI writes, downloading every language in
+  priority order. Also fixed `pkg/webserver/scan.go` opening its own store with
+  `database.OpenStore` — Pebble's exclusive lock made that fail silently,
+  leaving `store` nil, which would have made the whole feature a no-op in
+  production while every test passed.
 
 ## What to pick up, roughly in order
 
-1. **Mass-edit / bulk profile assign** (`BAZARR_PARITY_STATUS.md` line ~106,
-   🔴). Currently single-item only. Self-contained, user-visible in the UI, and
-   directly evaluable — probably the best value per unit of risk.
+1. **Mass-edit / bulk profile assign** (`BAZARR_PARITY_STATUS.md`, 🔴). This is
+   what the last session was originally sent to do and is now unblocked —
+   assignments finally mean something. Self-contained and user-visible.
+   Suggested shape: `POST /api/media/profiles/bulk` registered as its own exact
+   route (not string-matched inside `mediaProfilesHandler`), `basic` auth to
+   match the single-item route, validate `profile_id` once then return a
+   per-item results array so the UI can say "7 of 9 assigned". Note
+   `MediaLibrary.jsx` already posts to `/api/bulk-operation`, which is not
+   mounted — decide whether to remove that dead call or implement it, but don't
+   hang the new profile action off its error handling, which swallows failures
+   into `console.error`.
 
-2. **Surface `subtitles.format` and `subtitles.single_language` in Settings.**
-   Both work but are config-file only, so neither is discoverable in the UI.
-   ⚠️ Read the `project_subtitle_manager_notifications_config` memory first:
-   `POST /api/config` `viper.Set()`s keys verbatim, and a Settings tab once
-   saved flat keys that the runtime never read, so saving silently did nothing.
-   **Verify both halves — that the UI writes the key the runtime reads.**
+2. **Profiles are still unwired outside library scans.** Monitor loop, watcher,
+   webhooks, scheduler and *arr all call `scanner.ProcessFile` with a single
+   language. Wiring them needs a decision first: `MonitoredItem.Languages` is a
+   second, independent desired-languages mechanism, and something has to win.
+   Ask me rather than picking.
 
-3. **Two findings I raised but deliberately did not fix.** Both are on merged
-   PR #2228; decide what you want done:
-   - `security.ValidateAndSanitizePath` (`pkg/security/security.go`, the
-     `os.TempDir()` branch) accepts **any** absolute path under the system temp
-     dir, regardless of `media_directory` / `allowed_base_dirs`. The comment
-     says "testing/development", but there is no build tag and no config gate —
-     it ships in production, where on Linux/Docker that means all of `/tmp`.
-     Demonstrated escape: with a temp-rooted media dir,
-     `<mediadir>/../../etc/passwd.mkv` is accepted. Not fixed because several
-     tests appear to rely on it, so it needs its own PR plus test fallout work.
+3. **Three known bugs, none fixed.**
+   - A file explicitly assigned the *default* profile is indistinguishable from
+     an unassigned one, so it gets the scan's language rather than that
+     profile's list. Needs a store method reporting whether an assignment row
+     exists, separate from which profile governs the file (interface + 3
+     implementations + mocks).
+   - The last remaining language profile cannot be deleted:
+     `GetDefaultLanguageProfile` returns the first profile when none is flagged,
+     and `handleDeleteProfile` refuses to delete the default.
+   - `cmd/profiles.go` hardcodes `database.OpenStore(..., "pebble")`, ignoring
+     `db_backend`.
+
+4. **Whisper is configured but dead.** `whisper.transcribe_url` points at
+   `http://172.16.3.22:19847` (the `windows-gpu` box), which is up but serves
+   `/transcribe`, `/transcribe-batch`, `/health` — a custom FastAPI server
+   returning `{"text","error"}`, **text only, no timestamps**.
+   `WhisperTranscribe` speaks the native `/asr` protocol and gets a 404. The
+   config already records the `onerahmet/openai-whisper-asr-webservice` image
+   and port 9000 for the standard service; port 9000 is currently closed. Ask
+   me to start that container rather than trying to build subtitles out of an
+   untimed transcript.
+
+5. **Two findings from an earlier session, still open.**
+   - `security.ValidateAndSanitizePath` accepts **any** absolute path under
+     `os.TempDir()`, with no build tag and no config gate, voiding
+     `allowed_base_dirs` in production. Several tests rely on it, so it needs
+     its own PR plus test fallout work.
    - Two open CodeQL "uncontrolled data in path expression" alerts on
-     `pkg/webserver/subtitlepath.go`. I believe they are safe and pinned both
-     constraints with tests in `pkg/security/formatpath_test.go`. Dismiss them
-     or don't — your call.
+     `pkg/webserver/subtitlepath.go`. Believed safe; both constraints pinned
+     with tests in `pkg/security/formatpath_test.go`. Dismiss them or don't.
 
-4. **Remaining 🟡 matrix items**, if the above run out: scheduled search &
-   upgrade loop, per-provider throttling depth, manual-search ranking (only
-   `opensubtitles` implements `Searcher`), subsync original-language reference,
-   per-job scheduler intervals.
-
-5. **Providers are blocked, not merely unfinished.** Phase 1 (keyless) is
-   genuinely exhausted — eight candidates were probed live on 2026-07-31 and
-   the results are tabulated in `PROVIDER_BUILDOUT_PROMPT.md`. Phase 2 needs
-   credentials in my local `~/.subtitle-manager.yaml`; **only wire config key
-   names and protocol, never handle the secret values, and use httptest mocks.**
-   Ask me which providers I've configured rather than guessing.
+6. **Providers are blocked, not merely unfinished.** Phase 1 (keyless) is
+   genuinely exhausted — eight candidates probed live on 2026-07-31, results
+   tabulated in `PROVIDER_BUILDOUT_PROMPT.md`. Phase 2 needs credentials in my
+   local `~/.subtitle-manager.yaml`; **only wire config key names and protocol,
+   never handle the secret values, and use httptest mocks.** Ask me which
+   providers I've configured rather than guessing.
 
 ## How I want you to work
 
@@ -88,11 +125,15 @@ both against the code before acting on them** — several have been wrong.
   — the submodule otherwise breaks git operations there.
 - **Prove every test is non-vacuous**: break the fix, confirm the matching test
   fails, restore. This has caught roughly a dozen tests that passed for the
-  wrong reason, including several I had already called verified.
+  wrong reason.
 - **Don't trust a passing test as evidence the feature works.** Nearly every
-  real bug in this project was invisible until something was actually run —
-  a live provider fetch, a real HTTP request, the app itself. Prefer verifying
-  against reality over verifying against a mock.
+  real bug here was invisible until something was actually run. The 2026-08-01
+  session is the case in point twice over: a green suite would have shipped a
+  feature that did nothing in production, and a "live verification" that
+  appeared to disprove a working fix turned out to have been answered by an
+  orphaned binary holding the port. **When you verify live, confirm which
+  process answered** — `lsof -nP -iTCP:<port> -sTCP:LISTEN -t` against your own
+  PID, and check for a stale listener before starting anything.
 - Document decisions in the PR body and the parity doc as you go, so I can
   review and disagree later.
 


### PR DESCRIPTION
Keeps `docs/NEXT_SESSION_PROMPT.md` current, as the file itself asks.

Records what #2230/#2231/#2232 did, moves mass-edit back to the top (it is unblocked now that assignments affect downloads), and lists what is still open: the default-profile-assignment ambiguity, the undeletable last profile, `cmd/profiles.go` hardcoding pebble, and the Whisper server speaking `/transcribe` rather than `/asr`.

Also adds a working note earned the hard way: when verifying live, confirm which process answered. An orphaned binary holding port 8090 made a working fix look broken for several minutes.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3