### PR TITLE
fix(security): stop the temp-directory bypass from voiding allowed_base_dirs

### DIFF
--- a/changelog.d/20260804-tempdir-path-bypass.md
+++ b/changelog.d/20260804-tempdir-path-bypass.md
@@ -1,0 +1,22 @@
+### Security
+
+#### `allowed_base_dirs` is no longer voided by a temp-directory bypass
+
+`security.ValidateAndSanitizePath` accepted **any** absolute path under
+`os.TempDir()`, unconditionally — no build tag, no config key, no comment
+explaining the exposure. Because the system temp directory is world-writable,
+that meant a path an attacker could steer under `/tmp` was accepted regardless
+of how the operator had configured the allowed roots, so the setting protected
+nothing against that one case.
+
+The escape hatch existed for a real reason: the test suite builds fixtures under
+`t.TempDir()`, and around 68 test files depend on those paths validating. It is
+now gated on `testing.Testing()`, which is true only in a test binary — so the
+hatch stays open exactly where it was needed and is closed in every shipped
+binary, with no change required to any of those tests.
+
+The gate is exposed as a package variable rather than an inline call, so the
+production behaviour is actually testable: a test can close the hatch and assert
+that a temp path is refused while a configured media root still validates.
+Otherwise the closed case would be untestable by construction, since every test
+runs with it open.

--- a/pkg/security/formatpath_test.go
+++ b/pkg/security/formatpath_test.go
@@ -1,7 +1,7 @@
 // file: pkg/security/formatpath_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6d0a94f1-58c3-4e27-b91f-72e5c0846a3b
-// last-edited: 2026-07-31
+// last-edited: 2026-08-04
 
 package security
 
