### PR TITLE
fix(providers): make opensubtitlescom real and correct legacy api_url values

### DIFF
--- a/changelog.d/20260804-opensubtitles-endpoint-fixes.md
+++ b/changelog.d/20260804-opensubtitles-endpoint-fixes.md
@@ -1,0 +1,29 @@
+### Fixed
+
+#### The `opensubtitlescom` provider was a stub that could never work
+
+It pointed at `api.opensubtitlescom.com` — not a real host; the API lives at
+`api.opensubtitles.com` — and issued `GET /subtitles/{name}/{lang}`, an endpoint
+that exists in no version of the API. It could never have returned a subtitle,
+and because the registry offered it as a separate provider, every fetch wave
+tried it, consumed one of the concurrent slots, and failed.
+
+Meanwhile `pkg/providers/opensubtitles` is already a complete REST v1 client. So
+`opensubtitlescom` is now a thin wrapper over it rather than a second
+implementation. Credentials are read from `opensubtitles.*`, falling back to
+`providers.opensubtitlescom.*` — the spelling a Bazarr import produces for this
+provider name — with the former winning, so this cannot change a working setup.
+
+The fallback is read inline rather than written back into viper. Provider
+constructors run inside the fetch wave's goroutines, so mutating global config
+there would be a data race against viper's non-thread-safe map and would
+silently rewrite configuration for every other component too.
+
+#### A legacy `opensubtitles.api_url` no longer breaks every request
+
+The client speaks REST v1 only. A config carried over from the XML-RPC or legacy
+REST API keeps a host like `rest.opensubtitles.org`, which cannot serve those
+requests — verified 2026-08-04: it answers the v1 search path with 400, while
+`api.opensubtitles.com/api/v1` answers 403, i.e. exists and merely wants
+credentials. Known-legacy hosts are now replaced with the v1 base and a warning
+naming the setting. Any other configured value is honoured untouched.

--- a/pkg/providers/opensubtitles/opensubtitles.go
+++ b/pkg/providers/opensubtitles/opensubtitles.go
@@ -1,7 +1,7 @@
 // file: pkg/providers/opensubtitles/opensubtitles.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5af27051-d855-4321-9990-c4a59eaabbd5
-// last-edited: 2026-07-23
+// last-edited: 2026-08-04
 
 package opensubtitles
 
@@ -12,10 +12,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/logging"
 )
 
 // LoginResponse represents the response from the OpenSubtitles login API
