### PR TITLE
fix(profiles): reject unknown profile IDs on Pebble, the default backend

### DIFF
--- a/changelog.d/20260804-profile-lookup-pebble-nil.md
+++ b/changelog.d/20260804-profile-lookup-pebble-nil.md
@@ -1,0 +1,24 @@
+### Fixed
+
+#### Assigning a nonexistent language profile no longer silently succeeds
+
+`GetLanguageProfile` signals "no such profile" differently per backend, and
+nothing in the interface said so: the SQL backends return `sql.ErrNoRows` while
+`PebbleStore` returns `(nil, nil)`. Every caller was written against the SQL
+behaviour — "an error means not found" — so on Pebble, which is the **default**
+backend, an unknown profile ID passed validation.
+
+The visible effect: `POST /api/media/profiles/bulk` with a profile ID that does
+not exist returned `200` and `{"succeeded":N,"failed":0}`, writing assignments
+pointing at nothing. Found by driving a running server rather than by a test —
+the existing tests configure SQLite, the one backend where the naive check
+happens to work. The single-item assign route, the profile GET route and both
+`subtitle-manager profiles` subcommands had the identical check.
+
+`database.ProfileMissing` now encodes the divergence in one place and every
+caller asks it. Normalising there rather than changing `PebbleStore` keeps the
+blast radius to the callers that ask this question: `GetMediaProfile` returns
+`GetLanguageProfile`'s result directly, so making Pebble return an error would
+change what a dangling assignment looks like to unrelated callers.
+
+The new regression tests run against Pebble specifically.

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -1,5 +1,5 @@
 // file: cmd/profiles.go
-// version: 1.1.0
+// version: 1.2.0
 // last-edited: 2026-08-04
 // guid: 3f4e5d6c-7b8a-9c0d-1e2f-4e5d6c7b8a9c
 
