### PR TITLE
feat(profiles): honour assigned language profiles on every automated download path

### DIFF
--- a/changelog.d/20260804-profiles-all-download-paths.md
+++ b/changelog.d/20260804-profiles-all-download-paths.md
@@ -1,0 +1,28 @@
+### Changed
+
+#### Language profiles now govern every automated download, not just library scans
+
+An assigned language profile previously affected only a library scan. The
+monitor loop, the filesystem watcher, the Sonarr and Radarr webhooks, and
+`subtitle-manager sonarr`/`radarr` all called the pipeline with one language and
+ignored the assignment. They now download every language the file's profile asks
+for, in priority order, through the same pipeline — so scoring, the Whisper
+fallback, post-processing and download history apply unchanged.
+
+**The precedence decision.** `MonitoredItem.Languages` is a second, independent
+desired-languages mechanism, and something had to win. **The profile wins.**
+`MonitoredItem.Languages` is *accumulated* rather than curated — the monitor's
+sync code unions in every language it is ever asked for and never removes one,
+so it cannot express "stop wanting German". A profile assignment is a deliberate
+per-file choice made in the UI, and an append-only accumulation should not
+override a deliberate choice.
+
+**What is deliberately left alone:** requests that name a language directly —
+the web download endpoint's `?lang=`, the custom webhook's validated `lang`
+field, and `fetch <file> <lang>`. Those are someone asking for one specific
+thing right now rather than stating a policy about the file, so a profile does
+not override them.
+
+A profile-assigned monitored item still retries, fails and auto-blacklists
+exactly as before; that bookkeeping was factored into a helper both paths share
+rather than duplicated.

--- a/cmd/radarr.go
+++ b/cmd/radarr.go
@@ -1,3 +1,8 @@
+// file: cmd/radarr.go
+// version: 1.0.0
+// guid: 61cbb50f-9d36-4700-b970-7dac611ebbd9
+// last-edited: 2026-08-04
+
 package cmd
 
 import (
@@ -37,6 +42,12 @@ var radarrCmd = &cobra.Command{
 			} else {
 				logger.Warnf("db open: %v", err)
 			}
+		}
+		// An assigned language profile governs an *arr import: nothing here
+		// names a language for this particular file, so a choice made in the
+		// UI should win over the connector's default.
+		if handled, err := scanner.ProcessWithProfileIfAssigned(ctx, path, "", nil, true, store); handled {
+			return err
 		}
 		return scanner.ProcessFile(ctx, path, lang, "", nil, true, store)
 	},

--- a/cmd/sonarr.go
+++ b/cmd/sonarr.go
@@ -1,3 +1,8 @@
+// file: cmd/sonarr.go
+// version: 1.0.0
+// guid: 74705a61-aef7-400c-b5a5-23c2276a28ee
+// last-edited: 2026-08-04
+
 package cmd
 
 import (
@@ -37,6 +42,12 @@ var sonarrCmd = &cobra.Command{
 			} else {
 				logger.Warnf("db open: %v", err)
 			}
+		}
+		// An assigned language profile governs an *arr import: nothing here
+		// names a language for this particular file, so a choice made in the
+		// UI should win over the connector's default.
+		if handled, err := scanner.ProcessWithProfileIfAssigned(ctx, path, "", nil, true, store); handled {
+			return err
 		}
 		return scanner.ProcessFile(ctx, path, lang, "", nil, true, store)
 	},

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -169,8 +169,21 @@ production with a fully green test suite.
 
 **What is still open.**
 
-- Only library scans. The monitor loop, watcher, webhooks, scheduler and
-  Sonarr/Radarr paths still call `ProcessFile` with a single language.
+- ~~Only library scans.~~ **Fixed 2026-08-04.** The monitor loop, watcher, the
+  Sonarr/Radarr webhooks and the `sonarr`/`radarr` CLI commands now route
+  through `scanner.ProcessWithProfileIfAssigned`, which honours the file's own
+  profile and reports whether it did so the caller can fall through.
+
+  **Precedence, decided here:** an assigned profile beats
+  `MonitoredItem.Languages`. That field is *accumulated*, not curated —
+  `sync.go` unions in every language it is ever asked for and never removes one,
+  so it cannot express "stop wanting German" — while an assignment is a
+  deliberate per-file choice. Pinned by
+  `TestAssignedProfileBeatsMonitoredItemLanguages`.
+
+  Deliberately **not** overridden: requests that name a language directly, i.e.
+  the web download endpoint's `?lang=`, the custom webhook's validated `lang`,
+  and `fetch <file> <lang>`. Those are one specific request, not a policy.
 - **Cutoff score and Forced/HI are dropped.** `processWithAssignedProfile`
   passes a bare language code, so `ProcessFile` scores candidates with
   `scoring.LoadProfileFromConfig()` — the global `scoring.*` settings. The

