### PR TITLE
fix(scanner): apply a language profile's cutoff score and Forced/HI when scoring

### DIFF
--- a/changelog.d/20260804-profile-scoring-overrides.md
+++ b/changelog.d/20260804-profile-scoring-overrides.md
@@ -1,0 +1,20 @@
+### Fixed
+
+#### A language profile's cutoff score and Forced/HI flags now reach the scorer
+
+A language profile carries a `CutoffScore` and per-language `Forced`/`HI`
+preferences, and none of them affected anything. The download path scored every
+candidate with the global `scoring.*` settings, so a profile saying "Spanish,
+forced, minimum score 90" was honoured only in its choice of language — the
+threshold and the flags were dropped silently, which made profiles look far more
+configurable than they were.
+
+The file's assigned profile is now layered over the global scoring profile:
+`CutoffScore` replaces the minimum score, and a language marked `Forced` or `HI`
+turns on the matching allow/prefer flags for that language only.
+
+Two deliberate limits. A *false* `Forced`/`HI` is not treated as a prohibition —
+the flags mean "this is preferred", not "reject everything else", so turning one
+off returns to the global policy rather than narrowing to nothing. And a file
+with no assignment is scored exactly as before, so nothing changes for anyone
+not using profiles.

--- a/docs/BAZARR_PARITY_STATUS.md
+++ b/docs/BAZARR_PARITY_STATUS.md
@@ -184,11 +184,13 @@ production with a fully green test suite.
   Deliberately **not** overridden: requests that name a language directly, i.e.
   the web download endpoint's `?lang=`, the custom webhook's validated `lang`,
   and `fetch <file> <lang>`. Those are one specific request, not a policy.
-- **Cutoff score and Forced/HI are dropped.** `processWithAssignedProfile`
-  passes a bare language code, so `ProcessFile` scores candidates with
-  `scoring.LoadProfileFromConfig()` — the global `scoring.*` settings. The
-  per-language `Forced`/`HI` preferences and the profile's `CutoffScore` never
-  reach the scorer. Only the retired `scoredProfileFetch` ever applied them.
+- ~~Cutoff score and Forced/HI are dropped.~~ **Fixed 2026-08-04.**
+  `applyAssignedProfileOverrides` layers the file's assigned profile over the
+  global scoring profile inside `fetchBestScored`: `CutoffScore` replaces the
+  minimum score, and a language marked `Forced`/`HI` turns on the matching
+  allow/prefer flags for that language only. A *false* flag is not a
+  prohibition — it returns to the global policy rather than narrowing to
+  nothing — and an unassigned file is scored exactly as before.
 - ~~A file explicitly assigned the default profile reads as unassigned.~~
   **Fixed 2026-08-04.** `GetAssignedProfileID` was added to `SubtitleStore` and
   all three implementations; it reports whether an assignment row exists,

