### PR TITLE
fix(webserver): stop syscall.Statfs breaking every Windows release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 2.0.1
+# version: 2.1.0
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
 
 name: Continuous Integration
@@ -46,3 +46,38 @@ jobs:
       skip-e2e-tests: true
       skip-linting: false
     secrets: inherit
+
+  # Compile every platform goreleaser ships.
+  #
+  # The reusable CI above builds only the runner's own platform, so a
+  # Unix-only syscall compiled fine on Linux and broke the release build
+  # instead — releases failed for days while every PR stayed green. This is a
+  # compile check, not a test run: cross-compiled binaries cannot be executed
+  # here, and catching the build break is the whole point.
+  cross-build:
+    name: Cross-compile release targets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: go build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 2.1.0
+# version: 2.1.1
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
 
 name: Continuous Integration
@@ -70,8 +70,11 @@ jobs:
           - goos: windows
             goarch: amd64
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      # SHA-pinned to match every other workflow here; this repo's policy
+      # rejects tag refs, which fails the job at set-up time rather than at the
+      # build step.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
           cache: true

--- a/changelog.d/20260804-fix-windows-release-build.md
+++ b/changelog.d/20260804-fix-windows-release-build.md
@@ -1,0 +1,20 @@
+### Fixed
+
+#### Releases build again on Windows
+
+Every release since at least 2026-08-03 failed. `pkg/webserver/system.go` called
+`syscall.Statfs` unconditionally to report disk usage, and that call does not
+exist on Windows, so goreleaser's `windows/amd64` build failed and took the
+whole release with it — while CI stayed green, because CI only ever compiled the
+runner's own platform.
+
+Disk usage now goes through a small per-platform helper: `statfs` on Unix,
+`GetDiskFreeSpaceEx` on Windows. On Windows the free figure is the bytes
+available *to the caller* rather than total free bytes; the two differ under
+disk quotas, and the former is the more useful answer to "how much room is left
+for subtitles". `"/"` is also not a volume on Windows, so the queried root now
+comes from `SystemDrive`.
+
+CI gained a `cross-build` job that compiles all four targets goreleaser ships
+(linux/amd64, linux/arm64, darwin/arm64, windows/amd64). Without it this class
+of break stays invisible until a release fails, which is exactly what happened.

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.40.0
 	google.golang.org/api v0.287.1
 	google.golang.org/grpc v1.82.1