--- a/pkg/monitoring/monitor.go
+++ b/pkg/monitoring/monitor.go
@@ -1,5 +1,6 @@
 // file: pkg/monitoring/monitor.go
-// version: 1.1.0
+// version: 1.2.0
+// last-edited: 2026-08-04
 // guid: 12345678-1234-1234-1234-123456789012
 
 package monitoring
@@ -129,6 +130,20 @@ func (m *EpisodeMonitor) processItem(ctx context.Context, item *MonitoredItem) e
 	// Update last checked time
 	item.LastChecked = time.Now()
 
+	// A file with its own language profile is downloaded for the languages that
+	// profile asks for, in priority order, instead of item.Languages.
+	//
+	// The profile wins because item.Languages is accumulated rather than
+	// curated — sync.go unions in every language it is ever asked for and never
+	// removes one — while an assignment is a deliberate per-file choice. See
+	// scanner.ProcessWithProfileIfAssigned for the full reasoning.
+	if handled, err := scanner.ProcessWithProfileIfAssigned(ctx, item.Path, "", nil, true, m.store); handled {
+		if err != nil {
+			m.logger.Debugf("assigned profile failed for %s: %v", item.Path, err)
+		}
+		return m.recordCheckOutcome(item, err == nil)
+	}
+
 	// Check each requested language
 	foundAny := false
 	for _, lang := range item.Languages {
@@ -139,6 +154,14 @@ func (m *EpisodeMonitor) processItem(ctx context.Context, item *MonitoredItem) e
 		foundAny = true
 	}
 