@@ -120,10 +124,7 @@ type Client struct {
 
 // New returns a new Client configured with username/password from viper config.
 func New(_ string) *Client {
-	apiURL := viper.GetString("opensubtitles.api_url")
-	if apiURL == "" {
-		apiURL = "https://api.opensubtitles.com/api/v1"
-	}
+	apiURL := resolveAPIURL(viper.GetString("opensubtitles.api_url"))
 	ua := viper.GetString("opensubtitles.user_agent")
 	if ua == "" {
 		ua = "subtitle-manager v1.0"
@@ -135,6 +136,68 @@ func New(_ string) *Client {
 	return &Client{
 		APIURL:     apiURL,
 		UserAgent:  ua,
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		username:   username,
+		password:   password,
+	}
+}
+
+// DefaultAPIURL is the OpenSubtitles.com REST v1 base this client speaks.
+const DefaultAPIURL = "https://api.opensubtitles.com/api/v1"
+
+// legacyHosts are OpenSubtitles endpoints that predate the REST v1 API. This
+// client only speaks v1 — POST /login, GET /subtitles?moviehash=..., POST
+// /download — so pointing it at one of these produces nothing but failures.
+//
+// They appear in real configs because they were the correct value for the old
+// XML-RPC and legacy REST APIs, and a config carried forward from either keeps
+// the stale host. Verified 2026-08-04: rest.opensubtitles.org answers the v1
+// search path with 400, while api.opensubtitles.com/api/v1 answers 403 (missing
+// key), i.e. the endpoint exists and only wants credentials.
+var legacyHosts = map[string]bool{
+	"rest.opensubtitles.org": true,
+	"api.opensubtitles.org":  true,
+	"www.opensubtitles.org":  true,
+	"opensubtitles.org":      true,
+}
+
+// resolveAPIURL returns the API base to use, correcting a known-legacy host.
+//
+// An explicitly configured URL is otherwise honoured untouched — overriding it
+// is how the tests point the client at httptest, and second-guessing an
+// operator's deliberate value would be worse than a clear failure. Only hosts
+// that provably cannot serve this client's requests are replaced, and that is
+// said out loud rather than done silently.
+func resolveAPIURL(configured string) string {
+	if configured == "" {
+		return DefaultAPIURL
+	}
+	u, err := url.Parse(configured)
+	if err != nil || !legacyHosts[strings.ToLower(u.Hostname())] {
+		return configured
+	}
+	logging.GetLogger("opensubtitles").Warnf(
+		"opensubtitles.api_url is %q, which is a legacy endpoint this client cannot use; falling back to %s. Remove the setting or set it to the v1 base to silence this.",
+		configured, DefaultAPIURL)
+	return DefaultAPIURL
+}
+
+// NewWithCredentials builds a client from explicit values.
+//
+// It exists so a caller that resolves configuration itself does not have to
+// mutate global viper state to influence New(). Provider constructors run
+// inside the fetch wave's goroutines, one per provider per fetch, so a
+// viper.Set there is a data race against viper's non-thread-safe global map —
+// and quietly rewrites config for every other component besides.
+//
+// Empty values fall back to the same defaults New() uses.
+func NewWithCredentials(apiURL, userAgent, username, password string) *Client {
+	if userAgent == "" {
+		userAgent = "subtitle-manager v1.0"
+	}
+	return &Client{
+		APIURL:     resolveAPIURL(apiURL),
+		UserAgent:  userAgent,
 		HTTPClient: &http.Client{Timeout: 15 * time.Second},
 		username:   username,
 		password:   password,

--- a/pkg/providers/opensubtitles/opensubtitles_test.go
+++ b/pkg/providers/opensubtitles/opensubtitles_test.go
@@ -1,3 +1,8 @@
+// file: pkg/providers/opensubtitles/opensubtitles_test.go
+// version: 1.0.0
+// guid: 6bd3fcef-66ea-425f-be25-cbcea87859fe
+// last-edited: 2026-08-04
+
 package opensubtitles
 
 import (
@@ -127,5 +132,43 @@ func TestNewUsesConfig(t *testing.T) {
 	}
 	if c.UserAgent != "ua" {
 		t.Fatalf("expected user_agent ua, got %s", c.UserAgent)
+	}
+}
+
+// TestResolveAPIURLCorrectsLegacyHosts pins that a config carried over from the
+// old XML-RPC or legacy REST API does not silently break every request.
+//
+// This client only speaks REST v1 (POST /login, GET /subtitles?moviehash=...,
+// POST /download). Verified 2026-08-04: rest.opensubtitles.org answers the v1
+// search path with 400, while api.opensubtitles.com/api/v1 answers 403 —
+// i.e. the endpoint exists and only wants credentials.
+func TestResolveAPIURLCorrectsLegacyHosts(t *testing.T) {
+	for _, legacy := range []string{
+		"https://rest.opensubtitles.org",
+		"https://api.opensubtitles.org/xml-rpc",
+		"http://www.opensubtitles.org",
+	} {
+		if got := resolveAPIURL(legacy); got != DefaultAPIURL {
+			t.Errorf("resolveAPIURL(%q) = %q, want %q", legacy, got, DefaultAPIURL)
+		}
+	}
+}
+
+// TestResolveAPIURLHonoursDeliberateOverrides is the control. Overriding the
+// base URL is how these tests point the client at httptest, and second-guessing
+// an operator's deliberate value would be worse than a clear failure — so only
+// hosts that provably cannot serve this client are replaced.
+func TestResolveAPIURLHonoursDeliberateOverrides(t *testing.T) {
+	for _, keep := range []string{
+		"http://127.0.0.1:8080",
+		"https://api.opensubtitles.com/api/v1",
+		"https://mirror.example.com/api/v1",
+	} {
+		if got := resolveAPIURL(keep); got != keep {
+			t.Errorf("resolveAPIURL(%q) = %q, want it unchanged", keep, got)
+		}
+	}
+	if got := resolveAPIURL(""); got != DefaultAPIURL {
+		t.Errorf("empty config = %q, want the default", got)
 	}
 }

--- a/pkg/providers/opensubtitlescom/opensubtitlescom.go
+++ b/pkg/providers/opensubtitlescom/opensubtitlescom.go
@@ -1,48 +1,88 @@
 // file: pkg/providers/opensubtitlescom/opensubtitlescom.go
+// version: 2.0.0
+// guid: 7d3a0c58-2e91-4b46-a5f0-91c48e7d2b03
+// last-edited: 2026-08-04
+
+// Package opensubtitlescom exposes the OpenSubtitles.com REST v1 API under the
+// name operators and Bazarr configs use for it.
+//
+// # Why this is a thin wrapper
+//
+// It used to be an independent stub: it pointed at "api.opensubtitlescom.com" —
+// which is not a real host, the API lives at api.opensubtitles.com — and issued
+// GET /subtitles/{name}/{lang}, an endpoint that exists in no version of the
+// API. It could never have returned a subtitle.
+//
+// Meanwhile pkg/providers/opensubtitles is already a complete v1 client:
+// POST /login, moviehash search against GET /subtitles, and POST /download. So
+// the fix is not to write a second implementation but to stop pretending there
+// are two providers. Registering both names was actively harmful — the registry
+// tried the stub on every fetch wave, where it took one of the concurrent slots
+// and always failed.
 package opensubtitlescom
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"path/filepath"
-	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jdfalk/subtitle-manager/pkg/providers/opensubtitles"
 )
 
-// Client implements the providers.Provider interface for Opensubtitlescom.
-// It performs a simple HTTP GET to download subtitles.
+// Client adapts the OpenSubtitles v1 client to the provider name
+// "opensubtitlescom".
 type Client struct {
-	// APIURL is the base URL of the Opensubtitlescom API.
-	APIURL string
-	// HTTPClient is used to make requests.
-	HTTPClient *http.Client
+	inner *opensubtitles.Client
 }
 
-// New returns a Client configured with reasonable defaults.
+// New returns a client backed by the real OpenSubtitles.com v1 implementation.
+//
+// Credentials normally live under opensubtitles.*. A config may instead carry
+// them under providers.opensubtitlescom.* — the spelling a Bazarr import
+// produces for this provider name — so both are read, with opensubtitles.*
+// winning. Adding this therefore cannot change a setup that already works.
+//
+// The fallback is read inline rather than written back to viper. Provider
+// constructors run inside the fetch wave's goroutines, so mutating global
+// config here would be a data race against viper's non-thread-safe map, and
+// would silently rewrite configuration for every other component too.
 func New() *Client {
-	return &Client{
-		APIURL:     "https://api.opensubtitlescom.com",
-		HTTPClient: &http.Client{Timeout: 15 * time.Second},
-	}
+	return &Client{inner: opensubtitles.NewWithCredentials(
+		pick("api_url"),
+		pick("user_agent"),
+		pick("username"),
+		pick("password"),
+	)}
 }
 
-// Fetch downloads the subtitle for mediaPath in lang.
-// It returns the subtitle bytes or an error.
+// pick returns opensubtitles.<key>, falling back to
+// providers.opensubtitlescom.<key>.
+func pick(key string) string {
+	if v := viper.GetString("opensubtitles." + key); v != "" {
+		return v
+	}
+	return viper.GetString("providers.opensubtitlescom." + key)
+}
+
+// Fetch returns subtitle bytes for mediaPath in lang.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	name := filepath.Base(mediaPath)
-	url := fmt.Sprintf("%s/subtitles/%s/%s", c.APIURL, name, lang)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return io.ReadAll(resp.Body)
+	return c.inner.Fetch(ctx, mediaPath, lang)
+}
+
+// Search returns candidate subtitle URLs, keeping the Searcher capability the
+// underlying client offers.
+func (c *Client) Search(ctx context.Context, mediaPath, lang string) ([]string, error) {
+	return c.inner.Search(ctx, mediaPath, lang)
+}
+
+// SearchWithResults exposes scored search, which is what lets the scanner's
+// score-gated download path use this provider instead of falling back to a
+// plain fetch.
+func (c *Client) SearchWithResults(ctx context.Context, mediaPath, lang string) ([]opensubtitles.SearchResult, error) {
+	return c.inner.SearchWithResults(ctx, mediaPath, lang)
+}
+
+// FetchByResult downloads a specific search result.
+func (c *Client) FetchByResult(ctx context.Context, result opensubtitles.SearchResult) ([]byte, error) {
+	return c.inner.FetchByResult(ctx, result)
 }

--- a/pkg/providers/opensubtitlescom/opensubtitlescom_test.go
+++ b/pkg/providers/opensubtitlescom/opensubtitlescom_test.go
@@ -1,3 +1,8 @@
+// file: pkg/providers/opensubtitlescom/opensubtitlescom_test.go
+// version: 2.0.0
+// guid: b91f4e07-6c23-4a85-90d1-4f7e2a6c8503
+// last-edited: 2026-08-04
+
 package opensubtitlescom
 
 import (
@@ -5,28 +10,152 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
-// TestClientFetch verifies that the client downloads subtitles using the expected URL.
-func TestClientFetch(t *testing.T) {
-	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		fmt.Fprint(w, "data")
-	}))
+// v1Server speaks the shape of the OpenSubtitles.com REST v1 API: log in for a
+// token, search /subtitles, POST /download for a link, then fetch the link.
+//
+// The previous test asserted a GET to /subtitles/{name}/{lang} — an endpoint
+// that exists in no version of the API — so it passed against a provider that
+// could never have downloaded anything. Modelling the real conversation is the
+// whole point.
+type v1Server struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (s *v1Server) record(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seen = append(s.seen, path)
+}
+
+func (s *v1Server) paths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.seen...)
+}
+
+func (s *v1Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.record(r.Method + " " + r.URL.Path)
+	switch {
+	case r.URL.Path == "/login":
+		fmt.Fprint(w, `{"token":"t","status":"200"}`)
+	case strings.HasPrefix(r.URL.Path, "/subtitles"):
+		fmt.Fprint(w, `{"data":[{"attributes":{"subtitle_id":"1","release":"GROUP","files":[{"file_id":1}]}}]}`)
+	case r.URL.Path == "/download":
+		fmt.Fprintf(w, `{"link":"http://%s/file.srt"}`, r.Host)
+	case r.URL.Path == "/file.srt":
+		fmt.Fprint(w, "real subtitle")
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// mediaFile writes a real file: the client hashes the media to search by
+// moviehash, so a path that does not exist never reaches the API at all.
+//
+// It must be at least 128 KiB. The OpenSubtitles hash reads 64 KiB from each
+// end of the file, so anything smaller fails with "unexpected EOF" before a
+// single request is made.
+func mediaFile(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "Movie.2020.mkv")
+	if err := os.WriteFile(p, make([]byte, 256*1024), 0644); err != nil {
+		t.Fatalf("create media: %v", err)
+	}
+	return p
+}
+
+func TestFetchUsesTheRealV1API(t *testing.T) {
+	h := &v1Server{}
+	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	c := New()
-	c.APIURL = srv.URL
-	b, err := c.Fetch(context.Background(), "/path/movie.mkv", "en")
-	if err != nil {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("opensubtitles.api_url", srv.URL)
+	viper.Set("opensubtitles.username", "u")
+	viper.Set("opensubtitles.password", "p")
+	vid := mediaFile(t)
+
+	// This asserts the *protocol*, not the payload. The underlying client's
+	// download step is separately broken — it GETs {api}/download?file_id=
+	// instead of POSTing {"file_id":N} and following the returned link — and
+	// that is fixed on its own branch. What matters here is that this provider
+	// now speaks v1 at all rather than a fabricated endpoint.
+	if _, err := New().Fetch(context.Background(), vid, "en"); err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
-	if string(b) != "data" {
-		t.Fatalf("unexpected body: %s", b)
+
+	// The old stub would have issued GET /subtitles/Movie.2020.mkv/en and
+	// nothing else. Assert the v1 conversation actually happened.
+	var searched bool
+	for _, p := range h.paths() {
+		if strings.HasPrefix(p, "GET /subtitles") && !strings.Contains(p, "Movie.2020.mkv") {
+			searched = true
+		}
 	}
-	if gotURL != "/subtitles/movie.mkv/en" {
-		t.Fatalf("unexpected url: %s", gotURL)
+	if !searched {
+		t.Errorf("no v1 search request was made; saw %v", h.paths())
+	}
+}
+
+// TestAlternateConfigKeysAreAdopted covers a config that carries the
+// credentials under providers.opensubtitlescom.* — the spelling a Bazarr import
+// produces for this provider name — rather than opensubtitles.*.
+func TestAlternateConfigKeysAreAdopted(t *testing.T) {
+	h := &v1Server{}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("providers.opensubtitlescom.api_url", srv.URL)
+	viper.Set("providers.opensubtitlescom.username", "u")
+	viper.Set("providers.opensubtitlescom.password", "p")
+	vid := mediaFile(t)
+
+	if _, err := New().Fetch(context.Background(), vid, "en"); err != nil {
+		t.Fatalf("fetch with alternate keys: %v", err)
+	}
+	if len(h.paths()) == 0 {
+		t.Error("no request reached the server; the alternate config keys were not used")
+	}
+}
+
+// TestExistingKeysWin pins that reading the alternate spelling can never change
+// a setup that already works.
+func TestExistingKeysWin(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("opensubtitles.username", "primary")
+	viper.Set("providers.opensubtitlescom.username", "secondary")
+
+	if got := pick("username"); got != "primary" {
+		t.Errorf("username = %q; the existing opensubtitles.* value must win", got)
+	}
+}
+
+// TestConstructionDoesNotMutateConfig pins that resolving the fallback is a
+// read. Provider constructors run concurrently inside the fetch wave, so a
+// viper.Set here would be a data race against viper's global map — and would
+// rewrite configuration for every other component besides.
+func TestConstructionDoesNotMutateConfig(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("providers.opensubtitlescom.username", "secondary")
+
+	New()
+
+	if got := viper.GetString("opensubtitles.username"); got != "" {
+		t.Errorf("constructing the provider wrote opensubtitles.username = %q", got)
 	}
 }


### PR DESCRIPTION
Found while checking whether your OpenSubtitles credentials would actually work.
Two independent problems, both of which made the main credentialed provider
fail silently.

## 1. `opensubtitlescom` was a stub that could never work

It pointed at **`api.opensubtitlescom.com`** — not a real host; the API is
`api.opensubtitles.com` — and issued `GET /subtitles/{name}/{lang}`, an endpoint
that exists in no version of the API. It could never have returned a subtitle.

Worse, the registry offered it as a *separate* provider, so every fetch wave
tried it, consumed one of the concurrent slots, and failed.

`pkg/providers/opensubtitles` is already a complete REST v1 client, so this is
now a thin wrapper over it rather than a second implementation. Credentials come
from `opensubtitles.*`, falling back to `providers.opensubtitlescom.*` — the
spelling a Bazarr import produces for this name — with the former winning, so it
cannot change a working setup.

**The fallback is read inline, not written back into viper.** Provider
constructors run inside the fetch wave's goroutines, so a `viper.Set` there is a
data race against viper's non-thread-safe global map — and would silently
rewrite config for every other component too. I had written the `viper.Set`
version first; `TestConstructionDoesNotMutateConfig` now pins against it, and
`go test -race ./pkg/providers/... ./pkg/scanner/` is clean.

## 2. A legacy `opensubtitles.api_url` breaks every request

This client speaks REST v1 only. A config carried over from the XML-RPC or
legacy REST API keeps a host like `rest.opensubtitles.org`, which cannot serve
those requests. **Your config has exactly this.** Verified live 2026-08-04:

| URL | result |
|---|---|
| `rest.opensubtitles.org/subtitles?languages=en` | **400** |
| `api.opensubtitles.com/api/v1/subtitles?languages=en` | **403** — exists, wants the key |

Known-legacy hosts are now replaced with the v1 base plus a warning naming the
setting. **Any other configured value is honoured untouched** — overriding the
base URL is how the tests reach `httptest`, and second-guessing a deliberate
value would be worse than a clear failure.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...`, and
`go test -race ./pkg/providers/... ./pkg/scanner/` all clean.

The old `opensubtitlescom` test asserted the fabricated endpoint, so it passed
against a provider that could never download anything — a mock encoding a
protocol nothing speaks. It's replaced by one driving the real v1 conversation
(login → search → download → follow link) and asserting the search request
actually happened.

Non-vacuity confirmed on all three behaviours: removing the legacy-host
correction, reintroducing the `viper.Set`, and stubbing `Fetch` each fail their
matching test.

## Known, deliberately NOT fixed here

While writing the mock I found the shared client's **download step is also
wrong**, and it needs its own PR:

- it does `GET {api}/download?file_id=...`; the API wants `POST /download` with
  body `{"file_id": N}`, then a GET of the returned `link`
- it takes the id from `attributes.subtitle_id`; the API's file id lives at
  `attributes.files[].file_id`
- it sets only `Authorization`; the API requires `Api-Key` as well

Confirmed against the [API docs](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started),
not guessed. The existing `opensubtitles` test hides it by serving the file
directly on `GET /download`. Fixing that on this branch would have meant
shipping a mock built on my own reading of a protocol I hadn't confirmed yet, so
it's split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3