### PR TITLE
fix(profiles): honour explicit default assignments and let the last profile be deleted

### DIFF
--- a/changelog.d/20260804-profile-assignment-fixes.md
+++ b/changelog.d/20260804-profile-assignment-fixes.md
@@ -1,0 +1,31 @@
+### Fixed
+
+#### Three language-profile bugs, all of which silently ignored what you asked for
+
+**A file assigned the *default* profile was treated as unassigned.** Assignment
+used to be inferred from "the profile this file resolves to is not the default",
+because `GetMediaProfile` falls back to the default on a miss and so can never
+report one. Assigning the default profile therefore did nothing — the file was
+scanned with the scan's own language instead of that profile's language list.
+A new store method, `GetAssignedProfileID`, answers whether an assignment row
+exists separately from which profile governs the file.
+
+**The last language profile could not be deleted.** The delete guard asked
+`GetDefaultLanguageProfile` whether the target was the default, but that helper
+answers "which profile governs by default" and falls back to the *first* profile
+when none is flagged. So the last remaining profile always came back as the
+default and was always refused — there was no sequence of requests that emptied
+the list — and with several profiles and no default set, an arbitrary one was
+permanently undeletable. The guard now reads the `IsDefault` flag, and deleting
+the only profile is allowed since there is nothing left to fall back to anyway.
+
+**Deleting the last profile did not stick.** `PebbleStore`'s
+`GetDefaultLanguageProfile` *created* a profile when the store was empty, and
+`GetMediaProfile` called it on every miss — so a delete lasted only until the
+next lookup, which wrote the profile back, flagged default, and therefore
+undeletable again. Reads no longer create rows, matching `SQLStore`, which never
+did.
+
+Also: `subtitle-manager profiles` opened its store with the backend hardcoded to
+`pebble`, ignoring `db_backend`, so on a SQLite or Postgres deployment the CLI
+and the web UI were reading and writing two different databases.

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -1,5 +1,6 @@
 // file: cmd/profiles.go
-// version: 1.0.0
+// version: 1.1.0
+// last-edited: 2026-08-04
 // guid: 3f4e5d6c-7b8a-9c0d-1e2f-4e5d6c7b8a9c
 
 package cmd