+	return m.recordCheckOutcome(item, foundAny)
+}
+
+// recordCheckOutcome applies the retry/blacklist bookkeeping for one check and
+// persists the item. It is shared by the profile-driven and per-language paths
+// so a profile-assigned file still retries, fails and auto-blacklists exactly
+// like any other monitored item.
+func (m *EpisodeMonitor) recordCheckOutcome(item *MonitoredItem, foundAny bool) error {
 	// Update retry count and status
 	if !foundAny {
 		item.RetryCount++

--- a/pkg/monitoring/profile_precedence_test.go
+++ b/pkg/monitoring/profile_precedence_test.go
@@ -1,0 +1,127 @@
+// file: pkg/monitoring/profile_precedence_test.go
+// version: 1.0.0
+// guid: 7c1d40b9-3e28-4a56-9f7d-2b8e0c4a6135
+// last-edited: 2026-08-04
+
+package monitoring
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
+	"github.com/jdfalk/subtitle-manager/pkg/providers"
+	providersmocks "github.com/jdfalk/subtitle-manager/pkg/providers/mocks"
+)
+
+// monitorProfileStore opens a throwaway Pebble store. Pebble rather than SQLite
+// so this runs without the sqlite build tag, which CI does not set.
+func monitorProfileStore(t *testing.T) database.SubtitleStore {
+	t.Helper()
+	store, err := database.OpenStore(filepath.Join(t.TempDir(), "db"), "pebble")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// srtFor builds a minimal but genuinely well-formed SRT cue.
+func srtFor(lang string) []byte {
+	return []byte("1\n00:00:01,000 --> 00:00:02,000\n" + lang + " line\n")
+}
+
+// TestAssignedProfileBeatsMonitoredItemLanguages pins the precedence decision.
+//
+// MonitoredItem.Languages and a language profile are two independent
+// desired-languages mechanisms, and something has to win. The profile does,
+// because Languages is *accumulated* rather than curated — sync.go unions in
+// every language it is ever asked for and never removes one, so it cannot
+// express "stop wanting German". A profile assignment is a deliberate per-file
+// choice made in the UI, and an append-only accumulation should not override
+// a deliberate choice.
+//
+// The item below asks for "de" while the assigned profile asks for es then fr.
+// Exactly the profile's languages must be fetched, and "de" must not be — if
+// the two were merged instead of one winning, this test would catch that too.
+func TestAssignedProfileBeatsMonitoredItemLanguages(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "episode.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := monitorProfileStore(t)
+	if err := store.CreateLanguageProfile(&database.LanguageProfile{
+		ID:   "assigned",
+		Name: "Assigned",
+		Languages: []profiles.LanguageConfig{
+			{Language: "fr", Priority: 2},
+			{Language: "es", Priority: 1},
+		},
+		CutoffScore: 75,
+	}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if err := store.AssignProfileToMedia(vid, "assigned"); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+
+	// The monitor calls the pipeline with a nil provider, so it resolves one
+	// through the registry. Registering a factory and pinning the instance list
+	// keeps this deterministic — otherwise FetchFromAll falls back to *every*
+	// registered provider and the test makes real network calls.
+	p := providersmocks.NewMockProvider(t)
+	// The bytes must be real SRT: the multi-provider path rejects anything that
+	// does not look like a subtitle (providers.looksLikeSubtitle), because stub
+	// providers were answering 200 to everything and ending the search.
+	p.On("Fetch", mock.Anything, mock.Anything, "es").Return(srtFor("es"), nil).Once()
+	p.On("Fetch", mock.Anything, mock.Anything, "fr").Return(srtFor("fr"), nil).Once()
+	// "de" is allowed but never expected. Without this the regression case —
+	// item.Languages winning — makes testify call FailNow inside the provider
+	// goroutine, which deadlocks against the wave's WaitGroup and turns a clear
+	// assertion failure into a ten-minute hang. Declaring it lets the missing
+	// es/fr calls and the stray de subtitle do the reporting instead.
+	p.On("Fetch", mock.Anything, mock.Anything, "de").
+		Return(srtFor("de"), nil).Maybe()
+	providers.RegisterFactory("monitortest", func() providers.Provider { return p })
+	prev := providers.ListInstances()
+	providers.SetInstances([]providers.Instance{
+		{ID: "monitortest", Name: "monitortest", Enabled: true},
+	})
+	t.Cleanup(func() { providers.SetInstances(prev) })
+
+	m := NewEpisodeMonitor(time.Hour, nil, nil, store, 3, false)
+	item := &MonitoredItem{
+		ID:         "item-1",
+		Path:       vid,
+		Languages:  []string{"de"},
+		MaxRetries: 3,
+	}
+	if err := m.processItem(context.Background(), item); err != nil {
+		t.Fatalf("process item: %v", err)
+	}
+
+	p.AssertExpectations(t)
+	if _, err := os.Stat(filepath.Join(dir, "episode.de.srt")); err == nil {
+		t.Error("wrote a de subtitle: MonitoredItem.Languages overrode the assigned profile")
+	}
+	for _, lang := range []string{"es", "fr"} {
+		if _, err := os.Stat(filepath.Join(dir, "episode."+lang+".srt")); err != nil {
+			t.Errorf("no %s subtitle written: %v", lang, err)
+		}
+	}
+	if item.Status != StatusFound {
+		t.Errorf("status = %q, want %q: the profile path must still record the outcome",
+			item.Status, StatusFound)
+	}
+}

--- a/pkg/scanner/profile.go
+++ b/pkg/scanner/profile.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/profile.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4f7c2a91-8d05-4e63-b7a2-90c1e5d3846b
 // last-edited: 2026-08-04
 
@@ -154,4 +154,44 @@ func processWithAssignedProfile(ctx context.Context, path string, langs []string
 		return nil
 	}
 	return firstErr
+}
+
+// ProcessWithProfileIfAssigned runs the download pipeline using the file's own
+// language profile when it has one, and reports whether it did. A caller that
+// gets false back should fall through to its own single-language behaviour.
+//
+// # Precedence
+//
+// This is the single place that decides an explicit profile assignment beats
+// whatever language the calling path would otherwise have used — including
+// MonitoredItem.Languages, which is the monitor loop's independent list of
+// desired languages.
+//
+// That field loses because it is *accumulated*, not curated: sync.go unions in
+// every language it is ever asked for and never removes one, so it cannot
+// express "stop wanting French". A profile assignment is a deliberate per-file
+// choice made in the UI. An append-only accumulation should not override a
+// deliberate choice.
+//
+// The exception is a request that names a language directly — the web
+// download endpoint's ?lang=, `fetch <file> <lang>`. Those are the user asking
+// for one specific thing right now, not a policy about the file, so they are
+// left alone and do not call this.
+func ProcessWithProfileIfAssigned(ctx context.Context, path string, providerName string,
+	p providers.Provider, upgrade bool, store database.SubtitleStore) (bool, error) {
+	lookupStore := store
+	if lookupStore == nil {
+		var err error
+		if lookupStore, err = database.GetSharedStore(); err != nil {
+			return false, nil
+		}
+	}
+	if !anyLanguageProfiles(lookupStore) {
+		return false, nil
+	}
+	langs, ok := assignedProfileLanguages(path, lookupStore)
+	if !ok {
+		return false, nil
+	}
+	return true, processWithAssignedProfile(ctx, path, langs, providerName, p, upgrade, store)
 }

--- a/pkg/scanner/profile_test.go
+++ b/pkg/scanner/profile_test.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/profile_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9e2b6c74-51af-4d38-a0e6-7b3c8f1d20a5
 // last-edited: 2026-08-04
 
@@ -337,4 +337,59 @@ func TestDeletingTheLastProfileStaysDeleted(t *testing.T) {
 		}
 		t.Errorf("a lookup recreated %d profile(s) %v after the last was deleted", len(after), names)
 	}
+}
+
+// TestProcessWithProfileIfAssignedReportsHandled pins the contract every wired
+// download path depends on: the helper must say whether it took over, so the
+// caller knows whether to fall through to its own single language.
+//
+// Getting this backwards in either direction is silent: reporting handled when
+// it did nothing loses the download entirely, and reporting unhandled after
+// downloading duplicates it.
+func TestProcessWithProfileIfAssignedReportsHandled(t *testing.T) {
+	dir := t.TempDir()
+	assignedVid := filepath.Join(dir, "assigned.mkv")
+	plainVid := filepath.Join(dir, "plain.mkv")
+	for _, v := range []string{assignedVid, plainVid} {
+		if err := os.WriteFile(v, []byte("x"), 0644); err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+	}
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	store := profileTestStore(t)
+	newProfile(t, store, "default", true, profiles.LanguageConfig{Language: "en", Priority: 1})
+	assigned := newProfile(t, store, "assigned", false,
+		profiles.LanguageConfig{Language: "fr", Priority: 2},
+		profiles.LanguageConfig{Language: "es", Priority: 1})
+	if err := store.AssignProfileToMedia(assignedVid, assigned); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+
+	m := providersmocks.NewMockProvider(t)
+	m.On("Fetch", mock.Anything, mock.Anything, "es").Return([]byte("es-sub"), nil).Once()
+	m.On("Fetch", mock.Anything, mock.Anything, "fr").Return([]byte("fr-sub"), nil).Once()
+
+	handled, err := ProcessWithProfileIfAssigned(context.Background(), assignedVid, "test", m, false, store)
+	if err != nil {
+		t.Fatalf("assigned file: %v", err)
+	}
+	if !handled {
+		t.Fatal("assigned file reported unhandled; the caller would download its own language instead")
+	}
+	m.AssertExpectations(t)
+
+	// The unassigned file must be declined, not silently downloaded with the
+	// default profile's languages — otherwise every file in the library becomes
+	// profile-driven the moment a default exists.
+	unassigned := providersmocks.NewMockProvider(t)
+	handled, err = ProcessWithProfileIfAssigned(context.Background(), plainVid, "test", unassigned, false, store)
+	if err != nil {
+		t.Fatalf("unassigned file: %v", err)
+	}
+	if handled {
+		t.Error("unassigned file reported handled; the caller would skip its own download")
+	}
+	unassigned.AssertExpectations(t)
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,3 +1,8 @@
+// file: pkg/watcher/watcher.go
+// version: 1.0.0
+// guid: b30941d0-038e-4c97-9601-7d2dc16520ad
+// last-edited: 2026-08-04
+
 package watcher
 
 import (
@@ -56,7 +61,7 @@ func WatchDirectory(ctx context.Context, dir, lang, providerName string, p provi
 			logger.Warnf("watch error: %v", err)
 		case ev := <-w.Events:
 			if ev.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write) != 0 && isVideoFile(ev.Name) {
-				if err := scanner.ProcessFile(ctx, ev.Name, lang, providerName, p, false, store); err != nil {
+				if err := processWatched(ctx, ev.Name, lang, providerName, p, store); err != nil {
 					logger.Warnf("process %s: %v", ev.Name, err)
 				}
 			}
@@ -106,10 +111,25 @@ func WatchDirectoryRecursive(ctx context.Context, dir, lang, providerName string
 				}
 			}
 			if ev.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write) != 0 && isVideoFile(ev.Name) {
-				if err := scanner.ProcessFile(ctx, ev.Name, lang, providerName, p, false, store); err != nil {
+				if err := processWatched(ctx, ev.Name, lang, providerName, p, store); err != nil {
 					logger.Warnf("process %s: %v", ev.Name, err)
 				}
 			}
 		}
 	}
