### PR TITLE
docs: remove internal host details from the public next-session prompt

### DIFF
--- a/changelog.d/20260802_000000_scrub_internal_host.md
+++ b/changelog.d/20260802_000000_scrub_internal_host.md
@@ -1,0 +1,13 @@
+<!-- file: changelog.d/20260802_000000_scrub_internal_host.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c1e4a90-2b83-4f56-9d17-8e0a35b6f2c4 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- Removed a private network address and internal hostname from
+  `docs/NEXT_SESSION_PROMPT.md`. This repository is public and the file had no
+  reason to record where a self-hosted service lives. The Whisper section is
+  also rewritten: the transcription fallback now works, so the instructions to
+  start a container and repoint the URL were both stale and impossible on that
+  host.

--- a/docs/NEXT_SESSION_PROMPT.md
+++ b/docs/NEXT_SESSION_PROMPT.md
@@ -1,7 +1,7 @@
 <!-- file: docs/NEXT_SESSION_PROMPT.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 3a7f21c8-64b9-4e05-9d3a-8f1e07b26c54 -->
-<!-- last-edited: 2026-08-01 -->
+<!-- last-edited: 2026-08-02 -->
 
 # Next-session prompt
 
@@ -89,15 +89,22 @@ instead. Three PRs, all merged:
    - `cmd/profiles.go` hardcodes `database.OpenStore(..., "pebble")`, ignoring
      `db_backend`.
 
-4. **Whisper is configured but dead.** `whisper.transcribe_url` points at
-   `http://172.16.3.22:19847` (the `windows-gpu` box), which is up but serves
-   `/transcribe`, `/transcribe-batch`, `/health` — a custom FastAPI server
-   returning `{"text","error"}`, **text only, no timestamps**.
-   `WhisperTranscribe` speaks the native `/asr` protocol and gets a 404. The
-   config already records the `onerahmet/openai-whisper-asr-webservice` image
-   and port 9000 for the standard service; port 9000 is currently closed. Ask
-   me to start that container rather than trying to build subtitles out of an
-   untimed transcript.
+4. **Whisper: RESOLVED 2026-08-02, no config change needed.** The transcription
+   fallback works end-to-end; leave `whisper.transcribe_url` alone.
+
+   The GPU host runs a custom FastAPI Whisper server that previously served only
+   `/transcribe` and discarded segment timings, so `WhisperTranscribe` — which
+   speaks the native `/asr` protocol — got a 404. That server now also serves
+   `/asr`, returning real SRT/VTT built from `segment.start`/`.end`. Verified
+   against a real media file: 196 monotonic cues over 10 minutes, driven through
+   the `transcribe` CLI rather than curl.
+
+   Two constraints worth knowing before touching it: the GPU has no room for a
+   second resident model, so one process serves both this project and another;
+   and inference is therefore serialised behind a lock, meaning a long
+   transcription blocks the other project's requests for its duration. The
+   deployment is **not** in this repo — the operator's notes have the details.
+   Do not record host addresses here; this file is public.
 
 5. **Two findings from an earlier session, still open.**
    - `security.ValidateAndSanitizePath` accepts **any** absolute path under


### PR DESCRIPTION
## What

`docs/NEXT_SESSION_PROMPT.md` recorded a private RFC1918 address and an internal hostname for the self-hosted Whisper service. This repository is **public**, so that published home-network topology for no benefit. The address belongs in the operator's own config and notes.

The same section was also factually stale — it described the Whisper fallback as dead and told the next session to start a container on port 9000. That is impossible on the host in question (no Docker, no WSL) and no longer necessary: the server now speaks the native `/asr` protocol with real segment timings, so the fallback works against the URL already configured.

## Scope of the fix

This removes the value **going forward only**. It remains reachable in git history via `a9563ab0` and `1e995091`. Purging it would need a history rewrite and a force-push, which is the repository owner's call and is deliberately not done here.

Severity is low: the address is RFC1918 and non-routable from the internet, and no credential was ever committed. A repo-wide scan for private IPs, hostnames and credential-shaped strings found nothing else — the remaining `172.16.` hits are the SSRF allow/deny lists in `pkg/notifications` and `pkg/webhooks`, which are legitimate code.

## Verification

- `grep -rnE '172\.16\.|windows-gpu' docs/` → clean
- Full-history check for the address confirms the only two commits are the ones named above.