@@ -197,10 +197,15 @@ var assignProfileCmd = &cobra.Command{
 		defer store.Close()
 
 		// Verify profile exists
+		// Pebble returns (nil, nil) for an unknown ID, so an error check alone
+		// would accept one. See database.ProfileMissing.
 		profile, err := store.GetLanguageProfile(profileID)
-		if err != nil {
-			logger.Errorf("profile not found: %v", err)
+		if database.ProfileMissing(profile, err) {
 			return fmt.Errorf("profile %s not found", profileID)
+		}
+		if err != nil {
+			logger.Errorf("failed to look up profile: %v", err)
+			return err
 		}
 
 		// Assign profile to media using the validated path
@@ -318,10 +323,15 @@ var deleteProfileCmd = &cobra.Command{
 		defer store.Close()
 
 		// Check if it's the default profile
+		// Pebble returns (nil, nil) for an unknown ID, so an error check alone
+		// would accept one. See database.ProfileMissing.
 		profile, err := store.GetLanguageProfile(profileID)
-		if err != nil {
-			logger.Errorf("profile not found: %v", err)
+		if database.ProfileMissing(profile, err) {
 			return fmt.Errorf("profile %s not found", profileID)
+		}
+		if err != nil {
+			logger.Errorf("failed to look up profile: %v", err)
+			return err
 		}
 
 		if profile.IsDefault {

--- a/pkg/database/profilelookup.go
+++ b/pkg/database/profilelookup.go
@@ -1,0 +1,42 @@
+// file: pkg/database/profilelookup.go
+// version: 1.0.0
+// guid: 0a6d24b7-8f19-4c53-b2e0-5d719f3ac846
+// last-edited: 2026-08-04
+
+package database
+
+import (
+	"database/sql"
+	"errors"
+)
+
+// ProfileMissing reports whether a GetLanguageProfile result means "there is no
+// such profile".
+//
+// # Why this is needed
+//
+// The implementations disagree about how a miss is signalled, and nothing in
+// the interface said so:
+//
+//	SQLStore / PostgresStore  ->  (nil, sql.ErrNoRows)
+//	PebbleStore              ->  (nil, nil)
+//
+// Every caller was written against the SQL behaviour — "err != nil means not
+// found" — which silently does the wrong thing on Pebble, the *default*
+// backend. The bulk profile-assign endpoint accepted a nonexistent profile ID
+// and reported success for every item, writing assignments that point at
+// nothing; verified live on a Pebble store before this was fixed.
+//
+// It is easy for a test to miss: the webserver profile tests configure SQLite,
+// so they exercise the one backend where the naive check happens to work.
+//
+// Normalising here rather than changing PebbleStore keeps the blast radius to
+// the callers that ask this question. GetMediaProfile returns
+// GetLanguageProfile's result directly, so making Pebble return an error would
+// change what a dangling assignment looks like to several unrelated callers.
+func ProfileMissing(profile *LanguageProfile, err error) bool {
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	return err == nil && profile == nil
+}

--- a/pkg/webserver/profiles.go
+++ b/pkg/webserver/profiles.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/profiles.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 0a9b8c7d-6e5f-1a2b-4c3d-7e6f8a9b0c1d
 // last-edited: 2026-08-04
 
@@ -151,12 +151,12 @@ func handleGetProfile(w http.ResponseWriter, r *http.Request, db *sql.DB, profil
 	}
 
 	profile, err := store.GetLanguageProfile(profileID)
+	if database.ProfileMissing(profile, err) {
+		http.Error(w, "Profile not found", http.StatusNotFound)
+		return
+	}
 	if err != nil {
-		if err == sql.ErrNoRows {
-			http.Error(w, "Profile not found", http.StatusNotFound)
-		} else {
-			http.Error(w, "Failed to get profile", http.StatusInternalServerError)
-		}
+		http.Error(w, "Failed to get profile", http.StatusInternalServerError)
 		return
 	}
 
@@ -354,14 +354,15 @@ func handleAssignMediaProfile(w http.ResponseWriter, r *http.Request, db *sql.DB
 		return
 	}
 
-	// Verify profile exists
-	_, err = store.GetLanguageProfile(request.ProfileID)
+	// Verify profile exists. See database.ProfileMissing: Pebble signals a miss
+	// with (nil, nil), so checking only the error accepts unknown IDs there.
+	profile, err := store.GetLanguageProfile(request.ProfileID)
+	if database.ProfileMissing(profile, err) {
+		http.Error(w, "Profile not found", http.StatusNotFound)
+		return
+	}
 	if err != nil {
-		if err == sql.ErrNoRows {
-			http.Error(w, "Profile not found", http.StatusNotFound)
-		} else {
-			http.Error(w, "Failed to verify profile", http.StatusInternalServerError)
-		}
+		http.Error(w, "Failed to verify profile", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/webserver/profiles_bulk.go
+++ b/pkg/webserver/profiles_bulk.go
@@ -1,5 +1,5 @@
 // file: pkg/webserver/profiles_bulk.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5f2c1a7e-9b34-4d68-a0e1-3c7d92f45b18
 // last-edited: 2026-08-04
 
@@ -112,12 +112,18 @@ func bulkMediaProfilesHandler(db *sql.DB) http.Handler {
 		// errors would bury a single fixable mistake in a results array.
 		clearing := req.ProfileID == ""
 		if !clearing {
-			if _, err := store.GetLanguageProfile(req.ProfileID); err != nil {
-				if err == sql.ErrNoRows {
-					http.Error(w, "Profile not found", http.StatusNotFound)
-				} else {
-					http.Error(w, "Failed to verify profile", http.StatusInternalServerError)
-				}
+			// database.ProfileMissing rather than "err != nil": PebbleStore
+			// returns (nil, nil) for an unknown ID while the SQL backends
+			// return sql.ErrNoRows, so the naive check passed on Pebble — the
+			// default backend — and wrote assignments pointing at nothing while
+			// reporting every one as succeeded.
+			profile, err := store.GetLanguageProfile(req.ProfileID)
+			if database.ProfileMissing(profile, err) {
+				http.Error(w, "Profile not found", http.StatusNotFound)
+				return
+			}
+			if err != nil {
+				http.Error(w, "Failed to verify profile", http.StatusInternalServerError)
 				return
 			}
 		}

--- a/pkg/webserver/profiles_bulk_pebble_test.go
+++ b/pkg/webserver/profiles_bulk_pebble_test.go
@@ -1,0 +1,112 @@
+// file: pkg/webserver/profiles_bulk_pebble_test.go
+// version: 1.0.0
+// guid: e5c81b40-93a7-4d62-a018-27f6b4c5309e
+// last-edited: 2026-08-04
+
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// usePebbleProfileStore points the profile handlers at a throwaway Pebble store.
+//
+// The existing profile tests configure SQLite, which is exactly why the bug this
+// file covers survived them: SQLStore reports a missing profile with
+// sql.ErrNoRows, so an "err != nil means not found" check happens to work there.
+// PebbleStore returns (nil, nil) instead — and Pebble is the default backend.
+func usePebbleProfileStore(t *testing.T) {
+	t.Helper()
+	prevBackend := viper.GetString("db_backend")
+	prevPath := viper.GetString("db_path")
+	t.Cleanup(func() {
+		viper.Set("db_backend", prevBackend)
+		viper.Set("db_path", prevPath)
+	})
+	viper.Set("db_backend", "pebble")
+	viper.Set("db_path", filepath.Join(t.TempDir(), "db"))
+}
+
+// TestBulkRejectsUnknownProfileOnPebble is the regression.
+//
+// Verified live against a running server on a Pebble store: POST with
+// profile_id "does-not-exist" returned 200 and {"succeeded":1,"failed":0},
+// writing an assignment that pointed at no profile. The validation was there
+// and had a test — the test just ran on the one backend where the check works.
+func TestBulkRejectsUnknownProfileOnPebble(t *testing.T) {
+	usePebbleProfileStore(t)
+
+	body, err := json.Marshal(bulkProfileRequest{
+		ProfileID: "does-not-exist",
+		MediaIDs:  []string{"/media/Show/ep1.mkv"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	bulkMediaProfilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/api/media/profiles/bulk", bytes.NewReader(body)))
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("got %d (body: %s), want 404; an unknown profile must never be assigned",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestBulkAcceptsKnownProfileOnPebble is the control: without it, a fix that
+// rejected everything would look correct.
+func TestBulkAcceptsKnownProfileOnPebble(t *testing.T) {
+	usePebbleProfileStore(t)
+
+	id := createTestProfile(t, "pebble-profile", "en")
+
+	body, err := json.Marshal(bulkProfileRequest{
+		ProfileID: id,
+		MediaIDs:  []string{"/media/Show/ep1.mkv", "/media/Show/ep2.mkv"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	bulkMediaProfilesHandler(nil).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/api/media/profiles/bulk", bytes.NewReader(body)))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d (body: %s), want 200", rr.Code, rr.Body.String())
+	}
+	var resp bulkProfileResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Succeeded != 2 || resp.Failed != 0 {
+		t.Errorf("succeeded=%d failed=%d, want 2/0", resp.Succeeded, resp.Failed)
+	}
+}
+
+// TestSingleAssignRejectsUnknownProfileOnPebble covers the same divergence on
+// the single-item route, which had the identical check.
+func TestSingleAssignRejectsUnknownProfileOnPebble(t *testing.T) {
+	usePebbleProfileStore(t)
+
+	body := []byte(`{"profile_id":"does-not-exist"}`)
+	mux, _, err := newMux(nil)
+	if err != nil {
+		t.Fatalf("newMux: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPut, mediaProfileURL("/media/Show/ep1.mkv"), bytes.NewReader(body)))
+
+	if rr.Code == http.StatusOK || rr.Code == http.StatusNoContent {
+		t.Fatalf("got %d; an unknown profile must not be assigned", rr.Code)
+	}
+}


### PR DESCRIPTION
**This is a bug in what I shipped earlier today (#2238), found by driving a
running server rather than by the test suite.**

`POST /api/media/profiles/bulk` with a profile ID that does not exist returned:

```
HTTP 200  {"profile_id":"does-not-exist","succeeded":1,"failed":0,...}
```

That is exactly the silent corruption the up-front validation was added to
prevent — and it *had* a test, which I even break-tested. The test just ran on
SQLite.

## Root cause

`GetLanguageProfile` signals "no such profile" differently per backend, and
nothing in the interface said so:

| backend | miss looks like |
|---|---|
| `SQLStore` / `PostgresStore` | `(nil, sql.ErrNoRows)` |
| `PebbleStore` | `(nil, nil)` |

Every caller was written against the SQL behaviour — *an error means not
found* — which silently accepts unknown IDs on Pebble. **Pebble is the default
backend** (`cmd/root.go` sets `db_backend: pebble`), so this is what most
installs actually do.

The same check appears in four more places: the single-item assign route, the
profile GET route, and both `subtitle-manager profiles` subcommands.

## The fix

`database.ProfileMissing(profile, err)` encodes the divergence in one place and
every caller asks it.

I deliberately did **not** change `PebbleStore` to return an error instead.
`GetMediaProfile` returns `GetLanguageProfile`'s result directly, so that would
change what a *dangling assignment* looks like to several unrelated callers —
a much wider blast radius than the question being asked here.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...` all clean.

Three new tests that run **against Pebble specifically**, because that is the
gap the existing SQLite-configured tests leave. Reverting the check reproduces
the live symptom exactly:

```
got 200 (body: {"profile_id":"does-not-exist","succeeded":1,"failed":0,...})
```

`TestBulkAcceptsKnownProfileOnPebble` is the control — without it, a fix that
rejected everything would look correct.

## Worth noting for future work

This is the second time today a backend divergence hid behind a green suite (the
first was `GetDefaultLanguageProfile` creating rows on Pebble but not on SQL, in
#2239). The profile tests defaulting to SQLite while the product defaults to
Pebble is a structural gap, not bad luck — running the whole `pkg/webserver`
profile suite against both backends would be a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3