@@ -140,7 +141,6 @@ require (
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect

--- a/pkg/webserver/diskusage_test.go
+++ b/pkg/webserver/diskusage_test.go
@@ -1,0 +1,53 @@
+// file: pkg/webserver/diskusage_test.go
+// version: 1.0.0
+// guid: c04a8f16-5b93-4e27-a1d8-36f905e2b7c3
+// last-edited: 2026-08-04
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDiskUsageReportsSomething pins that the platform helper actually queries
+// the filesystem rather than silently returning zeros.
+//
+// Zeros are the documented failure value, so a helper that always failed would
+// still satisfy the type checker and produce a valid JSON response. Any real
+// machine running this test has a non-empty root filesystem.
+func TestDiskUsageReportsSomething(t *testing.T) {
+	free, total := diskUsage(systemRoot())
+	if total == 0 {
+		t.Fatalf("diskUsage(%q) reported total=0; the query failed", systemRoot())
+	}
+	if free > total {
+		t.Errorf("free (%d) exceeds total (%d)", free, total)
+	}
+}
+
+// TestSystemHandlerReportsDisk covers the handler wiring, since the fields are
+// what the UI reads.
+func TestSystemHandlerReportsDisk(t *testing.T) {
+	rr := httptest.NewRecorder()
+	systemHandler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/system", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rr.Code)
+	}
+
+	var got struct {
+		OS        string `json:"os"`
+		DiskTotal uint64 `json:"disk_total"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OS == "" {
+		t.Error("os is empty")
+	}
+	if got.DiskTotal == 0 {
+		t.Error("disk_total is 0; the handler is not reaching the platform helper")
+	}
+}

--- a/pkg/webserver/diskusage_unix.go
+++ b/pkg/webserver/diskusage_unix.go
@@ -1,0 +1,28 @@
+// file: pkg/webserver/diskusage_unix.go
+// version: 1.0.0
+// guid: 2d81f4a6-73c0-4b19-8e52-6f0a9d31bc47
+// last-edited: 2026-08-04
+
+//go:build !windows
+
+package webserver
+
+import "syscall"
+
+// diskUsage reports the free and total bytes of the filesystem holding path.
+//
+// Both are zero when the filesystem cannot be queried. The caller reports these
+// as informational system stats, so a failure here should degrade the numbers
+// rather than fail the request.
+func diskUsage(path string) (free, total uint64) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(path, &fs); err != nil {
+		return 0, 0
+	}
+	// Bsize is int64 on Linux and int32 on Darwin, hence the conversion.
+	bsize := uint64(fs.Bsize)
+	return fs.Bfree * bsize, fs.Blocks * bsize
+}
+
+// systemRoot is the path whose filesystem the system stats describe.
+func systemRoot() string { return "/" }

--- a/pkg/webserver/diskusage_windows.go
+++ b/pkg/webserver/diskusage_windows.go
@@ -1,0 +1,46 @@
+// file: pkg/webserver/diskusage_windows.go
+// version: 1.0.0
+// guid: 8b52c07e-1a4d-4f39-95c6-0e73d2b8a614
+// last-edited: 2026-08-04
+
+//go:build windows
+
+package webserver
+
+import (
+	"golang.org/x/sys/windows"
+	"os"
+)
+
+// diskUsage reports the free and total bytes of the volume holding path.
+//
+// Windows has no statfs; GetDiskFreeSpaceEx is the equivalent. Both values are
+// zero when the volume cannot be queried, matching the Unix implementation —
+// the caller reports these as informational stats and should degrade the
+// numbers rather than fail the request.
+//
+// The "free" figure is the caller-available free bytes rather than the total
+// free bytes, which differ when disk quotas are in force. Available is the more
+// useful of the two for "how much room is left for subtitles".
+func diskUsage(path string) (free, total uint64) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, 0
+	}
+	var availableToCaller, totalBytes, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &availableToCaller, &totalBytes, &totalFree); err != nil {
+		return 0, 0
+	}
+	return availableToCaller, totalBytes
+}
+
+// systemRoot is the path whose volume the system stats describe.
+//
+// "/" is not a volume on Windows. SystemDrive is normally "C:", which
+// GetDiskFreeSpaceEx needs as a directory path, hence the separator.
+func systemRoot() string {
+	if drive := os.Getenv("SystemDrive"); drive != "" {
+		return drive + `\`
+	}
+	return `C:\`
+}

--- a/pkg/webserver/system.go
+++ b/pkg/webserver/system.go
@@ -1,7 +1,7 @@
 // file: pkg/webserver/system.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 37c23ec8-b8b9-4086-be5c-8058fee3fd54
-// last-edited: 2026-07-30
+// last-edited: 2026-08-04
 
 package webserver
 
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"syscall"
 	"time"
 
 	"github.com/spf13/viper"
@@ -58,16 +57,17 @@ func systemHandler() http.Handler {
 		DiskTotal  uint64 `json:"disk_total"`
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var statfs syscall.Statfs_t
-		root := "/"
-		_ = syscall.Statfs(root, &statfs)
+		// Disk stats come from a per-platform helper: Windows has no statfs,
+		// and calling syscall.Statfs unconditionally broke every release build
+		// for the windows target while the Linux build stayed green.
+		free, total := diskUsage(systemRoot())
 		data := info{
 			GoVersion:  runtime.Version(),
 			OS:         runtime.GOOS,
 			Arch:       runtime.GOARCH,
 			Goroutines: runtime.NumGoroutine(),
-			DiskFree:   statfs.Bfree * uint64(statfs.Bsize),
-			DiskTotal:  statfs.Blocks * uint64(statfs.Bsize),
+			DiskFree:   free,
+			DiskTotal:  total,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(data)


### PR DESCRIPTION
**Releases have been failing since at least 2026-08-03** and nothing surfaced
it — every PR stayed green. Found while checking why `Release | main` showed
`completed/failure` after today's merges.

```
pkg/webserver/system.go:61:22: undefined: syscall.Statfs_t
pkg/webserver/system.go:63:15: undefined: syscall.Statfs
⨯ release failed after 7m37s
```

`systemHandler` called `syscall.Statfs` unconditionally to report disk usage.
That call does not exist on Windows, so goreleaser's `windows/amd64` build
failed and took the entire release with it. Reproduced locally with
`GOOS=windows go build ./...` before changing anything.

## The fix

Disk usage moves behind a per-platform helper:

- `diskusage_unix.go` (`!windows`) — `syscall.Statfs`. `Bsize` is `int64` on
  Linux and `int32` on Darwin, hence the explicit conversion.
- `diskusage_windows.go` (`windows`) — `GetDiskFreeSpaceEx`.

Two Windows details worth a look:

- The free figure is the bytes **available to the caller**, not total free
  bytes. They diverge under disk quotas, and the former is the better answer to
  "how much room is left for subtitles".
- `"/"` is not a volume on Windows, so the queried root comes from
  `SystemDrive` (falling back to `C:\`).

Both return `(0, 0)` on failure, matching the previous behaviour of ignoring the
`Statfs` error — these are informational stats and shouldn't fail the request.

`golang.org/x/sys` moves from indirect to direct in `go.mod`.

## The part that matters more than the fix

**CI gains a `cross-build` job** compiling all four targets goreleaser ships:
linux/amd64, linux/arm64, darwin/arm64, windows/amd64. The reusable CI workflow
only ever built the runner's own platform, which is why a Unix-only syscall
sailed through every check and only broke at release time. Without this, the
same class of break recurs and is again invisible for days.

It is a compile check, not a test run — cross-compiled binaries can't execute on
the runner, and catching the build break is the entire point.

## Testing

- `go build ./...` for **all four targets** — the windows one fails on `main`
  and passes here.
- `go test ./pkg/webserver/` clean.
- Two new tests. `TestDiskUsageReportsSomething` exists because `(0, 0)` is the
  documented failure value, so a helper that always failed would still
  type-check and still return valid JSON. Breaking the helper to always fail
  makes both new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3