+}
+
+// processWatched downloads subtitles for a newly seen file, honouring the
+// file's own language profile when it has one and falling back to the single
+// language the watcher was started with.
+//
+// The watcher is an automated path — nobody named a language for this
+// particular file — so an assignment made in the UI should govern it, the same
+// way it governs a library scan.
+func processWatched(ctx context.Context, path, lang, providerName string,
+	p providers.Provider, store database.SubtitleStore) error {
+	if handled, err := scanner.ProcessWithProfileIfAssigned(ctx, path, providerName, p, false, store); handled {
+		return err
+	}
+	return scanner.ProcessFile(ctx, path, lang, providerName, p, false, store)
 }

--- a/pkg/webhooks/handlers.go
+++ b/pkg/webhooks/handlers.go
@@ -1,7 +1,7 @@
 // file: pkg/webhooks/handlers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 123e4567-e89b-12d3-a456-426614174002
-// last-edited: 2026-07-30
+// last-edited: 2026-08-04
 
 package webhooks
 
@@ -144,10 +144,11 @@ func (h *SonarrWebhookHandler) Handle(ctx context.Context, payload []byte, heade
 	// fetched English subtitles for everything imported through Sonarr with no
 	// setting anywhere to change it. It now follows the configured default.
 	//
-	// This is still not the language *profile* assigned to the series — the
-	// handler receives a file path and has no database to resolve one — which
-	// is the remaining half of this gap and is tracked separately.
-	if err := scanner.ProcessFile(ctx, filePath, profiles.DefaultLanguage(), "", nil, true, nil); err != nil {
+	// A file with its own language profile is downloaded for that profile's
+	// languages instead. Nothing in a Sonarr import names a language for this
+	// particular file, so an assignment made in the UI should govern it. The
+	// nil store is fine — the helper resolves the shared store itself.
+	if err := processWebhookFile(ctx, filePath, profiles.DefaultLanguage(), "", nil); err != nil {
 		h.logger.Warnf("Failed to process file from Sonarr webhook: %v", err)
 		return fmt.Errorf("processing failed: %v", err)
 	}
@@ -187,9 +188,9 @@ func (h *RadarrWebhookHandler) Handle(ctx context.Context, payload []byte, heade
 	h.logger.Infof("Processing Radarr download: %s", filePath)
 
 	// Process file for subtitle download. See the Sonarr handler above for why
-	// this follows the configured default language rather than a hardcoded
-	// English, and what the remaining gap is.
-	if err := scanner.ProcessFile(ctx, filePath, profiles.DefaultLanguage(), "", nil, true, nil); err != nil {
+	// this follows an assigned language profile first and the configured
+	// default language otherwise.
+	if err := processWebhookFile(ctx, filePath, profiles.DefaultLanguage(), "", nil); err != nil {
 		h.logger.Warnf("Failed to process file from Radarr webhook: %v", err)
 		return fmt.Errorf("processing failed: %v", err)
 	}
@@ -344,4 +345,20 @@ func (h *RadarrWebhookHandler) GetName() string {
 // GetName returns the handler name for custom webhooks.
 func (h *CustomWebhookHandler) GetName() string {
 	return "custom"
+}
+
+// processWebhookFile downloads subtitles for a file an *arr instance just
+// imported, honouring the file's own language profile when it has one.
+//
+// Only the Sonarr and Radarr handlers use this. The custom webhook is left on
+// scanner.ProcessFile deliberately: its payload carries an explicit, validated
+// language, which is the sender asking for one specific thing rather than a
+// policy about the file — the same reason the web download endpoint is
+// untouched. See scanner.ProcessWithProfileIfAssigned.
+func processWebhookFile(ctx context.Context, path, lang, providerName string,
+	p providers.Provider) error {
+	if handled, err := scanner.ProcessWithProfileIfAssigned(ctx, path, providerName, p, true, nil); handled {
+		return err
+	}
+	return scanner.ProcessFile(ctx, path, lang, providerName, p, true, nil)
 }


### PR DESCRIPTION
Replaces #2240, which was branched off `fix/profile-assignment-bugs` before that
landed. Because the repo is rebase-merge-only, the merged commit had a different
SHA with the same content, leaving #2240 `CONFLICTING` — and GitHub cannot build
the merge ref for a conflicting PR, so the `Continuous Integration` workflow
never queued at all. Same commit, cherry-picked onto current `main`.

---

Closes the largest remaining item in the language-profile gap: an assignment
previously affected only a library scan, so a profile set in the UI did nothing
for anything arriving via monitoring, the watcher, or an *arr import.

## The precedence decision

`BAZARR_PARITY_STATUS.md` flagged this as needing a decision rather than a
refactor, so here it is with the reasoning:

**An assigned profile beats `MonitoredItem.Languages`.**

That field is *accumulated*, not curated. `pkg/monitoring/sync.go:104` unions in
every language it is ever asked for and never removes one, so it cannot express
"stop wanting German" — it only grows. A profile assignment is a deliberate
per-file choice made in the UI. An append-only accumulation should not override
a deliberate choice.

`TestAssignedProfileBeatsMonitoredItemLanguages` pins it: the item asks for `de`,
the profile asks for `es` then `fr`, and exactly the profile's languages must be
fetched. It would also catch the two being merged rather than one winning.

## What changed

`scanner.ProcessWithProfileIfAssigned` is the single place that decision lives.
It downloads the profile's languages in priority order and **returns whether it
took over**, so callers with no assignment fall through unchanged. Getting that
boolean wrong is silent in both directions — reporting handled when it did
nothing loses the download, reporting unhandled after downloading duplicates it
— so it has its own test.

Wired: the monitor loop, the filesystem watcher (both event loops), the Sonarr
and Radarr webhook handlers, and `subtitle-manager sonarr`/`radarr`.

## What is deliberately left alone

Requests that **name a language directly**: the web download endpoint's `?lang=`,
the custom webhook's validated `lang` field, and `fetch <file> <lang>`. Those are
someone asking for one specific thing right now, not stating a policy about the
file. The Sonarr/Radarr handlers are wired precisely because nothing in an *arr
import names a language for that file — they were falling back to a configured
default.

The monitor's retry/blacklist bookkeeping moved into `recordCheckOutcome`, shared
by both paths, so a profile-assigned item still retries, fails and auto-blacklists
identically rather than skipping status updates.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...`, and
`go test -race ./pkg/monitoring/ ./pkg/scanner/ ./pkg/watcher/ ./pkg/webhooks/`
all clean. The race run matters here: the precedence test mutates
`providers.SetInstances`/`RegisterFactory` package globals while the fetch wave
reads them from goroutines.

Two new tests, both non-vacuous:

- Reverting the monitor wiring makes
  `TestAssignedProfileBeatsMonitoredItemLanguages` fail in 0.16s, reporting the
  stray `de` subtitle and the two missing ones.
- The helper's handled/unhandled contract is covered in both directions in
  `pkg/scanner`.

Two things worth flagging from writing those:

**The mock has to return real SRT.** `providers.looksLikeSubtitle` rejects a 200
whose body is not subtitle-shaped — added because stub providers were answering
200 to everything and ending the search. Scanner tests never hit it because they
inject a provider directly; a test that goes through the registry exercises
meaningfully more.

**The `de` expectation is declared `.Maybe()` on purpose.** Without it the
regression case makes testify call `FailNow` inside the provider goroutine, which
deadlocks against the fetch wave's `WaitGroup` and turns a clear assertion
failure into a ten-minute hang. I confirmed that hang before fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3