--- a/pkg/scanner/profile_scoring.go
+++ b/pkg/scanner/profile_scoring.go
@@ -1,0 +1,86 @@
+// file: pkg/scanner/profile_scoring.go
+// version: 1.0.0
+// guid: 3b7e02c9-14a6-4d58-9e07-8c15f2a4d6b3
+// last-edited: 2026-08-04
+
+package scanner
+
+import (
+	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
+	"github.com/jdfalk/subtitle-manager/pkg/scoring"
+	"github.com/jdfalk/subtitle-manager/pkg/security"
+)
+
+// applyAssignedProfileOverrides layers a media file's assigned language profile
+// on top of the global scoring profile.
+//
+// # Why this exists
+//
+// A language profile carries a CutoffScore and per-language Forced/HI
+// preferences, and none of them reached the scorer. The download path scored
+// every candidate with scoring.LoadProfileFromConfig() — the global scoring.*
+// settings — so a profile that said "Spanish, forced, minimum score 90" was
+// honoured only in its choice of language. The threshold and the flags were
+// silently dropped, which made the profile look far more configurable than it
+// was.
+//
+// The lookup happens here rather than being threaded through ProcessFile
+// because ProcessFile has a dozen callers and only needs the media path and
+// language, both of which it already has. That also means every caller benefits,
+// including the single-language paths where a file happens to have a profile.
+//
+// A false Forced/HI is deliberately not treated as a prohibition. The flags mean
+// "this is preferred", not "reject everything else"; turning a preference off
+// should widen the candidate set back to the global policy, not narrow it to
+// nothing.
+func applyAssignedProfileOverrides(p scoring.Profile, mediaPath, lang string, store database.SubtitleStore) scoring.Profile {
+	logger := logging.GetLogger("scanner")
+
+	lookupStore := store
+	if lookupStore == nil {
+		var err error
+		if lookupStore, err = database.GetSharedStore(); err != nil {
+			return p
+		}
+	}
+
+	// The assignment is keyed on the sanitized path, the same key the web
+	// handler writes and assignedProfileLanguages reads.
+	sanitized, err := security.ValidateAndSanitizePath(mediaPath)
+	if err != nil {
+		return p
+	}
+
+	assignedID, err := lookupStore.GetAssignedProfileID(sanitized)
+	if err != nil || assignedID == "" {
+		return p
+	}
+	profile, err := lookupStore.GetLanguageProfile(assignedID)
+	if err != nil || profile == nil {
+		return p
+	}
+
+	if profile.CutoffScore > 0 {
+		p.MinScore = profile.CutoffScore
+	}
+
+	for _, l := range profile.Languages {
+		if l.Language != lang {
+			continue
+		}
+		if l.HI {
+			p.AllowHI = true
+			p.PreferHI = true
+		}
+		if l.Forced {
+			p.AllowForced = true
+			p.PreferForced = true
+		}
+		break
+	}
+
+	logger.Debugf("scoring %s (%s) with profile %s: min score %d, preferHI=%t preferForced=%t",
+		sanitized, lang, profile.ID, p.MinScore, p.PreferHI, p.PreferForced)
+	return p
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: pkg/scanner/scanner.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: ad2ef6ba-8afa-4ced-8508-0c535dbb23fd
 // last-edited: 2026-08-04
 package scanner
@@ -120,7 +120,7 @@ func ProcessFile(ctx context.Context, path, lang string, providerName string, p 
 	var matchScore *float64
 	scoredHandled := false
 	if sp, ok := p.(scoredProvider); ok && scoringEnabled() {
-		res, ferr := fetchBestScored(ctx, sp, path, lang)
+		res, ferr := fetchBestScored(ctx, sp, path, lang, store)
 		if ferr != nil {
 			err = ferr
 		} else if res == nil {

--- a/pkg/scanner/scored.go
+++ b/pkg/scanner/scored.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/scored.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9f2c8b41-6d0e-4a7c-b3f5-1e8a0c2d4b6a
-// last-edited: 2026-07-31
+// last-edited: 2026-08-04
 
 package scanner
 
@@ -52,7 +52,7 @@ type scoredResult struct {
 // score. It returns (nil, nil) when no candidate clears the threshold (a normal
 // "nothing good enough" outcome, not an error) and a non-nil error only on a
 // search or download failure.
-func fetchBestScored(ctx context.Context, sp scoredProvider, mediaPath, lang string) (*scoredResult, error) {
+func fetchBestScored(ctx context.Context, sp scoredProvider, mediaPath, lang string, store database.SubtitleStore) (*scoredResult, error) {
 	results, err := sp.SearchWithResults(ctx, mediaPath, lang)
 	if err != nil {
 		return nil, err
@@ -65,6 +65,9 @@ func fetchBestScored(ctx context.Context, sp scoredProvider, mediaPath, lang str
 	if err := scoring.ValidateProfile(profile); err != nil {
 		profile = scoring.DefaultProfile()
 	}
+	// A file with its own language profile scores against that profile's cutoff
+	// and Forced/HI preferences rather than only the global scoring.* settings.
+	profile = applyAssignedProfileOverrides(profile, mediaPath, lang, store)
 
 	subs := make([]scoring.Subtitle, len(results))
 	for i, r := range results {

--- a/pkg/scanner/scored_test.go
+++ b/pkg/scanner/scored_test.go
@@ -1,7 +1,7 @@
 // file: pkg/scanner/scored_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4e91a72-8b3d-4f60-a1c7-5d2e9f0b3a48
-// last-edited: 2026-07-23
+// last-edited: 2026-08-04
 
 package scanner
 
@@ -14,7 +14,9 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jdfalk/subtitle-manager/pkg/database"
+	"github.com/jdfalk/subtitle-manager/pkg/profiles"
 	"github.com/jdfalk/subtitle-manager/pkg/providers/opensubtitles"
+	"github.com/jdfalk/subtitle-manager/pkg/scoring"
 )
 
 // fakeScored implements both providers.Provider and the scanner's scoredProvider
@@ -148,5 +150,164 @@ func TestPriorMatchScore(t *testing.T) {
 	}
 	if priorMatchScore(store, "v.mkv", "de") != nil {
 		t.Fatal("expected nil for language with no records")
+	}
+}
+
+// assignScoringProfile stores a language profile and assigns it to vid.
+func assignScoringProfile(t *testing.T, store database.SubtitleStore, vid string, cutoff int, langs ...profiles.LanguageConfig) {
+	t.Helper()
+	if err := store.CreateLanguageProfile(&database.LanguageProfile{
+		ID:          "scored",
+		Name:        "Scored",
+		Languages:   langs,
+		CutoffScore: cutoff,
+	}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if err := store.AssignProfileToMedia(vid, "scored"); err != nil {
+		t.Fatalf("assign profile: %v", err)
+	}
+}
+
+// TestAssignedProfileCutoffGatesDownload is the point of the change: a language
+// profile's CutoffScore never reached the scorer, so a profile demanding a high
+// minimum score downloaded whatever the global scoring.* settings allowed.
+//
+// The global minimum is 0 here, so without the override the strong candidate is
+// downloaded. The profile demands 100, which nothing can reach.
+func TestAssignedProfileCutoffGatesDownload(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("scoring.enabled", true)
+	viper.Set("scoring.min_score", 0)
+	defer viper.Reset()
+
+	base := "Inception.2010.1080p.BluRay.x264-GROUP"
+	vid := filepath.Join(dir, base+".mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	assignScoringProfile(t, store, vid, 100, profiles.LanguageConfig{Language: "en", Priority: 1})
+
+	p := newFakeScored(base)
+	if err := ProcessFile(context.Background(), vid, "en", "opensubtitles", p, false, store); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, base+".en.srt")); err == nil {
+		t.Error("downloaded a subtitle below the profile's cutoff score; CutoffScore is being ignored")
+	}
+}
+
+// TestAssignedProfileCutoffAllowsQualifyingDownload is the control. Without it,
+// an override that rejected everything would look like a working gate.
+func TestAssignedProfileCutoffAllowsQualifyingDownload(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	viper.Set("scoring.enabled", true)
+	// A high global minimum that the profile must *lower* for this to pass,
+	// which also proves the override replaces the global value rather than
+	// merely tightening it.
+	viper.Set("scoring.min_score", 100)
+	defer viper.Reset()
+
+	base := "Inception.2010.1080p.BluRay.x264-GROUP"
+	vid := filepath.Join(dir, base+".mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	assignScoringProfile(t, store, vid, 1, profiles.LanguageConfig{Language: "en", Priority: 1})
+
+	p := newFakeScored(base)
+	if err := ProcessFile(context.Background(), vid, "en", "opensubtitles", p, false, store); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, base+".en.srt"))
+	if err != nil {
+		t.Fatalf("nothing downloaded; the profile's cutoff did not replace the global minimum: %v", err)
+	}
+	if string(data) != "good sub" {
+		t.Errorf("got %q, want the best candidate", data)
+	}
+}
+
+// TestAssignedProfileSetsForcedAndHIPreferences pins that the per-language flags
+// reach the scorer at all. They were dropped entirely, so a profile asking for
+// forced or hearing-impaired subtitles scored them exactly like any other.
+func TestAssignedProfileSetsForcedAndHIPreferences(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	assignScoringProfile(t, store, vid, 0,
+		profiles.LanguageConfig{Language: "en", Priority: 1, Forced: true, HI: true},
+		profiles.LanguageConfig{Language: "fr", Priority: 2})
+
+	base := scoring.Profile{}
+	got := applyAssignedProfileOverrides(base, vid, "en", store)
+	if !got.PreferHI || !got.AllowHI {
+		t.Error("HI preference did not reach the scorer")
+	}
+	if !got.PreferForced || !got.AllowForced {
+		t.Error("Forced preference did not reach the scorer")
+	}
+
+	// The flags are per language: fr asked for neither, so it must be untouched.
+	other := applyAssignedProfileOverrides(base, vid, "fr", store)
+	if other.PreferHI || other.PreferForced {
+		t.Error("applied en's flags to fr; the preferences are per language")
+	}
+}
+
+// TestUnassignedFileKeepsGlobalScoring pins that a file with no assignment is
+// scored exactly as before, so this change cannot alter existing behaviour for
+// anyone not using profiles.
+func TestUnassignedFileKeepsGlobalScoring(t *testing.T) {
+	dir := t.TempDir()
+	viper.Reset()
+	viper.Set("media_directory", dir)
+	defer viper.Reset()
+
+	vid := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(vid, []byte("x"), 0644); err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	store, err := database.OpenPebble(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	base := scoring.Profile{MinScore: 42}
+	got := applyAssignedProfileOverrides(base, vid, "en", store)
+	if got.MinScore != base.MinScore || got.PreferHI || got.PreferForced ||
+		got.AllowHI || got.AllowForced {
+		t.Errorf("changed the scoring profile for an unassigned file: %+v", got)
 	}
 }


### PR DESCRIPTION
Closes the last real hole in the language-profile feature, and the item I
deliberately scoped out of #2242 rather than growing that PR.

A language profile carries a `CutoffScore` and per-language `Forced`/`HI`
preferences. **None of them affected anything.** The download path scored every
candidate with `scoring.LoadProfileFromConfig()` — the *global* `scoring.*`
settings — so a profile saying "Spanish, forced, minimum score 90" was honoured
only in its choice of language. The threshold and the flags were dropped
silently, which made profiles look far more configurable than they were.

## The fix

`applyAssignedProfileOverrides` layers the file's assigned profile over the
global one inside `fetchBestScored`:

- `CutoffScore` **replaces** `MinScore` (it does not merely tighten it — see the
  control test below).
- A language marked `Forced` or `HI` turns on the matching allow/prefer flags,
  **for that language only**.

The lookup happens in the scorer rather than being threaded through
`ProcessFile`, which has a dozen callers and already has both the media path and
the language. That also means every caller benefits, including the
single-language paths where a file happens to have a profile assigned.

## Two deliberate limits, worth disagreeing with

**A false `Forced`/`HI` is not a prohibition.** The flags mean "this is
preferred", not "reject everything else". Turning one off returns to the global
policy rather than narrowing the candidate set to nothing. The alternative —
`HI: false` meaning `AllowHI: false` — would make an unticked checkbox silently
discard valid subtitles.

**An unassigned file is scored exactly as before.** Nothing changes for anyone
not using profiles, and `TestUnassignedFileKeepsGlobalScoring` pins it.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...`, and
`go test -race ./pkg/scanner/` all clean.

Four new tests, and the pair of cutoff tests is deliberately symmetric:

- `TestAssignedProfileCutoffGatesDownload` — global minimum 0, profile demands
  100, nothing may be downloaded.
- `TestAssignedProfileCutoffAllowsQualifyingDownload` — global minimum **100**,
  profile lowers it to 1, the best candidate must be downloaded. This is the
  control: without it, an override that rejected everything would look like a
  working gate, and it also proves the profile *replaces* the global value
  rather than only tightening it.

Non-vacuity: removing the single override call makes **both** cutoff tests fail,
each with the message describing its own direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3