@@ -40,10 +40,11 @@ func TestValidateSubtitleOutputPathWithFormatRejectsBadFormat(t *testing.T) {
 // CodeQL flags that call because it cannot see this constraint. Pinning it
 // here means the assumption breaks a test rather than breaking quietly.
 func TestValidateSubtitleOutputPathWithFormatConfinesPath(t *testing.T) {
-	// A fixed path rather than t.TempDir(): ValidateAndSanitizePath
-	// unconditionally admits anything under os.TempDir(), so a temp-rooted
+	// A fixed path rather than t.TempDir(): the temp-directory escape hatch in
+	// ValidateAndSanitizePath is open inside a test binary, so a temp-rooted
 	// media directory would not exercise the confinement being asserted here.
-	// See the note on that bypass in security.go.
+	// (The hatch is no longer unconditional — it is closed in production. See
+	// allowTempDirPaths in security.go and tempdir_gate_test.go.)
 	const dir = "/opt/media"
 	viper.Set("media_directory", dir)
 	defer viper.Reset()

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -1,7 +1,7 @@
 // file: pkg/security/security.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: efe90a08-389d-4157-a46e-8a57bfc1181a
-// last-edited: 2026-07-31
+// last-edited: 2026-08-04
 package security
 
 import (
@@ -12,9 +12,19 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"testing"
 
 	"github.com/spf13/viper"
 )
+
+// allowTempDirPaths controls the temp-directory escape hatch in
+// ValidateAndSanitizePath. It is true only in a test binary.
+//
+// It is a variable rather than a direct testing.Testing() call at the use site
+// so the production behaviour is observable: a test can set it to false and
+// assert that a temp path is refused. Without that, the closed case would be
+// untestable by construction — every test runs with the hatch open.
+var allowTempDirPaths = testing.Testing()
 
 // ValidateURL checks if raw is a safe HTTP or HTTPS URL.
 // It blocks known metadata services and dangerous ports.
@@ -130,9 +140,22 @@ func ValidateAndSanitizePath(userPath string) (string, error) {
 		}
 	}
 
-	// Special handling for temporary directories in testing/development scenarios
-	// Allow paths within the system temp directory but still check for path traversal
-	if tempDir := os.TempDir(); tempDir != "" {
+	// Temp-directory escape hatch, for tests only.
+	//
+	// This used to be unconditional, which quietly voided `allowed_base_dirs` in
+	// production: /tmp is world-writable, so any path an attacker could steer
+	// under it was accepted no matter how the operator had configured the
+	// allowed roots. Nothing gated it — no build tag, no config key.
+	//
+	// It exists because the suite builds fixtures under t.TempDir() and 68 test
+	// files depend on those paths validating. testing.Testing() reports whether
+	// this is a test binary, so the hatch is open exactly where it is needed and
+	// closed everywhere else, without every one of those tests having to
+	// configure an allowed root. A production binary never takes this branch.
+	//
+	// The traversal check below is kept even so: a test fixture path containing
+	// ".." should still be rejected rather than normalised into acceptance.
+	if tempDir := os.TempDir(); allowTempDirPaths && tempDir != "" {
 		relPath, err := filepath.Rel(tempDir, absPath)
 		if err == nil && !strings.HasPrefix(relPath, "..") {
 			if strings.Contains(relPath, "..") {

--- a/pkg/security/tempdir_gate_test.go
+++ b/pkg/security/tempdir_gate_test.go
@@ -1,0 +1,102 @@
+// file: pkg/security/tempdir_gate_test.go
+// version: 1.0.0
+// guid: 5a3e91c7-06b4-4d82-bf15-9e7c3a2048d6
+// last-edited: 2026-08-04
+
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// withProductionPathRules closes the temp-directory escape hatch for the
+// duration of a test, so assertions can be made about how a real binary
+// behaves. Every test otherwise runs with the hatch open, which makes the
+// closed case untestable by construction.
+func withProductionPathRules(t *testing.T) {
+	t.Helper()
+	prev := allowTempDirPaths
+	allowTempDirPaths = false
+	t.Cleanup(func() { allowTempDirPaths = prev })
+}
+
+// TestTempDirIsRejectedInProduction is the point of the change.
+//
+// ValidateAndSanitizePath used to accept *any* absolute path under
+// os.TempDir(), with no build tag and no config key gating it. Since /tmp is
+// world-writable, that voided allowed_base_dirs entirely: a path an attacker
+// could steer under the temp directory was accepted no matter how the operator
+// had configured the allowed roots.
+func TestTempDirIsRejectedInProduction(t *testing.T) {
+	withProductionPathRules(t)
+
+	allowed := t.TempDir()
+	viper.Set("media_directory", allowed)
+	t.Cleanup(viper.Reset)
+
+	// Somewhere under the system temp dir but outside the configured root.
+	outside := filepath.Join(os.TempDir(), "attacker-controlled", "payload.mkv")
+	if got, err := ValidateAndSanitizePath(outside); err == nil {
+		t.Errorf("accepted %q (returned %q); a world-writable temp path must not "+
+			"override allowed_base_dirs", outside, got)
+	}
+}
+
+// TestConfiguredRootStillWorksInProduction is the control: closing the hatch
+// must not break the paths an operator actually configured. Without this, a fix
+// that simply refused everything would look correct.
+func TestConfiguredRootStillWorksInProduction(t *testing.T) {
+	withProductionPathRules(t)
+
+	allowed := t.TempDir()
+	viper.Set("media_directory", allowed)
+	t.Cleanup(viper.Reset)
+
+	inside := filepath.Join(allowed, "show", "episode.mkv")
+	got, err := ValidateAndSanitizePath(inside)
+	if err != nil {
+		t.Fatalf("rejected a path inside the configured media directory: %v", err)
+	}
+	if got != inside {
+		t.Errorf("got %q, want %q", got, inside)
+	}
+}
+
+// TestTempDirIsAllowedInTests pins the other half of the contract: the hatch is
+// open in a test binary, which is what keeps the ~68 test files that build
+// fixtures under t.TempDir() working without each configuring an allowed root.
+//
+// If this ever fails, the gate has been tightened in a way that will break the
+// suite rather than only production behaviour.
+func TestTempDirIsAllowedInTests(t *testing.T) {
+	if !allowTempDirPaths {
+		t.Fatal("allowTempDirPaths is false inside a test binary; testing.Testing() should be true here")
+	}
+
+	viper.Set("media_directory", "/nonexistent-root-for-this-test")
+	t.Cleanup(viper.Reset)
+
+	fixture := filepath.Join(t.TempDir(), "fixture.mkv")
+	if _, err := ValidateAndSanitizePath(fixture); err != nil {
+		t.Errorf("rejected a t.TempDir() fixture path: %v", err)
+	}
+}
+
+// TestTraversalStillRejectedUnderTempDir pins that the hatch never became a way
+// to smuggle traversal through: the ".." check inside it is load-bearing even
+// while the hatch is open.
+func TestTraversalStillRejectedUnderTempDir(t *testing.T) {
+	viper.Set("media_directory", "/nonexistent-root-for-this-test")
+	t.Cleanup(viper.Reset)
+
+	// filepath.Clean resolves the "..", so this lands outside the temp dir and
+	// must not validate.
+	escaping := filepath.Join(os.TempDir(), "..", "..", "etc", "passwd")
+	if got, err := ValidateAndSanitizePath(escaping); err == nil {
+		t.Errorf("accepted %q (returned %q)", escaping, got)
+	}
+}


### PR DESCRIPTION
Closes the first of the two open security findings in
`docs/NEXT_SESSION_PROMPT.md`.

## The problem

`security.ValidateAndSanitizePath` accepted **any** absolute path under
`os.TempDir()`, unconditionally — no build tag, no config key, and only a
comment calling it "special handling for testing/development scenarios". The
system temp directory is world-writable, so a path an attacker could steer under
`/tmp` was accepted regardless of how the operator had configured
`allowed_base_dirs`. The setting protected nothing against that case.

## Why it wasn't simply deleted

The hatch exists for a real reason: the suite builds fixtures under `t.TempDir()`
and roughly **68 test files** depend on those paths validating. Deleting it means
a large, mechanical, error-prone edit to all of them — the kind of change where a
test quietly gets weakened instead of fixed.

Gating on `testing.Testing()` (true only in a test binary) keeps the hatch open
exactly where it was needed and closes it in every shipped binary. **No test file
changed.** Both suites pass unmodified.

## The part worth reviewing

The gate is a package variable, not an inline `testing.Testing()` call:

```go
var allowTempDirPaths = testing.Testing()
```

Every test runs with the hatch open, so the closed case — the entire point of
the fix — would otherwise be **untestable by construction**. The variable lets a
test close it and assert real production behaviour. If you'd rather not have a
mutable package var in `pkg/security`, the alternative is a `go run`-based
subprocess test, which I judged worse: slower, toolchain-dependent, and harder to
read.

## Testing

Four new tests in `pkg/security/tempdir_gate_test.go`:

- a temp path outside the configured root is **refused** with the hatch closed
- a path inside the configured media root still **validates** with it closed —
  the control, without which "refuse everything" would look like a fix
- the hatch is **open** in a test binary, so the ~68 fixture-based tests keep
  working; if this fails, the gate was tightened in a way that breaks the suite
- traversal is still rejected under the temp dir even with the hatch open

Non-vacuity: restoring the unconditional hatch makes
`TestTempDirIsRejectedInProduction` fail, printing the accepted attacker path.

`go build ./...`, `go test ./...` and `go test -tags sqlite ./...` all clean.

Also updated the comment in `formatpath_test.go` that documented the old
unconditional behaviour, so it no longer describes something untrue.

## Note

The **second** open finding — the two CodeQL "uncontrolled data in path
expression" alerts on `pkg/webserver/subtitlepath.go` — is untouched here.
Those constraints are pinned by `formatpath_test.go` and are believed safe;
dismissing or keeping them is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3