@@ -32,7 +33,7 @@ var listProfilesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := logging.GetLogger("profiles")
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err
@@ -146,7 +147,7 @@ var createProfileCmd = &cobra.Command{
 			return err
 		}
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err
@@ -188,7 +189,7 @@ var assignProfileCmd = &cobra.Command{
 			return fmt.Errorf("invalid media path: %w", err)
 		}
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err
@@ -229,7 +230,7 @@ var removeProfileCmd = &cobra.Command{
 			return fmt.Errorf("invalid media path: %w", err)
 		}
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err
@@ -262,7 +263,7 @@ var showMediaProfileCmd = &cobra.Command{
 			return fmt.Errorf("invalid media path: %w", err)
 		}
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err
@@ -309,7 +310,7 @@ var deleteProfileCmd = &cobra.Command{
 		logger := logging.GetLogger("profiles")
 		profileID := args[0]
 
-		store, err := database.OpenStore(database.GetDatabasePath(), "pebble")
+		store, err := database.OpenStore(database.GetDatabasePath(), database.GetDatabaseBackend())
 		if err != nil {
 			logger.Errorf("failed to open database: %v", err)
 			return err

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -176,12 +176,12 @@ production with a fully green test suite.
   `scoring.LoadProfileFromConfig()` — the global `scoring.*` settings. The
   per-language `Forced`/`HI` preferences and the profile's `CutoffScore` never
   reach the scorer. Only the retired `scoredProfileFetch` ever applied them.
-- **A file explicitly assigned the default profile reads as unassigned**, so it
-  is scanned with the scan's own language rather than that profile's list.
-  `GetMediaProfile` falls back to the default instead of reporting a miss, and
-  there is no store method distinguishing "an assignment row exists" from
-  "this is what governs the file". Fixing it means adding one to the interface
-  and all three implementations.
+- ~~A file explicitly assigned the default profile reads as unassigned.~~
+  **Fixed 2026-08-04.** `GetAssignedProfileID` was added to `SubtitleStore` and
+  all three implementations; it reports whether an assignment row exists,
+  separately from which profile governs the file, and never falls back or
+  creates rows. `assignedProfileLanguages` now uses it instead of inferring
+  assignment from "resolved to something other than the default".
 
 The original diagnosis, for context:
 
@@ -208,17 +208,30 @@ Note when fixing: `MonitoredItem.Languages` is a second, independent
 desired-languages mechanism. Making the monitor loop profile-driven means
 deciding which of the two wins — a product decision, not a refactor.
 
-### The last language profile cannot be deleted — **open**
+### The last language profile cannot be deleted — **fixed 2026-08-04**
 
-`GetDefaultLanguageProfile` returns the first profile in the list when none is
-explicitly marked default, and `handleDeleteProfile` refuses to delete the
-default. With one profile left, that profile is always "the default", so
-`DELETE /api/profiles/{id}` answers 400 forever. Reproduced on the preview
-instance.
+`GetDefaultLanguageProfile` returned the first profile in the list when none was
+explicitly marked default, and `handleDeleteProfile` refused to delete the
+default. With one profile left, that profile was always "the default", so
+`DELETE /api/profiles/{id}` answered 400 forever. Reproduced on the preview
+instance. With several profiles and none flagged, an arbitrary one was likewise
+permanently undeletable.
 
-Related: `cmd/profiles.go` hardcodes `database.OpenStore(..., "pebble")`,
-ignoring `db_backend`, so `subtitle-manager profiles show` reads the wrong
-store on a sqlite or postgres deployment.
+The guard now reads the `IsDefault` flag from the list rather than asking
+`GetDefaultLanguageProfile`, and deleting the *only* profile is permitted —
+there is no other profile for scans to fall back to either way, so refusing
+just left the user stuck.
+
+A second defect sat behind it, and fixing only the guard would have left the
+bug reappearing one request later: `PebbleStore.GetDefaultLanguageProfile`
+**created** a profile when the store was empty, and `GetMediaProfile` called it
+on every miss. Deleting the last profile therefore lasted only until the next
+lookup, which wrote it back — flagged default, and so refused again. Pebble no
+longer creates on read, matching `SQLStore`, which never did.
+
+Also fixed: `cmd/profiles.go` hardcoded `database.OpenStore(..., "pebble")`,
+ignoring `db_backend`, so `subtitle-manager profiles show` read a different
+store from the web UI on a sqlite or postgres deployment.
 
 ## Implementation plan (backend)
 

--- a/pkg/backups/service_test.go
+++ b/pkg/backups/service_test.go
@@ -1,5 +1,6 @@
 // file: pkg/backups/service_test.go
-// version: 1.0.1
+// version: 1.1.0
+// last-edited: 2026-08-04
 // guid: 123e4567-e89b-12d3-a456-426614174012
 
 package backups
@@ -299,6 +300,11 @@ func (m *mockSubtitleStore) AssignProfileToMedia(mediaID, profileID string) erro
 func (m *mockSubtitleStore) RemoveProfileFromMedia(mediaID string) error          { return nil }
 func (m *mockSubtitleStore) GetMediaProfile(mediaID string) (*database.LanguageProfile, error) {
 	return &database.LanguageProfile{}, nil
+}
+func (m *mockSubtitleStore) GetAssignedProfileID(mediaID string) (string, error) {
+	// These fakes exist for backup/monitoring tests that never assign a
+	// profile; "" is the honest answer for "nothing was assigned".
+	return "", nil
 }
 func (m *mockSubtitleStore) CreateLanguageProfile(profile *database.LanguageProfile) error {
 	return nil

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,3 +1,8 @@
+// file: pkg/database/database.go
+// version: 1.0.0
+// guid: 6e68e15d-7acf-4121-94f7-b29e4650650d
+// last-edited: 2026-08-04
+
 // Package database provides data storage and retrieval functionality for subtitle-manager.
 // It supports SQLite and other database backends for managing subtitle metadata and operations.
 //
@@ -1481,6 +1486,20 @@ func (s *SQLStore) AssignProfileToMedia(mediaID, profileID string) error {
 func (s *SQLStore) RemoveProfileFromMedia(mediaID string) error {
 	_, err := s.db.Exec(`DELETE FROM media_profiles WHERE media_id = ?`, mediaID)
 	return err
+}
+
+// GetAssignedProfileID reports which profile was explicitly assigned to a media
+// item, or "" when it has none. It never falls back to the default.
+func (s *SQLStore) GetAssignedProfileID(mediaID string) (string, error) {
+	var profileID string
+	row := s.db.QueryRow(`SELECT profile_id FROM media_profiles WHERE media_id = ?`, mediaID)
+	if err := row.Scan(&profileID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return profileID, nil
 }
 
 // GetMediaProfile retrieves the language profile assigned to a media item.

--- a/pkg/database/mocks/subtitlestore_mock.go
+++ b/pkg/database/mocks/subtitlestore_mock.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	"time"
 
-	common "buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
+	"buf.build/gen/go/falkcorp/gcommon/protocolbuffers/go/commonpb/v2"
 	"github.com/jdfalk/subtitle-manager/pkg/database"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -64,7 +64,7 @@ type MockSubtitleStore_AssignProfileToMedia_Call struct {
 // AssignProfileToMedia is a helper method to define mock.On call
 //   - mediaID string
 //   - profileID string
-func (_e *MockSubtitleStore_Expecter) AssignProfileToMedia(mediaID interface{}, profileID interface{}) *MockSubtitleStore_AssignProfileToMedia_Call {
+func (_e *MockSubtitleStore_Expecter) AssignProfileToMedia(mediaID any, profileID any) *MockSubtitleStore_AssignProfileToMedia_Call {
 	return &MockSubtitleStore_AssignProfileToMedia_Call{Call: _e.mock.On("AssignProfileToMedia", mediaID, profileID)}
 }
 
@@ -121,7 +121,7 @@ type MockSubtitleStore_AssignTagToMedia_Call struct {
 // AssignTagToMedia is a helper method to define mock.On call
 //   - mediaID int64
 //   - tagID int64
-func (_e *MockSubtitleStore_Expecter) AssignTagToMedia(mediaID interface{}, tagID interface{}) *MockSubtitleStore_AssignTagToMedia_Call {
+func (_e *MockSubtitleStore_Expecter) AssignTagToMedia(mediaID any, tagID any) *MockSubtitleStore_AssignTagToMedia_Call {
 	return &MockSubtitleStore_AssignTagToMedia_Call{Call: _e.mock.On("AssignTagToMedia", mediaID, tagID)}
 }
 
@@ -178,7 +178,7 @@ type MockSubtitleStore_AssignTagToUser_Call struct {
 // AssignTagToUser is a helper method to define mock.On call
 //   - userID int64
 //   - tagID int64
-func (_e *MockSubtitleStore_Expecter) AssignTagToUser(userID interface{}, tagID interface{}) *MockSubtitleStore_AssignTagToUser_Call {
+func (_e *MockSubtitleStore_Expecter) AssignTagToUser(userID any, tagID any) *MockSubtitleStore_AssignTagToUser_Call {
 	return &MockSubtitleStore_AssignTagToUser_Call{Call: _e.mock.On("AssignTagToUser", userID, tagID)}
 }
 
@@ -482,7 +482,7 @@ type MockSubtitleStore_CreateAPIKey_Call struct {
 // CreateAPIKey is a helper method to define mock.On call
 //   - userID string
 //   - key string
-func (_e *MockSubtitleStore_Expecter) CreateAPIKey(userID interface{}, key interface{}) *MockSubtitleStore_CreateAPIKey_Call {
+func (_e *MockSubtitleStore_Expecter) CreateAPIKey(userID any, key any) *MockSubtitleStore_CreateAPIKey_Call {
 	return &MockSubtitleStore_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", userID, key)}
 }
 
@@ -538,7 +538,7 @@ type MockSubtitleStore_CreateLanguageProfile_Call struct {
 
 // CreateLanguageProfile is a helper method to define mock.On call
 //   - profile *database.LanguageProfile
-func (_e *MockSubtitleStore_Expecter) CreateLanguageProfile(profile interface{}) *MockSubtitleStore_CreateLanguageProfile_Call {
+func (_e *MockSubtitleStore_Expecter) CreateLanguageProfile(profile any) *MockSubtitleStore_CreateLanguageProfile_Call {
 	return &MockSubtitleStore_CreateLanguageProfile_Call{Call: _e.mock.On("CreateLanguageProfile", profile)}
 }
 
@@ -591,7 +591,7 @@ type MockSubtitleStore_CreateOneTimeToken_Call struct {
 //   - userID string
 //   - token string
 //   - duration time.Duration
-func (_e *MockSubtitleStore_Expecter) CreateOneTimeToken(userID interface{}, token interface{}, duration interface{}) *MockSubtitleStore_CreateOneTimeToken_Call {
+func (_e *MockSubtitleStore_Expecter) CreateOneTimeToken(userID any, token any, duration any) *MockSubtitleStore_CreateOneTimeToken_Call {
 	return &MockSubtitleStore_CreateOneTimeToken_Call{Call: _e.mock.On("CreateOneTimeToken", userID, token, duration)}
 }
 
@@ -654,7 +654,7 @@ type MockSubtitleStore_CreateSession_Call struct {
 //   - userID string
 //   - token string
 //   - duration time.Duration
-func (_e *MockSubtitleStore_Expecter) CreateSession(userID interface{}, token interface{}, duration interface{}) *MockSubtitleStore_CreateSession_Call {
+func (_e *MockSubtitleStore_Expecter) CreateSession(userID any, token any, duration any) *MockSubtitleStore_CreateSession_Call {
 	return &MockSubtitleStore_CreateSession_Call{Call: _e.mock.On("CreateSession", userID, token, duration)}
 }
 
@@ -727,7 +727,7 @@ type MockSubtitleStore_CreateUser_Call struct {
 //   - passwordHash string
 //   - email string
 //   - role string
-func (_e *MockSubtitleStore_Expecter) CreateUser(username interface{}, passwordHash interface{}, email interface{}, role interface{}) *MockSubtitleStore_CreateUser_Call {
+func (_e *MockSubtitleStore_Expecter) CreateUser(username any, passwordHash any, email any, role any) *MockSubtitleStore_CreateUser_Call {
 	return &MockSubtitleStore_CreateUser_Call{Call: _e.mock.On("CreateUser", username, passwordHash, email, role)}
 }
 
@@ -793,7 +793,7 @@ type MockSubtitleStore_DeleteDownload_Call struct {
 
 // DeleteDownload is a helper method to define mock.On call
 //   - file string
-func (_e *MockSubtitleStore_Expecter) DeleteDownload(file interface{}) *MockSubtitleStore_DeleteDownload_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteDownload(file any) *MockSubtitleStore_DeleteDownload_Call {
 	return &MockSubtitleStore_DeleteDownload_Call{Call: _e.mock.On("DeleteDownload", file)}
 }
 
@@ -844,7 +844,7 @@ type MockSubtitleStore_DeleteLanguageProfile_Call struct {
 
 // DeleteLanguageProfile is a helper method to define mock.On call
 //   - id string
-func (_e *MockSubtitleStore_Expecter) DeleteLanguageProfile(id interface{}) *MockSubtitleStore_DeleteLanguageProfile_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteLanguageProfile(id any) *MockSubtitleStore_DeleteLanguageProfile_Call {
 	return &MockSubtitleStore_DeleteLanguageProfile_Call{Call: _e.mock.On("DeleteLanguageProfile", id)}
 }
 
@@ -895,7 +895,7 @@ type MockSubtitleStore_DeleteMediaItem_Call struct {
 
 // DeleteMediaItem is a helper method to define mock.On call
 //   - path string
-func (_e *MockSubtitleStore_Expecter) DeleteMediaItem(path interface{}) *MockSubtitleStore_DeleteMediaItem_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteMediaItem(path any) *MockSubtitleStore_DeleteMediaItem_Call {
 	return &MockSubtitleStore_DeleteMediaItem_Call{Call: _e.mock.On("DeleteMediaItem", path)}
 }
 
@@ -946,7 +946,7 @@ type MockSubtitleStore_DeleteMonitoredItem_Call struct {
 
 // DeleteMonitoredItem is a helper method to define mock.On call
 //   - id string
-func (_e *MockSubtitleStore_Expecter) DeleteMonitoredItem(id interface{}) *MockSubtitleStore_DeleteMonitoredItem_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteMonitoredItem(id any) *MockSubtitleStore_DeleteMonitoredItem_Call {
 	return &MockSubtitleStore_DeleteMonitoredItem_Call{Call: _e.mock.On("DeleteMonitoredItem", id)}
 }
 
@@ -997,7 +997,7 @@ type MockSubtitleStore_DeleteSubtitle_Call struct {
 
 // DeleteSubtitle is a helper method to define mock.On call
 //   - file string
-func (_e *MockSubtitleStore_Expecter) DeleteSubtitle(file interface{}) *MockSubtitleStore_DeleteSubtitle_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteSubtitle(file any) *MockSubtitleStore_DeleteSubtitle_Call {
 	return &MockSubtitleStore_DeleteSubtitle_Call{Call: _e.mock.On("DeleteSubtitle", file)}
 }
 
@@ -1048,7 +1048,7 @@ type MockSubtitleStore_DeleteSubtitleSource_Call struct {
 
 // DeleteSubtitleSource is a helper method to define mock.On call
 //   - sourceHash string
-func (_e *MockSubtitleStore_Expecter) DeleteSubtitleSource(sourceHash interface{}) *MockSubtitleStore_DeleteSubtitleSource_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteSubtitleSource(sourceHash any) *MockSubtitleStore_DeleteSubtitleSource_Call {
 	return &MockSubtitleStore_DeleteSubtitleSource_Call{Call: _e.mock.On("DeleteSubtitleSource", sourceHash)}
 }
 
@@ -1099,7 +1099,7 @@ type MockSubtitleStore_DeleteTag_Call struct {
 
 // DeleteTag is a helper method to define mock.On call
 //   - id int64
-func (_e *MockSubtitleStore_Expecter) DeleteTag(id interface{}) *MockSubtitleStore_DeleteTag_Call {
+func (_e *MockSubtitleStore_Expecter) DeleteTag(id any) *MockSubtitleStore_DeleteTag_Call {
 	return &MockSubtitleStore_DeleteTag_Call{Call: _e.mock.On("DeleteTag", id)}
 }
 
@@ -1122,6 +1122,66 @@ func (_c *MockSubtitleStore_DeleteTag_Call) Return(err error) *MockSubtitleStore
 }
 
 func (_c *MockSubtitleStore_DeleteTag_Call) RunAndReturn(run func(id int64) error) *MockSubtitleStore_DeleteTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAssignedProfileID provides a mock function for the type MockSubtitleStore
+func (_mock *MockSubtitleStore) GetAssignedProfileID(mediaID string) (string, error) {
+	ret := _mock.Called(mediaID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAssignedProfileID")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return returnFunc(mediaID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
+		r0 = returnFunc(mediaID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(mediaID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSubtitleStore_GetAssignedProfileID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAssignedProfileID'
+type MockSubtitleStore_GetAssignedProfileID_Call struct {
+	*mock.Call
+}
+
+// GetAssignedProfileID is a helper method to define mock.On call
+//   - mediaID string
+func (_e *MockSubtitleStore_Expecter) GetAssignedProfileID(mediaID any) *MockSubtitleStore_GetAssignedProfileID_Call {
+	return &MockSubtitleStore_GetAssignedProfileID_Call{Call: _e.mock.On("GetAssignedProfileID", mediaID)}
+}
+
+func (_c *MockSubtitleStore_GetAssignedProfileID_Call) Run(run func(mediaID string)) *MockSubtitleStore_GetAssignedProfileID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSubtitleStore_GetAssignedProfileID_Call) Return(s string, err error) *MockSubtitleStore_GetAssignedProfileID_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockSubtitleStore_GetAssignedProfileID_Call) RunAndReturn(run func(mediaID string) (string, error)) *MockSubtitleStore_GetAssignedProfileID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1159,7 +1219,7 @@ type MockSubtitleStore_GetDashboardLayout_Call struct {
 
 // GetDashboardLayout is a helper method to define mock.On call
 //   - userID string
-func (_e *MockSubtitleStore_Expecter) GetDashboardLayout(userID interface{}) *MockSubtitleStore_GetDashboardLayout_Call {
+func (_e *MockSubtitleStore_Expecter) GetDashboardLayout(userID any) *MockSubtitleStore_GetDashboardLayout_Call {
 	return &MockSubtitleStore_GetDashboardLayout_Call{Call: _e.mock.On("GetDashboardLayout", userID)}
 }
 
@@ -1276,7 +1336,7 @@ type MockSubtitleStore_GetLanguageProfile_Call struct {
 
 // GetLanguageProfile is a helper method to define mock.On call
 //   - id string
-func (_e *MockSubtitleStore_Expecter) GetLanguageProfile(id interface{}) *MockSubtitleStore_GetLanguageProfile_Call {
+func (_e *MockSubtitleStore_Expecter) GetLanguageProfile(id any) *MockSubtitleStore_GetLanguageProfile_Call {
 	return &MockSubtitleStore_GetLanguageProfile_Call{Call: _e.mock.On("GetLanguageProfile", id)}
 }
 
@@ -1338,7 +1398,7 @@ type MockSubtitleStore_GetMediaAltTitles_Call struct {
 
 // GetMediaAltTitles is a helper method to define mock.On call
 //   - path string
-func (_e *MockSubtitleStore_Expecter) GetMediaAltTitles(path interface{}) *MockSubtitleStore_GetMediaAltTitles_Call {
+func (_e *MockSubtitleStore_Expecter) GetMediaAltTitles(path any) *MockSubtitleStore_GetMediaAltTitles_Call {
 	return &MockSubtitleStore_GetMediaAltTitles_Call{Call: _e.mock.On("GetMediaAltTitles", path)}
 }
 
@@ -1398,7 +1458,7 @@ type MockSubtitleStore_GetMediaFieldLocks_Call struct {
 
 // GetMediaFieldLocks is a helper method to define mock.On call
 //   - path string
-func (_e *MockSubtitleStore_Expecter) GetMediaFieldLocks(path interface{}) *MockSubtitleStore_GetMediaFieldLocks_Call {
+func (_e *MockSubtitleStore_Expecter) GetMediaFieldLocks(path any) *MockSubtitleStore_GetMediaFieldLocks_Call {
 	return &MockSubtitleStore_GetMediaFieldLocks_Call{Call: _e.mock.On("GetMediaFieldLocks", path)}
 }
 
@@ -1460,7 +1520,7 @@ type MockSubtitleStore_GetMediaItem_Call struct {
 
 // GetMediaItem is a helper method to define mock.On call
 //   - path string
-func (_e *MockSubtitleStore_Expecter) GetMediaItem(path interface{}) *MockSubtitleStore_GetMediaItem_Call {
+func (_e *MockSubtitleStore_Expecter) GetMediaItem(path any) *MockSubtitleStore_GetMediaItem_Call {
 	return &MockSubtitleStore_GetMediaItem_Call{Call: _e.mock.On("GetMediaItem", path)}
 }
 
@@ -1522,7 +1582,7 @@ type MockSubtitleStore_GetMediaProfile_Call struct {
 
 // GetMediaProfile is a helper method to define mock.On call
 //   - mediaID string
-func (_e *MockSubtitleStore_Expecter) GetMediaProfile(mediaID interface{}) *MockSubtitleStore_GetMediaProfile_Call {
+func (_e *MockSubtitleStore_Expecter) GetMediaProfile(mediaID any) *MockSubtitleStore_GetMediaProfile_Call {
 	return &MockSubtitleStore_GetMediaProfile_Call{Call: _e.mock.On("GetMediaProfile", mediaID)}
 }
 
@@ -1582,7 +1642,7 @@ type MockSubtitleStore_GetMediaReleaseGroup_Call struct {
 
 // GetMediaReleaseGroup is a helper method to define mock.On call
 //   - path string
-func (_e *MockSubtitleStore_Expecter) GetMediaReleaseGroup(path interface{}) *MockSubtitleStore_GetMediaReleaseGroup_Call {
+func (_e *MockSubtitleStore_Expecter) GetMediaReleaseGroup(path any) *MockSubtitleStore_GetMediaReleaseGroup_Call {
 	return &MockSubtitleStore_GetMediaReleaseGroup_Call{Call: _e.mock.On("GetMediaReleaseGroup", path)}
 }
 
@@ -1644,7 +1704,7 @@ type MockSubtitleStore_GetMonitoredItemsToCheck_Call struct {
 
 // GetMonitoredItemsToCheck is a helper method to define mock.On call
 //   - interval time.Duration
-func (_e *MockSubtitleStore_Expecter) GetMonitoredItemsToCheck(interval interface{}) *MockSubtitleStore_GetMonitoredItemsToCheck_Call {
+func (_e *MockSubtitleStore_Expecter) GetMonitoredItemsToCheck(interval any) *MockSubtitleStore_GetMonitoredItemsToCheck_Call {
 	return &MockSubtitleStore_GetMonitoredItemsToCheck_Call{Call: _e.mock.On("GetMonitoredItemsToCheck", interval)}
 }
 
@@ -1706,7 +1766,7 @@ type MockSubtitleStore_GetSubtitleSource_Call struct {
 
 // GetSubtitleSource is a helper method to define mock.On call
 //   - sourceHash string
-func (_e *MockSubtitleStore_Expecter) GetSubtitleSource(sourceHash interface{}) *MockSubtitleStore_GetSubtitleSource_Call {
+func (_e *MockSubtitleStore_Expecter) GetSubtitleSource(sourceHash any) *MockSubtitleStore_GetSubtitleSource_Call {
 	return &MockSubtitleStore_GetSubtitleSource_Call{Call: _e.mock.On("GetSubtitleSource", sourceHash)}
 }
 
@@ -1734,23 +1794,23 @@ func (_c *MockSubtitleStore_GetSubtitleSource_Call) RunAndReturn(run func(source
 }
 
 // GetUserByEmail provides a mock function for the type MockSubtitleStore
-func (_mock *MockSubtitleStore) GetUserByEmail(email string) (*common.User, error) {
+func (_mock *MockSubtitleStore) GetUserByEmail(email string) (*commonv2.User, error) {
 	ret := _mock.Called(email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByEmail")
 	}
 
-	var r0 *common.User
+	var r0 *commonv2.User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.User, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*commonv2.User, error)); ok {
 		return returnFunc(email)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.User); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *commonv2.User); ok {
 		r0 = returnFunc(email)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.User)
+			r0 = ret.Get(0).(*commonv2.User)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
@@ -1768,7 +1828,7 @@ type MockSubtitleStore_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - email string
-func (_e *MockSubtitleStore_Expecter) GetUserByEmail(email interface{}) *MockSubtitleStore_GetUserByEmail_Call {
+func (_e *MockSubtitleStore_Expecter) GetUserByEmail(email any) *MockSubtitleStore_GetUserByEmail_Call {
 	return &MockSubtitleStore_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
 }
 
@@ -1785,34 +1845,34 @@ func (_c *MockSubtitleStore_GetUserByEmail_Call) Run(run func(email string)) *Mo
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByEmail_Call) Return(user *common.User, err error) *MockSubtitleStore_GetUserByEmail_Call {
+func (_c *MockSubtitleStore_GetUserByEmail_Call) Return(user *commonv2.User, err error) *MockSubtitleStore_GetUserByEmail_Call {
 	_c.Call.Return(user, err)
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByEmail_Call) RunAndReturn(run func(email string) (*common.User, error)) *MockSubtitleStore_GetUserByEmail_Call {
+func (_c *MockSubtitleStore_GetUserByEmail_Call) RunAndReturn(run func(email string) (*commonv2.User, error)) *MockSubtitleStore_GetUserByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserByID provides a mock function for the type MockSubtitleStore
-func (_mock *MockSubtitleStore) GetUserByID(id string) (*common.User, error) {
+func (_mock *MockSubtitleStore) GetUserByID(id string) (*commonv2.User, error) {
 	ret := _mock.Called(id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByID")
 	}
 
-	var r0 *common.User
+	var r0 *commonv2.User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.User, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*commonv2.User, error)); ok {
 		return returnFunc(id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.User); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *commonv2.User); ok {
 		r0 = returnFunc(id)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.User)
+			r0 = ret.Get(0).(*commonv2.User)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
@@ -1830,7 +1890,7 @@ type MockSubtitleStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockSubtitleStore_Expecter) GetUserByID(id interface{}) *MockSubtitleStore_GetUserByID_Call {
+func (_e *MockSubtitleStore_Expecter) GetUserByID(id any) *MockSubtitleStore_GetUserByID_Call {
 	return &MockSubtitleStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -1847,34 +1907,34 @@ func (_c *MockSubtitleStore_GetUserByID_Call) Run(run func(id string)) *MockSubt
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByID_Call) Return(user *common.User, err error) *MockSubtitleStore_GetUserByID_Call {
+func (_c *MockSubtitleStore_GetUserByID_Call) Return(user *commonv2.User, err error) *MockSubtitleStore_GetUserByID_Call {
 	_c.Call.Return(user, err)
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByID_Call) RunAndReturn(run func(id string) (*common.User, error)) *MockSubtitleStore_GetUserByID_Call {
+func (_c *MockSubtitleStore_GetUserByID_Call) RunAndReturn(run func(id string) (*commonv2.User, error)) *MockSubtitleStore_GetUserByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserByUsername provides a mock function for the type MockSubtitleStore
-func (_mock *MockSubtitleStore) GetUserByUsername(username string) (*common.User, error) {
+func (_mock *MockSubtitleStore) GetUserByUsername(username string) (*commonv2.User, error) {
 	ret := _mock.Called(username)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByUsername")
 	}
 
-	var r0 *common.User
+	var r0 *commonv2.User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.User, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*commonv2.User, error)); ok {
 		return returnFunc(username)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.User); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *commonv2.User); ok {
 		r0 = returnFunc(username)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.User)
+			r0 = ret.Get(0).(*commonv2.User)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
@@ -1892,7 +1952,7 @@ type MockSubtitleStore_GetUserByUsername_Call struct {
 
 // GetUserByUsername is a helper method to define mock.On call
 //   - username string
-func (_e *MockSubtitleStore_Expecter) GetUserByUsername(username interface{}) *MockSubtitleStore_GetUserByUsername_Call {
+func (_e *MockSubtitleStore_Expecter) GetUserByUsername(username any) *MockSubtitleStore_GetUserByUsername_Call {
 	return &MockSubtitleStore_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", username)}
 }
 
@@ -1909,12 +1969,12 @@ func (_c *MockSubtitleStore_GetUserByUsername_Call) Run(run func(username string
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByUsername_Call) Return(user *common.User, err error) *MockSubtitleStore_GetUserByUsername_Call {
+func (_c *MockSubtitleStore_GetUserByUsername_Call) Return(user *commonv2.User, err error) *MockSubtitleStore_GetUserByUsername_Call {
 	_c.Call.Return(user, err)
 	return _c
 }
 
-func (_c *MockSubtitleStore_GetUserByUsername_Call) RunAndReturn(run func(username string) (*common.User, error)) *MockSubtitleStore_GetUserByUsername_Call {
+func (_c *MockSubtitleStore_GetUserByUsername_Call) RunAndReturn(run func(username string) (*commonv2.User, error)) *MockSubtitleStore_GetUserByUsername_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1943,7 +2003,7 @@ type MockSubtitleStore_InsertDownload_Call struct {
 
 // InsertDownload is a helper method to define mock.On call
 //   - rec *database.DownloadRecord
-func (_e *MockSubtitleStore_Expecter) InsertDownload(rec interface{}) *MockSubtitleStore_InsertDownload_Call {
+func (_e *MockSubtitleStore_Expecter) InsertDownload(rec any) *MockSubtitleStore_InsertDownload_Call {
 	return &MockSubtitleStore_InsertDownload_Call{Call: _e.mock.On("InsertDownload", rec)}
 }
 
@@ -1994,7 +2054,7 @@ type MockSubtitleStore_InsertMediaItem_Call struct {
 
 // InsertMediaItem is a helper method to define mock.On call
 //   - rec *database.MediaItem
-func (_e *MockSubtitleStore_Expecter) InsertMediaItem(rec interface{}) *MockSubtitleStore_InsertMediaItem_Call {
+func (_e *MockSubtitleStore_Expecter) InsertMediaItem(rec any) *MockSubtitleStore_InsertMediaItem_Call {
 	return &MockSubtitleStore_InsertMediaItem_Call{Call: _e.mock.On("InsertMediaItem", rec)}
 }
 
@@ -2045,7 +2105,7 @@ type MockSubtitleStore_InsertMonitoredItem_Call struct {
 
 // InsertMonitoredItem is a helper method to define mock.On call
 //   - rec *database.MonitoredItem
-func (_e *MockSubtitleStore_Expecter) InsertMonitoredItem(rec interface{}) *MockSubtitleStore_InsertMonitoredItem_Call {
+func (_e *MockSubtitleStore_Expecter) InsertMonitoredItem(rec any) *MockSubtitleStore_InsertMonitoredItem_Call {
 	return &MockSubtitleStore_InsertMonitoredItem_Call{Call: _e.mock.On("InsertMonitoredItem", rec)}
 }
 
@@ -2096,7 +2156,7 @@ type MockSubtitleStore_InsertSubtitle_Call struct {
 
 // InsertSubtitle is a helper method to define mock.On call
 //   - rec *database.SubtitleRecord
-func (_e *MockSubtitleStore_Expecter) InsertSubtitle(rec interface{}) *MockSubtitleStore_InsertSubtitle_Call {
+func (_e *MockSubtitleStore_Expecter) InsertSubtitle(rec any) *MockSubtitleStore_InsertSubtitle_Call {
 	return &MockSubtitleStore_InsertSubtitle_Call{Call: _e.mock.On("InsertSubtitle", rec)}
 }
 
@@ -2147,7 +2207,7 @@ type MockSubtitleStore_InsertSubtitleSource_Call struct {
 
 // InsertSubtitleSource is a helper method to define mock.On call
 //   - src *database.SubtitleSource
-func (_e *MockSubtitleStore_Expecter) InsertSubtitleSource(src interface{}) *MockSubtitleStore_InsertSubtitleSource_Call {
+func (_e *MockSubtitleStore_Expecter) InsertSubtitleSource(src any) *MockSubtitleStore_InsertSubtitleSource_Call {
 	return &MockSubtitleStore_InsertSubtitleSource_Call{Call: _e.mock.On("InsertSubtitleSource", src)}
 }
 
@@ -2198,7 +2258,7 @@ type MockSubtitleStore_InsertTag_Call struct {
 
 // InsertTag is a helper method to define mock.On call
 //   - name string
-func (_e *MockSubtitleStore_Expecter) InsertTag(name interface{}) *MockSubtitleStore_InsertTag_Call {
+func (_e *MockSubtitleStore_Expecter) InsertTag(name any) *MockSubtitleStore_InsertTag_Call {
 	return &MockSubtitleStore_InsertTag_Call{Call: _e.mock.On("InsertTag", name)}
 }
 
@@ -2249,7 +2309,7 @@ type MockSubtitleStore_InvalidateSession_Call struct {
 
 // InvalidateSession is a helper method to define mock.On call
 //   - token string
-func (_e *MockSubtitleStore_Expecter) InvalidateSession(token interface{}) *MockSubtitleStore_InvalidateSession_Call {
+func (_e *MockSubtitleStore_Expecter) InvalidateSession(token any) *MockSubtitleStore_InvalidateSession_Call {
 	return &MockSubtitleStore_InvalidateSession_Call{Call: _e.mock.On("InvalidateSession", token)}
 }
 
@@ -2300,7 +2360,7 @@ type MockSubtitleStore_InvalidateUserSessions_Call struct {
 
 // InvalidateUserSessions is a helper method to define mock.On call
 //   - userID string
-func (_e *MockSubtitleStore_Expecter) InvalidateUserSessions(userID interface{}) *MockSubtitleStore_InvalidateUserSessions_Call {
+func (_e *MockSubtitleStore_Expecter) InvalidateUserSessions(userID any) *MockSubtitleStore_InvalidateUserSessions_Call {
 	return &MockSubtitleStore_InvalidateUserSessions_Call{Call: _e.mock.On("InvalidateUserSessions", userID)}
 }
 
@@ -2417,7 +2477,7 @@ type MockSubtitleStore_ListDownloadsByVideo_Call struct {
 
 // ListDownloadsByVideo is a helper method to define mock.On call
 //   - video string
-func (_e *MockSubtitleStore_Expecter) ListDownloadsByVideo(video interface{}) *MockSubtitleStore_ListDownloadsByVideo_Call {
+func (_e *MockSubtitleStore_Expecter) ListDownloadsByVideo(video any) *MockSubtitleStore_ListDownloadsByVideo_Call {
 	return &MockSubtitleStore_ListDownloadsByVideo_Call{Call: _e.mock.On("ListDownloadsByVideo", video)}
 }
 
@@ -2645,7 +2705,7 @@ type MockSubtitleStore_ListSubtitleSources_Call struct {
 // ListSubtitleSources is a helper method to define mock.On call
 //   - provider string
 //   - limit int
-func (_e *MockSubtitleStore_Expecter) ListSubtitleSources(provider interface{}, limit interface{}) *MockSubtitleStore_ListSubtitleSources_Call {
+func (_e *MockSubtitleStore_Expecter) ListSubtitleSources(provider any, limit any) *MockSubtitleStore_ListSubtitleSources_Call {
 	return &MockSubtitleStore_ListSubtitleSources_Call{Call: _e.mock.On("ListSubtitleSources", provider, limit)}
 }
 
@@ -2767,7 +2827,7 @@ type MockSubtitleStore_ListSubtitlesByVideo_Call struct {
 
 // ListSubtitlesByVideo is a helper method to define mock.On call
 //   - video string
-func (_e *MockSubtitleStore_Expecter) ListSubtitlesByVideo(video interface{}) *MockSubtitleStore_ListSubtitlesByVideo_Call {
+func (_e *MockSubtitleStore_Expecter) ListSubtitlesByVideo(video any) *MockSubtitleStore_ListSubtitlesByVideo_Call {
 	return &MockSubtitleStore_ListSubtitlesByVideo_Call{Call: _e.mock.On("ListSubtitlesByVideo", video)}
 }
 
@@ -2884,7 +2944,7 @@ type MockSubtitleStore_ListTagsForMedia_Call struct {
 
 // ListTagsForMedia is a helper method to define mock.On call
 //   - mediaID int64
-func (_e *MockSubtitleStore_Expecter) ListTagsForMedia(mediaID interface{}) *MockSubtitleStore_ListTagsForMedia_Call {
+func (_e *MockSubtitleStore_Expecter) ListTagsForMedia(mediaID any) *MockSubtitleStore_ListTagsForMedia_Call {
 	return &MockSubtitleStore_ListTagsForMedia_Call{Call: _e.mock.On("ListTagsForMedia", mediaID)}
 }
 
@@ -2946,7 +3006,7 @@ type MockSubtitleStore_ListTagsForUser_Call struct {
 
 // ListTagsForUser is a helper method to define mock.On call
 //   - userID int64
-func (_e *MockSubtitleStore_Expecter) ListTagsForUser(userID interface{}) *MockSubtitleStore_ListTagsForUser_Call {
+func (_e *MockSubtitleStore_Expecter) ListTagsForUser(userID any) *MockSubtitleStore_ListTagsForUser_Call {
 	return &MockSubtitleStore_ListTagsForUser_Call{Call: _e.mock.On("ListTagsForUser", userID)}
 }
 
@@ -2974,23 +3034,23 @@ func (_c *MockSubtitleStore_ListTagsForUser_Call) RunAndReturn(run func(userID i
 }
 
 // ListUsers provides a mock function for the type MockSubtitleStore
-func (_mock *MockSubtitleStore) ListUsers() ([]*common.User, error) {
+func (_mock *MockSubtitleStore) ListUsers() ([]*commonv2.User, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListUsers")
 	}
 
-	var r0 []*common.User
+	var r0 []*commonv2.User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]*common.User, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]*commonv2.User, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []*common.User); ok {
+	if returnFunc, ok := ret.Get(0).(func() []*commonv2.User); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*common.User)
+			r0 = ret.Get(0).([]*commonv2.User)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -3018,12 +3078,12 @@ func (_c *MockSubtitleStore_ListUsers_Call) Run(run func()) *MockSubtitleStore_L
 	return _c
 }
 
-func (_c *MockSubtitleStore_ListUsers_Call) Return(users []*common.User, err error) *MockSubtitleStore_ListUsers_Call {
+func (_c *MockSubtitleStore_ListUsers_Call) Return(users []*commonv2.User, err error) *MockSubtitleStore_ListUsers_Call {
 	_c.Call.Return(users, err)
 	return _c
 }
 
-func (_c *MockSubtitleStore_ListUsers_Call) RunAndReturn(run func() ([]*common.User, error)) *MockSubtitleStore_ListUsers_Call {
+func (_c *MockSubtitleStore_ListUsers_Call) RunAndReturn(run func() ([]*commonv2.User, error)) *MockSubtitleStore_ListUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3052,7 +3112,7 @@ type MockSubtitleStore_RemoveProfileFromMedia_Call struct {
 
 // RemoveProfileFromMedia is a helper method to define mock.On call
 //   - mediaID string
-func (_e *MockSubtitleStore_Expecter) RemoveProfileFromMedia(mediaID interface{}) *MockSubtitleStore_RemoveProfileFromMedia_Call {
+func (_e *MockSubtitleStore_Expecter) RemoveProfileFromMedia(mediaID any) *MockSubtitleStore_RemoveProfileFromMedia_Call {
 	return &MockSubtitleStore_RemoveProfileFromMedia_Call{Call: _e.mock.On("RemoveProfileFromMedia", mediaID)}
 }
 
@@ -3104,7 +3164,7 @@ type MockSubtitleStore_RemoveTagFromMedia_Call struct {
 // RemoveTagFromMedia is a helper method to define mock.On call
 //   - mediaID int64
 //   - tagID int64
-func (_e *MockSubtitleStore_Expecter) RemoveTagFromMedia(mediaID interface{}, tagID interface{}) *MockSubtitleStore_RemoveTagFromMedia_Call {
+func (_e *MockSubtitleStore_Expecter) RemoveTagFromMedia(mediaID any, tagID any) *MockSubtitleStore_RemoveTagFromMedia_Call {
 	return &MockSubtitleStore_RemoveTagFromMedia_Call{Call: _e.mock.On("RemoveTagFromMedia", mediaID, tagID)}
 }
 
@@ -3161,7 +3221,7 @@ type MockSubtitleStore_RemoveTagFromUser_Call struct {
 // RemoveTagFromUser is a helper method to define mock.On call
 //   - userID int64
 //   - tagID int64
-func (_e *MockSubtitleStore_Expecter) RemoveTagFromUser(userID interface{}, tagID interface{}) *MockSubtitleStore_RemoveTagFromUser_Call {
+func (_e *MockSubtitleStore_Expecter) RemoveTagFromUser(userID any, tagID any) *MockSubtitleStore_RemoveTagFromUser_Call {
 	return &MockSubtitleStore_RemoveTagFromUser_Call{Call: _e.mock.On("RemoveTagFromUser", userID, tagID)}
 }
 
@@ -3218,7 +3278,7 @@ type MockSubtitleStore_SetDashboardLayout_Call struct {
 // SetDashboardLayout is a helper method to define mock.On call
 //   - userID string
 //   - layout string
-func (_e *MockSubtitleStore_Expecter) SetDashboardLayout(userID interface{}, layout interface{}) *MockSubtitleStore_SetDashboardLayout_Call {
+func (_e *MockSubtitleStore_Expecter) SetDashboardLayout(userID any, layout any) *MockSubtitleStore_SetDashboardLayout_Call {
 	return &MockSubtitleStore_SetDashboardLayout_Call{Call: _e.mock.On("SetDashboardLayout", userID, layout)}
 }
 
@@ -3274,7 +3334,7 @@ type MockSubtitleStore_SetDefaultLanguageProfile_Call struct {
 
 // SetDefaultLanguageProfile is a helper method to define mock.On call
 //   - id string
-func (_e *MockSubtitleStore_Expecter) SetDefaultLanguageProfile(id interface{}) *MockSubtitleStore_SetDefaultLanguageProfile_Call {
+func (_e *MockSubtitleStore_Expecter) SetDefaultLanguageProfile(id any) *MockSubtitleStore_SetDefaultLanguageProfile_Call {
 	return &MockSubtitleStore_SetDefaultLanguageProfile_Call{Call: _e.mock.On("SetDefaultLanguageProfile", id)}
 }
 
@@ -3326,7 +3386,7 @@ type MockSubtitleStore_SetMediaAltTitles_Call struct {
 // SetMediaAltTitles is a helper method to define mock.On call
 //   - path string
 //   - titles []string
-func (_e *MockSubtitleStore_Expecter) SetMediaAltTitles(path interface{}, titles interface{}) *MockSubtitleStore_SetMediaAltTitles_Call {
+func (_e *MockSubtitleStore_Expecter) SetMediaAltTitles(path any, titles any) *MockSubtitleStore_SetMediaAltTitles_Call {
 	return &MockSubtitleStore_SetMediaAltTitles_Call{Call: _e.mock.On("SetMediaAltTitles", path, titles)}
 }
 
@@ -3383,7 +3443,7 @@ type MockSubtitleStore_SetMediaFieldLocks_Call struct {
 // SetMediaFieldLocks is a helper method to define mock.On call
 //   - path string
 //   - locks string
-func (_e *MockSubtitleStore_Expecter) SetMediaFieldLocks(path interface{}, locks interface{}) *MockSubtitleStore_SetMediaFieldLocks_Call {
+func (_e *MockSubtitleStore_Expecter) SetMediaFieldLocks(path any, locks any) *MockSubtitleStore_SetMediaFieldLocks_Call {
 	return &MockSubtitleStore_SetMediaFieldLocks_Call{Call: _e.mock.On("SetMediaFieldLocks", path, locks)}
 }
 
@@ -3440,7 +3500,7 @@ type MockSubtitleStore_SetMediaReleaseGroup_Call struct {
 // SetMediaReleaseGroup is a helper method to define mock.On call
 //   - path string
 //   - group string
-func (_e *MockSubtitleStore_Expecter) SetMediaReleaseGroup(path interface{}, group interface{}) *MockSubtitleStore_SetMediaReleaseGroup_Call {
+func (_e *MockSubtitleStore_Expecter) SetMediaReleaseGroup(path any, group any) *MockSubtitleStore_SetMediaReleaseGroup_Call {
 	return &MockSubtitleStore_SetMediaReleaseGroup_Call{Call: _e.mock.On("SetMediaReleaseGroup", path, group)}
 }
 
@@ -3497,7 +3557,7 @@ type MockSubtitleStore_SetMediaTitle_Call struct {
 // SetMediaTitle is a helper method to define mock.On call
 //   - path string
 //   - title string
-func (_e *MockSubtitleStore_Expecter) SetMediaTitle(path interface{}, title interface{}) *MockSubtitleStore_SetMediaTitle_Call {
+func (_e *MockSubtitleStore_Expecter) SetMediaTitle(path any, title any) *MockSubtitleStore_SetMediaTitle_Call {
 	return &MockSubtitleStore_SetMediaTitle_Call{Call: _e.mock.On("SetMediaTitle", path, title)}
 }
 
@@ -3553,7 +3613,7 @@ type MockSubtitleStore_UpdateLanguageProfile_Call struct {
 
 // UpdateLanguageProfile is a helper method to define mock.On call
 //   - profile *database.LanguageProfile
-func (_e *MockSubtitleStore_Expecter) UpdateLanguageProfile(profile interface{}) *MockSubtitleStore_UpdateLanguageProfile_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateLanguageProfile(profile any) *MockSubtitleStore_UpdateLanguageProfile_Call {
 	return &MockSubtitleStore_UpdateLanguageProfile_Call{Call: _e.mock.On("UpdateLanguageProfile", profile)}
 }
 
@@ -3604,7 +3664,7 @@ type MockSubtitleStore_UpdateMonitoredItem_Call struct {
 
 // UpdateMonitoredItem is a helper method to define mock.On call
 //   - rec *database.MonitoredItem
-func (_e *MockSubtitleStore_Expecter) UpdateMonitoredItem(rec interface{}) *MockSubtitleStore_UpdateMonitoredItem_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateMonitoredItem(rec any) *MockSubtitleStore_UpdateMonitoredItem_Call {
 	return &MockSubtitleStore_UpdateMonitoredItem_Call{Call: _e.mock.On("UpdateMonitoredItem", rec)}
 }
 
@@ -3658,7 +3718,7 @@ type MockSubtitleStore_UpdateSubtitleSourceStats_Call struct {
 //   - downloadCount int
 //   - successCount int
 //   - avgRating *float64
-func (_e *MockSubtitleStore_Expecter) UpdateSubtitleSourceStats(sourceHash interface{}, downloadCount interface{}, successCount interface{}, avgRating interface{}) *MockSubtitleStore_UpdateSubtitleSourceStats_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateSubtitleSourceStats(sourceHash any, downloadCount any, successCount any, avgRating any) *MockSubtitleStore_UpdateSubtitleSourceStats_Call {
 	return &MockSubtitleStore_UpdateSubtitleSourceStats_Call{Call: _e.mock.On("UpdateSubtitleSourceStats", sourceHash, downloadCount, successCount, avgRating)}
 }
 
@@ -3725,7 +3785,7 @@ type MockSubtitleStore_UpdateTag_Call struct {
 // UpdateTag is a helper method to define mock.On call
 //   - id int64
 //   - name string
-func (_e *MockSubtitleStore_Expecter) UpdateTag(id interface{}, name interface{}) *MockSubtitleStore_UpdateTag_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateTag(id any, name any) *MockSubtitleStore_UpdateTag_Call {
 	return &MockSubtitleStore_UpdateTag_Call{Call: _e.mock.On("UpdateTag", id, name)}
 }
 
@@ -3782,7 +3842,7 @@ type MockSubtitleStore_UpdateUserPassword_Call struct {
 // UpdateUserPassword is a helper method to define mock.On call
 //   - userID string
 //   - passwordHash string
-func (_e *MockSubtitleStore_Expecter) UpdateUserPassword(userID interface{}, passwordHash interface{}) *MockSubtitleStore_UpdateUserPassword_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateUserPassword(userID any, passwordHash any) *MockSubtitleStore_UpdateUserPassword_Call {
 	return &MockSubtitleStore_UpdateUserPassword_Call{Call: _e.mock.On("UpdateUserPassword", userID, passwordHash)}
 }
 
@@ -3839,7 +3899,7 @@ type MockSubtitleStore_UpdateUserRole_Call struct {
 // UpdateUserRole is a helper method to define mock.On call
 //   - username string
 //   - role string
-func (_e *MockSubtitleStore_Expecter) UpdateUserRole(username interface{}, role interface{}) *MockSubtitleStore_UpdateUserRole_Call {
+func (_e *MockSubtitleStore_Expecter) UpdateUserRole(username any, role any) *MockSubtitleStore_UpdateUserRole_Call {
 	return &MockSubtitleStore_UpdateUserRole_Call{Call: _e.mock.On("UpdateUserRole", username, role)}
 }
 
@@ -3904,7 +3964,7 @@ type MockSubtitleStore_ValidateAPIKey_Call struct {
 
 // ValidateAPIKey is a helper method to define mock.On call
 //   - key string
-func (_e *MockSubtitleStore_Expecter) ValidateAPIKey(key interface{}) *MockSubtitleStore_ValidateAPIKey_Call {
+func (_e *MockSubtitleStore_Expecter) ValidateAPIKey(key any) *MockSubtitleStore_ValidateAPIKey_Call {
 	return &MockSubtitleStore_ValidateAPIKey_Call{Call: _e.mock.On("ValidateAPIKey", key)}
 }
 
@@ -3964,7 +4024,7 @@ type MockSubtitleStore_ValidateOneTimeToken_Call struct {
 
 // ValidateOneTimeToken is a helper method to define mock.On call
 //   - token string
-func (_e *MockSubtitleStore_Expecter) ValidateOneTimeToken(token interface{}) *MockSubtitleStore_ValidateOneTimeToken_Call {
+func (_e *MockSubtitleStore_Expecter) ValidateOneTimeToken(token any) *MockSubtitleStore_ValidateOneTimeToken_Call {
 	return &MockSubtitleStore_ValidateOneTimeToken_Call{Call: _e.mock.On("ValidateOneTimeToken", token)}
 }
 
@@ -4024,7 +4084,7 @@ type MockSubtitleStore_ValidateSession_Call struct {
 
 // ValidateSession is a helper method to define mock.On call
 //   - token string
-func (_e *MockSubtitleStore_Expecter) ValidateSession(token interface{}) *MockSubtitleStore_ValidateSession_Call {
+func (_e *MockSubtitleStore_Expecter) ValidateSession(token any) *MockSubtitleStore_ValidateSession_Call {
 	return &MockSubtitleStore_ValidateSession_Call{Call: _e.mock.On("ValidateSession", token)}
 }
 

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -1,9 +1,14 @@
 // file: pkg/database/pebble.go
+// version: 1.0.0
+// guid: f376d786-9298-4568-a0d8-7d4167d0f7c0
+// last-edited: 2026-08-04
+
 package database
 
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -1617,25 +1622,18 @@ func (p *PebbleStore) GetDefaultLanguageProfile() (*LanguageProfile, error) {
 		}
 	}
 
-	// No default found, return the first profile or create one
+	// No profile is flagged default; fall back to the first one so callers that
+	// merely want "some governing profile" still get an answer.
 	if len(profilesList) > 0 {
 		return &profilesList[0], nil
 	}
 
-	// Create and return a default profile
-	defaultProfile := &LanguageProfile{
-		ID:          "default",
-		Name:        "Default",
-		Languages:   []profilesPkg.LanguageConfig{{Language: "en", Priority: 1, Forced: false, HI: false}},
-		CutoffScore: 80,
-		IsDefault:   true,
-		CreatedAt:   time.Now(),
-		UpdatedAt:   time.Now(),
-	}
-	if err := p.CreateLanguageProfile(defaultProfile); err != nil {
-		return nil, err
-	}
-	return defaultProfile, nil
+	// An empty store used to be answered by *creating* a "default" profile here.
+	// That made a read mutate the database, and GetMediaProfile calls this on
+	// every miss — so deleting the last profile only lasted until the next
+	// lookup, which resurrected it, flagged default, and therefore undeletable
+	// again. SQLStore has always reported a miss instead; this now matches it.
+	return nil, fmt.Errorf("no language profiles exist")
 }
 
 // AssignProfileToMedia assigns a language profile to a media item.
@@ -1657,6 +1655,26 @@ func (p *PebbleStore) AssignProfileToMedia(mediaID, profileID string) error {
 // RemoveProfileFromMedia removes language profile assignment from a media item.
 func (p *PebbleStore) RemoveProfileFromMedia(mediaID string) error {
 	return p.db.Delete(mediaProfileKey(mediaID), pebble.Sync)
+}
+
+// GetAssignedProfileID reports which profile was explicitly assigned to a media
+// item, or "" when it has none. It never falls back to the default and never
+// creates rows.
+func (p *PebbleStore) GetAssignedProfileID(mediaID string) (string, error) {
+	assignmentData, closer, err := p.db.Get(mediaProfileKey(mediaID))
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer closer.Close()
+
+	var assignment profilesPkg.MediaProfileAssignment
+	if err := json.Unmarshal(assignmentData, &assignment); err != nil {
+		return "", err
+	}
+	return assignment.ProfileID, nil
 }
 
 // GetMediaProfile retrieves the language profile assigned to a media item.

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -1,7 +1,7 @@
 // file: pkg/database/postgres.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: 29e61686-4676-4b4a-b4be-b0cb294239a3
-// last-edited: 2026-07-23
+// last-edited: 2026-08-04
 
 package database
 
@@ -733,6 +733,20 @@ VALUES ($1, $2, $3) ON CONFLICT (media_id) DO UPDATE SET profile_id = EXCLUDED.p
 func (p *PostgresStore) RemoveProfileFromMedia(mediaID string) error {
 	_, err := p.db.Exec(`DELETE FROM media_profiles WHERE media_id = $1`, mediaID)
 	return err
+}
+
+// GetAssignedProfileID reports which profile was explicitly assigned to a media
+// item, or "" when it has none. It never falls back to the default.
+func (p *PostgresStore) GetAssignedProfileID(mediaID string) (string, error) {
+	var profileID string
+	row := p.db.QueryRow(`SELECT profile_id FROM media_profiles WHERE media_id = $1`, mediaID)
+	if err := row.Scan(&profileID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return profileID, nil
 }
 
 // GetMediaProfile retrieves the language profile assigned to a media item.

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -1,3 +1,8 @@
+// file: pkg/database/store.go
+// version: 1.0.0
+// guid: db0c372c-d86a-47fd-ae26-7685d0d4a60f
+// last-edited: 2026-08-04
+
 package database
 
 import (
@@ -97,6 +102,17 @@ type SubtitleStore interface {
 	RemoveProfileFromMedia(mediaID string) error
 	// GetMediaProfile retrieves the language profile assigned to a media item.
 	GetMediaProfile(mediaID string) (*LanguageProfile, error)
+	// GetAssignedProfileID reports which profile was explicitly assigned to a
+	// media item, returning "" when the item has no assignment of its own.
+	//
+	// This exists because GetMediaProfile falls back to the default profile on a
+	// miss, so it can never answer "was anything assigned here?". That is the
+	// right answer for "which profile governs this file" and the wrong one for
+	// deciding whether to change how a scan behaves — and it makes a file
+	// explicitly assigned the default indistinguishable from an unassigned one.
+	//
+	// Unlike GetMediaProfile this never falls back and never creates rows.
+	GetAssignedProfileID(mediaID string) (string, error)
 	// Subtitle source tracking operations
 	InsertSubtitleSource(src *SubtitleSource) error
 	GetSubtitleSource(sourceHash string) (*SubtitleSource, error)

--- a/pkg/monitoring/monitor_test.go
+++ b/pkg/monitoring/monitor_test.go
@@ -1,5 +1,6 @@
 // file: pkg/monitoring/monitor_test.go
-// version: 1.0.1
+// version: 1.1.0
+// last-edited: 2026-08-04
 // guid: 12345678-1234-1234-1234-123456789015
 
 package monitoring
@@ -309,6 +310,11 @@ func (m *MockSubtitleStore) AssignProfileToMedia(mediaID, profileID string) erro
 func (m *MockSubtitleStore) RemoveProfileFromMedia(mediaID string) error          { return nil }
 func (m *MockSubtitleStore) GetMediaProfile(mediaID string) (*database.LanguageProfile, error) {
 	return &database.LanguageProfile{}, nil
+}
+func (m *MockSubtitleStore) GetAssignedProfileID(mediaID string) (string, error) {
+	// These fakes exist for backup/monitoring tests that never assign a
+	// profile; "" is the honest answer for "nothing was assigned".
+	return "", nil
 }
 func (m *MockSubtitleStore) CreateLanguageProfile(profile *database.LanguageProfile) error {
 	return nil

--- a/pkg/scanner/profile.go
+++ b/pkg/scanner/profile.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/profile.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f7c2a91-8d05-4e63-b7a2-90c1e5d3846b
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 
 package scanner
 
@@ -15,38 +15,28 @@ import (
 	"github.com/jdfalk/subtitle-manager/pkg/security"
 )
 
-// defaultProfileID returns the ID of the profile marked default (or "" when
-// none is) and whether any profiles exist at all.
+// anyLanguageProfiles reports whether the store holds any language profiles at
+// all, so a scan can skip per-file profile resolution entirely when none exist.
 //
-// It reads the list and looks for the flag rather than calling
-// GetDefaultLanguageProfile, which the backends disagree about: PebbleStore
-// falls back to the first profile when none is flagged and *writes a new
-// "default" profile* when the store is empty, while SQLStore strictly requires
-// is_default and reports a miss. A scan must not create rows as a side effect
-// of looking something up — especially not a profile that then cannot be
-// deleted — and it must behave the same on either backend.
+// This used to also return the default profile's ID, which callers passed back
+// in so assignedProfileLanguages could treat "resolved to the default" as "not
+// assigned". GetAssignedProfileID answers that directly now, so only the
+// short-circuit remains.
 //
-// The "any profiles at all" answer matters for the same reason: GetMediaProfile
-// itself falls back to GetDefaultLanguageProfile on a miss, so on an empty
-// store even a plain lookup would create the row. Callers skip profile
-// resolution entirely when there are none.
-func defaultProfileID(store database.SubtitleStore) (string, bool) {
+// It once carried a second, load-bearing reason: PebbleStore's
+// GetDefaultLanguageProfile *created* a "default" profile when the store was
+// empty, and GetMediaProfile called it on every miss, so on an empty store even
+// a plain lookup wrote a row — one that was then flagged default and could not
+// be deleted. Pebble no longer creates on read, so this guard is now only an
+// optimisation and no longer protects correctness.
+func anyLanguageProfiles(store database.SubtitleStore) bool {
 	list, err := store.ListLanguageProfiles()
-	if err != nil || len(list) == 0 {
-		return "", false
-	}
-	for _, p := range list {
-		if p.IsDefault {
-			return p.ID, true
-		}
-	}
-	return "", true
+	return err == nil && len(list) > 0
 }
 
 // assignedProfileLanguages returns the language codes a media file's assigned
 // language profile asks for, highest priority first, and whether the file has
-// an assignment at all. defaultID is the ID from defaultProfileID, hoisted out
-// of the caller's per-file loop.
+// an assignment at all.
 //
 // # Why "assigned" is not the same as "has a profile"
 //
@@ -56,22 +46,18 @@ func defaultProfileID(store database.SubtitleStore) (string, bool) {
 // whether to change how a scan behaves: it would silently switch every file in
 // the library to profile-driven downloading the moment any default exists.
 //
-// A file is therefore treated as assigned only when the profile it resolves to
-// is not the default one.
-//
-// This has a real consequence, not a cosmetic one: a file the user explicitly
-// assigned the *default* profile is indistinguishable from an unassigned file,
-// and will be scanned with the scan's own language rather than that profile's
-// language list. Telling the two apart needs a store method that reports
-// whether a row exists, separate from which profile governs the file. Until
-// then, assigning a non-default profile is the way to get profile-driven
-// languages.
+// This used to be approximated by treating "resolved to the default" as "not
+// assigned", which made a file explicitly assigned the *default* profile
+// indistinguishable from an unassigned one — it got the scan's own language
+// rather than that profile's list. GetAssignedProfileID reports whether a row
+// exists, separately from which profile governs the file, so the explicit
+// assignment is now honoured.
 //
 // The lookup uses the *sanitized* path. ProcessFile sanitizes before doing
 // anything, and the web handler stores a filepath.Clean-ed key, so looking up
 // a raw path here would miss what the UI wrote — the same key disagreement
 // that made per-item assignment collide before.
-func assignedProfileLanguages(path string, store database.SubtitleStore, defaultID string) ([]string, bool) {
+func assignedProfileLanguages(path string, store database.SubtitleStore) ([]string, bool) {
 	logger := logging.GetLogger("scanner")
 
 	if store == nil {
@@ -88,13 +74,16 @@ func assignedProfileLanguages(path string, store database.SubtitleStore, default
 		return nil, false
 	}
 
-	profile, err := store.GetMediaProfile(sanitized)
-	if err != nil || profile == nil {
+	assignedID, err := store.GetAssignedProfileID(sanitized)
+	if err != nil || assignedID == "" {
 		return nil, false
 	}
 
-	// A resolved profile that is merely the default means "no assignment".
-	if defaultID != "" && profile.ID == defaultID {
+	profile, err := store.GetLanguageProfile(assignedID)
+	if err != nil || profile == nil {
+		// A dangling assignment (profile deleted out from under it) is not an
+		// error worth failing the scan over — fall back to the scan's language.
+		logger.Debugf("assignment for %s names missing profile %s", sanitized, assignedID)
 		return nil, false
 	}
 

--- a/pkg/scanner/profile_test.go
+++ b/pkg/scanner/profile_test.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/profile_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9e2b6c74-51af-4d38-a0e6-7b3c8f1d20a5
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 
 package scanner
 
@@ -187,10 +187,10 @@ func TestAssignedProfileLanguagesOrdersByPriority(t *testing.T) {
 // PebbleStore.GetDefaultLanguageProfile *writes* a new profile with ID
 // "default" when the store is empty. Because a scan now consults profiles per
 // file, calling it would mean a first scan on a fresh install silently
-// conjures a profile row — one that cannot then be deleted, since
-// handleDeleteProfile refuses to remove the default. defaultProfileID reads
-// the list instead, which also makes the behaviour identical on SQLStore,
-// where GetDefaultLanguageProfile does not fall back or create.
+// conjures a profile row — one that could not then be deleted, since
+// handleDeleteProfile refuses to remove the default. Pebble no longer creates
+// on read, and anyLanguageProfiles reads the list, so the behaviour is now
+// identical on SQLStore.
 func TestScanCreatesNoProfileRows(t *testing.T) {
 	dir := t.TempDir()
 	vid := filepath.Join(dir, "movie.mkv")
@@ -222,9 +222,119 @@ func TestScanCreatesNoProfileRows(t *testing.T) {
 	}
 }
 
-// assignedProfileLanguagesForTest resolves the default once and calls through,
-// mirroring what the scan loop does.
+// assignedProfileLanguagesForTest calls through, mirroring the scan loop.
 func assignedProfileLanguagesForTest(path string, store database.SubtitleStore) ([]string, bool) {
-	id, _ := defaultProfileID(store)
-	return assignedProfileLanguages(path, store, id)
+	return assignedProfileLanguages(path, store)
+}
+
+// TestExplicitDefaultProfileAssignmentIsHonoured is the bug this change exists
+// to fix. A file explicitly assigned the *default* profile used to be
+// indistinguishable from an unassigned one, because assignment was inferred
+// from "the resolved profile is not the default" rather than from whether an
+// assignment row existed. Such a file was scanned with the scan's own language
+// instead of the profile's list — the user's explicit choice silently ignored.
+//
+// It is deliberately the mirror image of TestScanIgnoresDefaultProfile: same
+// default profile, same resolved profile, and the only difference is that
+// AssignProfileToMedia was called. The two must reach opposite conclusions.
+func TestExplicitDefaultProfileAssignmentIsHonoured(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	defaultID := newProfile(t, store, "default", true,
+		profiles.LanguageConfig{Language: "fr", Priority: 2},
+		profiles.LanguageConfig{Language: "es", Priority: 1})
+
+	if err := store.AssignProfileToMedia(vid, defaultID); err != nil {
+		t.Fatalf("assign default profile: %v", err)
+	}
+
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "es").Return([]byte("es-sub"), nil).Once()
+	m.On("Fetch", mock.Anything, mock.Anything, "fr").Return([]byte("fr-sub"), nil).Once()
+
+	if err := ScanDirectoryProgress(context.Background(), dir, "en", "test", m, false, 1, store, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	m.AssertExpectations(t)
+
+	if _, err := os.Stat(filepath.Join(dir, "movie.en.srt")); err == nil {
+		t.Error("wrote an en subtitle: an explicit assignment to the default profile was ignored")
+	}
+}
+
+// TestDanglingAssignmentFallsBackToScanLanguage covers deleting a profile that
+// files still reference. The assignment row survives the profile, and resolving
+// it must not fail the scan — the file falls back to the scan's own language.
+func TestDanglingAssignmentFallsBackToScanLanguage(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	newProfile(t, store, "keep", true, profiles.LanguageConfig{Language: "en", Priority: 1})
+	gone := newProfile(t, store, "gone", false, profiles.LanguageConfig{Language: "fr", Priority: 1})
+	if err := store.AssignProfileToMedia(vid, gone); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+	if err := store.DeleteLanguageProfile(gone); err != nil {
+		t.Fatalf("delete profile: %v", err)
+	}
+
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "en").Return([]byte("en-sub"), nil).Once()
+
+	if err := ScanDirectoryProgress(context.Background(), dir, "en", "test", m, false, 1, store, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	m.AssertExpectations(t)
+}
+
+// TestDeletingTheLastProfileStaysDeleted pins the resurrection bug.
+//
+// PebbleStore's GetDefaultLanguageProfile used to *create* a profile when the
+// store was empty, and GetMediaProfile called it on every miss. So deleting the
+// last profile only lasted until the next lookup, which wrote it back — flagged
+// default, and therefore refused by the delete handler for good. Fixing only
+// the delete guard would have left the bug reappearing one request later.
+func TestDeletingTheLastProfileStaysDeleted(t *testing.T) {
+	store := profileTestStore(t)
+
+	// Pebble seeds a default profile on init, so clear whatever is there.
+	list, err := store.ListLanguageProfiles()
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	for _, p := range list {
+		if err := store.DeleteLanguageProfile(p.ID); err != nil {
+			t.Fatalf("delete profile %s: %v", p.ID, err)
+		}
+	}
+
+	// The lookup that used to resurrect it.
+	if _, err := store.GetMediaProfile("/media/movie.mkv"); err == nil {
+		t.Log("GetMediaProfile succeeded on an empty store; only the write-back matters")
+	}
+
+	after, err := store.ListLanguageProfiles()
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	if len(after) != 0 {
+		names := make([]string, 0, len(after))
+		for _, p := range after {
+			names = append(names, p.ID+"/"+p.Name)
+		}
+		t.Errorf("a lookup recreated %d profile(s) %v after the last was deleted", len(after), names)
+	}
 }

--- a/pkg/scanner/progress.go
+++ b/pkg/scanner/progress.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/progress.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 30d76902-4260-48c3-8dbb-acbbdc9bcea7
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 package scanner
 
 import (
@@ -35,11 +35,10 @@ func ScanDirectoryProgress(ctx context.Context, dir, lang, providerName string,
 	// looking it up per file would mean a second full profile-list scan per
 	// file per worker.
 	var (
-		defaultID       string
 		profilesDefined bool
 	)
 	if store != nil {
-		defaultID, profilesDefined = defaultProfileID(store)
+		profilesDefined = anyLanguageProfiles(store)
 	}
 
 	work := pool.New().WithErrors().WithMaxGoroutines(workers)
@@ -59,16 +58,12 @@ func ScanDirectoryProgress(ctx context.Context, dir, lang, providerName string,
 			// language that profile asks for, in priority order, instead of
 			// the single lang this scan was started with. Files without an
 			// assignment are untouched by this — see
-			// assignedProfileLanguages for why "assigned" excludes the
-			// default profile.
+			// assignedProfileLanguages for how "assigned" is determined.
 			//
-			// The profilesDefined guard is a separate statement rather than
-			// part of the condition below: an if-statement's init clause runs
-			// before the condition is evaluated, so folding it in would still
-			// perform the lookup — and GetMediaProfile creates a default
-			// profile as a side effect on an empty Pebble store.
+			// profilesDefined short-circuits the per-file store read when
+			// the library has no profiles at all.
 			if profilesDefined {
-				if langs, ok := assignedProfileLanguages(f, store, defaultID); ok {
+				if langs, ok := assignedProfileLanguages(f, store); ok {
 					logger.Debugf("process %s with assigned profile (%v)", f, langs)
 					if err := processWithAssignedProfile(ctx, f, langs, providerName, p, upgrade, store); err == nil {
 						if cb != nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/scanner.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 package scanner
 
 import (
@@ -345,11 +345,10 @@ func ProcessFileWithProfile(ctx context.Context, path string, db *sql.DB, upgrad
 			return serr
 		}
 	}
-	defaultID, profilesDefined := defaultProfileID(lookupStore)
-	if !profilesDefined {
+	if !anyLanguageProfiles(lookupStore) {
 		return fmt.Errorf("no language profile assigned to %s", sanitizedPath)
 	}
-	langs, ok := assignedProfileLanguages(sanitizedPath, lookupStore, defaultID)
+	langs, ok := assignedProfileLanguages(sanitizedPath, lookupStore)
 	if !ok {
 		return fmt.Errorf("no language profile assigned to %s", sanitizedPath)
 	}

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/profiles.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 
 package webserver
 
@@ -207,11 +207,28 @@ func handleDeleteProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, pro
 		return
 	}
 
-	// Check if this is the default profile
-	defaultProfile, err := store.GetDefaultLanguageProfile()
-	if err == nil && defaultProfile.ID == profileID {
-		http.Error(w, "Cannot delete the default profile", http.StatusBadRequest)
+	// Refusing to delete the default profile is deliberate — it would leave
+	// scans with no fallback — but the check reads the IsDefault flag from the
+	// list rather than asking GetDefaultLanguageProfile.
+	//
+	// That helper answers "which profile governs by default", and when nothing
+	// is flagged it answers with the *first* profile. Used as a delete guard
+	// that made an arbitrary profile permanently undeletable in any store where
+	// no default had been set, and made the last remaining profile undeletable
+	// always — you could never empty the list.
+	//
+	// Deleting the only profile is therefore allowed: there is no other profile
+	// for scans to fall back to either way, and refusing leaves the user stuck.
+	profilesList, err := store.ListLanguageProfiles()
+	if err != nil {
+		http.Error(w, "Failed to delete profile", http.StatusInternalServerError)
 		return
+	}
+	for _, p := range profilesList {
+		if p.ID == profileID && p.IsDefault && len(profilesList) > 1 {
+			http.Error(w, "Cannot delete the default profile; set another profile as default first", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if err := store.DeleteLanguageProfile(profileID); err != nil {

--- a/pkg/webserver/profiles_test.go
+++ b/pkg/webserver/profiles_test.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/profiles_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1b0c9d8e-7f6e-2a3b-5c4d-8f7e9a0b1c2d
-// last-edited: 2026-08-01
+// last-edited: 2026-08-04
 
 package webserver
 
@@ -344,5 +344,104 @@ func TestMediaProfilesHandlerBadPath(t *testing.T) {
 	// Should return bad request for empty path
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+// deleteProfile issues DELETE through the item handler and returns the status.
+func deleteProfile(t *testing.T, id string) (int, string) {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	profilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodDelete, "/api/profiles/"+id, nil))
+	return rr.Code, rr.Body.String()
+}
+
+// profileIDs lists the IDs currently stored, through the collection handler.
+func profileIDs(t *testing.T) []string {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	profilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodGet, "/api/profiles", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list profiles: got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var list []profiles.LanguageProfile
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	ids := make([]string, 0, len(list))
+	for _, p := range list {
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// TestLastProfileIsDeletable pins that the profile list can be emptied.
+//
+// The delete guard asked GetDefaultLanguageProfile whether the target was the
+// default. That helper answers "which profile governs by default" and falls
+// back to the *first* profile when none is flagged — so the last remaining
+// profile always came back as the default and was always refused. There was no
+// sequence of requests that emptied the list.
+func TestLastProfileIsDeletable(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	for _, id := range profileIDs(t) {
+		if code, body := deleteProfile(t, id); code != http.StatusNoContent {
+			t.Fatalf("delete seeded profile %s: got %d (body: %s)", id, code, body)
+		}
+	}
+
+	if ids := profileIDs(t); len(ids) != 0 {
+		t.Errorf("profiles remain after deleting every one: %v", ids)
+	}
+}
+
+// TestNonDefaultProfileIsDeletableWhenNothingIsFlagged is the other half of the
+// same bug. With two profiles and no is_default set, GetDefaultLanguageProfile
+// returned whichever came first, making that arbitrary profile permanently
+// undeletable even though the user never chose it as the default.
+func TestNonDefaultProfileIsDeletableWhenNothingIsFlagged(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	for _, id := range profileIDs(t) {
+		if code, body := deleteProfile(t, id); code != http.StatusNoContent {
+			t.Fatalf("clear seeded profile %s: got %d (body: %s)", id, code, body)
+		}
+	}
+	first := createTestProfile(t, "first", "en")
+	createTestProfile(t, "second", "fr")
+
+	if code, body := deleteProfile(t, first); code != http.StatusNoContent {
+		t.Fatalf("delete unflagged profile: got %d (body: %s)", code, body)
+	}
+}
+
+// TestDefaultProfileStillProtectedWhenOthersExist pins what the guard is
+// actually for: while alternatives exist, removing the default would leave
+// scans without a fallback, so it stays refused.
+func TestDefaultProfileStillProtectedWhenOthersExist(t *testing.T) {
+	skipIfNoSQLite(t)
+	useTempProfileStore(t)
+
+	for _, id := range profileIDs(t) {
+		if code, body := deleteProfile(t, id); code != http.StatusNoContent {
+			t.Fatalf("clear seeded profile %s: got %d (body: %s)", id, code, body)
+		}
+	}
+	keep := createTestProfile(t, "keep", "en")
+	createTestProfile(t, "other", "fr")
+
+	rr := httptest.NewRecorder()
+	profilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/api/profiles/"+keep+"/default", nil))
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("set default: got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	if code, _ := deleteProfile(t, keep); code != http.StatusBadRequest {
+		t.Errorf("deleting the default with another profile present: got %d, want 400", code)
 	}
 }


### PR DESCRIPTION
Closes the three open language-profile defects recorded in
`BAZARR_PARITY_STATUS.md`. Each one silently ignored something the user
explicitly asked for, and none was visible from a green test suite.

## 1. A file assigned the *default* profile was treated as unassigned

Assignment was inferred from "the profile this file resolves to is not the
default", because `GetMediaProfile` falls back to the default on a miss and so
can never report one. Assigning the default profile did nothing — the file was
scanned with the scan's own language instead of that profile's list.

New store method `GetAssignedProfileID(mediaID) (string, error)` returns `""`
when nothing is assigned. It never falls back and never creates rows. Added to
the interface, all three implementations, the generated mock, and the two
hand-written test fakes.

## 2. The last language profile could not be deleted

The guard asked `GetDefaultLanguageProfile` whether the target was the default,
but that helper answers "which profile governs by default" and falls back to the
*first* profile when none is flagged. So the last remaining profile always came
back as the default — **there was no sequence of requests that emptied the
list** — and with several profiles and no default set, an arbitrary one was
permanently undeletable.

The guard now reads the `IsDefault` flag. Deleting the *only* profile is
allowed: there is no other profile for scans to fall back to either way, so
refusing just left the user stuck. Deleting the default while alternatives exist
is still refused, now with a message saying what to do about it.

## 3. Deleting the last profile did not stick

`PebbleStore.GetDefaultLanguageProfile` **created** a profile when the store was
empty, and `GetMediaProfile` called it on every miss. A delete lasted only until
the next lookup, which wrote the profile back — flagged default, and therefore
undeletable again. **Fixing only #2 would have left the bug reappearing one
request later.** Reads no longer create rows, matching `SQLStore`, which never
did.

## Also

- `cmd/profiles.go` hardcoded `OpenStore(..., "pebble")`, ignoring `db_backend`,
  so the CLI and web UI read different databases on sqlite/postgres.
- `defaultProfileID` → `anyLanguageProfiles`. Callers no longer need the
  default's ID, and with the create-on-read hazard gone the helper is now only a
  short-circuit — its docstring says so rather than claiming correctness duty.

## Key agreement, checked rather than assumed

The new reader is called with `security.ValidateAndSanitizePath` output while
the writers use `normalizeMediaID`. Both reduce to `filepath.Clean` for accepted
paths, so the keys agree; they differ only in whether a path is *accepted*. This
mattered because a test that writes and reads through the same helper would pass
either way.

## Testing

`go build ./...`, `go test ./...` and `go test -tags sqlite ./...` all clean
(the sqlite tag is not built by CI).

Six new tests. **Non-vacuity proven on the three fixes** by restoring the old
behaviour and confirming the matching test fails:

- restoring "resolved-to-default means unassigned" →
  `TestExplicitDefaultProfileAssignmentIsHonoured` fails (provider never called)
- restoring Pebble's create-on-read →
  `TestDeletingTheLastProfileStaysDeleted` fails, reporting the resurrected row
- restoring the `GetDefaultLanguageProfile` delete guard →
  `TestDefaultProfileStillProtectedWhenOthersExist` fails at the setup step,
  unable to clear the seeded profile at all

`TestScanIgnoresDefaultProfile` is deliberately the mirror image of the first:
same default profile, same resolved profile, and the only difference is whether
`AssignProfileToMedia` was called. The two must reach opposite conclusions.

## Note on the mocks

`pkg/database/mocks/subtitlestore_mock.go` is regenerated. The installed mockery
is newer than the one that produced the committed files and rewrites
`interface{}` → `any` across every mock in the repo; I reverted all of that
churn except this one file, which genuinely had to change. A separate mocks
refresh is worth doing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3