### PR TITLE
fix(opensubtitles): perform the real v1 download handshake

### DIFF
--- a/changelog.d/20260804-opensubtitles-download-flow.md
+++ b/changelog.d/20260804-opensubtitles-download-flow.md
@@ -1,0 +1,30 @@
+### Fixed
+
+#### OpenSubtitles downloads now actually work
+
+The client could search but never download. Three separate defects on the
+download path, all confirmed against the published REST v1 contract rather than
+inferred:
+
+- **The download step skipped the API's handshake.** It issued
+  `GET {api}/download?file_id=...` and returned that response body verbatim. The
+  v1 API does not serve subtitles from `/download`: it takes `POST /download`
+  with a JSON body `{"file_id": N}` and answers with `{"link": "..."}`, which the
+  caller then fetches. What landed on disk was the JSON envelope at best.
+- **The wrong identifier was sent.** The file id lives at
+  `attributes.files[].file_id`; the client used `attributes.subtitle_id`. Those
+  are different values, so even a correct request would have asked for a file
+  that does not exist.
+- **The `Api-Key` header was never sent.** The v1 API requires it alongside the
+  bearer token. `opensubtitles.api_key` was read by the CLI and then never
+  given to the client, which set the header to the empty string on login and
+  omitted it everywhere else.
+
+Quota exhaustion is now reported as an error too. A depleted account answers
+`200` with a message and no link, which the old code would have written to the
+media directory as if it were a subtitle.
+
+The existing tests hid all of this: the mock served the file directly from
+`GET /download`, so it modelled a protocol nothing speaks, and the
+`FetchByResult` test set only `subtitle_id`. Both are corrected, and the new
+mock rejects anything that departs from the documented contract.

--- a/pkg/providers/opensubtitles/download_flow_test.go
+++ b/pkg/providers/opensubtitles/download_flow_test.go
@@ -1,0 +1,183 @@
+// file: pkg/providers/opensubtitles/download_flow_test.go
+// version: 1.0.0
+// guid: 4c02e7b3-58a1-4d96-b7e2-1a05f39c684d
+// last-edited: 2026-08-04
+
+package opensubtitles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// strictV1 implements the download contract as documented, and rejects anything
+// else. That strictness is the point: the previous mock served the subtitle
+// directly from GET /download, so it passed against a client that never made
+// the POST the real API requires.
+//
+// Contract (OpenSubtitles REST API v1):
+//   - POST /download with JSON body {"file_id": N} -> {"link": "..."}
+//   - GET that link -> the subtitle bytes
+//   - Api-Key and Authorization headers on authenticated requests
+//   - file_id comes from attributes.files[].file_id, not attributes.subtitle_id
+type strictV1 struct {
+	mu       sync.Mutex
+	gotKey   string
+	gotAuth  string
+	gotBody  map[string]int
+	postSeen bool
+}
+
+func (s *strictV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/login":
+		fmt.Fprint(w, `{"token":"tok","status":"200"}`)
+
+	case strings.HasPrefix(r.URL.Path, "/subtitles"):
+		// subtitle_id and file_id deliberately differ, so a client reading the
+		// wrong field asks for a file that does not exist.
+		fmt.Fprint(w, `{"data":[{"attributes":{"subtitle_id":"999","release":"GROUP","files":[{"file_id":4242,"file_name":"s.srt"}]}}]}`)
+
+	case r.URL.Path == "/download":
+		if r.Method != http.MethodPost {
+			http.Error(w, "download requires POST", http.StatusMethodNotAllowed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]int
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			http.Error(w, "download requires a JSON body", http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		s.postSeen = true
+		s.gotBody = parsed
+		s.gotKey = r.Header.Get("Api-Key")
+		s.gotAuth = r.Header.Get("Authorization")
+		s.mu.Unlock()
+
+		if parsed["file_id"] != 4242 {
+			http.Error(w, "unknown file_id", http.StatusNotFound)
+			return
+		}
+		fmt.Fprintf(w, `{"link":"http://%s/cdn/s.srt","remaining":42}`, r.Host)
+
+	case r.URL.Path == "/cdn/s.srt":
+		fmt.Fprint(w, "1\n00:00:01,000 --> 00:00:02,000\nhello\n")
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func testMedia(t *testing.T) string {
+	t.Helper()
+	// At least 128 KiB: the OpenSubtitles hash reads 64 KiB from each end, so a
+	// smaller file fails before any request is made.
+	p := filepath.Join(t.TempDir(), "Movie.2020.mkv")
+	if err := os.WriteFile(p, make([]byte, 256*1024), 0644); err != nil {
+		t.Fatalf("create media: %v", err)
+	}
+	return p
+}
+
+// TestFetchFollowsTheDownloadLink is the regression. Before this, Fetch issued
+// GET /download?file_id=<subtitle_id> and returned that response body verbatim
+// — the JSON envelope at best, never a subtitle.
+func TestFetchFollowsTheDownloadLink(t *testing.T) {
+	h := &strictV1{}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("opensubtitles.api_url", srv.URL)
+	viper.Set("opensubtitles.username", "u")
+	viper.Set("opensubtitles.password", "p")
+	viper.Set("opensubtitles.api_key", "secret-key")
+
+	got, err := New("").Fetch(context.Background(), testMedia(t), "en")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if !strings.Contains(string(got), "hello") {
+		t.Fatalf("got %q, want the subtitle behind the download link", got)
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.postSeen {
+		t.Error("no POST /download was made")
+	}
+	// file_id, not subtitle_id: the mock returns 999 for the latter and 4242
+	// for the former, so reading the wrong field 404s.
+	if h.gotBody["file_id"] != 4242 {
+		t.Errorf("file_id = %d, want 4242 from attributes.files[].file_id", h.gotBody["file_id"])
+	}
+	if h.gotKey != "secret-key" {
+		t.Errorf("Api-Key header = %q, want the configured key", h.gotKey)
+	}
+	if h.gotAuth == "" {
+		t.Error("Authorization header missing")
+	}
+}
+
+// TestQuotaExhaustedIsReported covers the response a real account gets once its
+// daily allowance runs out: 200, a message, and no link. Returning that body as
+// if it were a subtitle would write a JSON file to the media directory.
+func TestQuotaExhaustedIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			fmt.Fprint(w, `{"token":"tok","status":"200"}`)
+			return
+		}
+		fmt.Fprint(w, `{"message":"You have downloaded your allowed subtitles for today","remaining":0}`)
+	}))
+	defer srv.Close()
+
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("opensubtitles.api_url", srv.URL)
+	viper.Set("opensubtitles.username", "u")
+	viper.Set("opensubtitles.password", "p")
+
+	c := New("")
+	_, err := c.resolveDownloadLink(context.Background(), 4242)
+	if err == nil {
+		t.Fatal("quota exhaustion was not reported as an error")
+	}
+	if !strings.Contains(err.Error(), "allowed subtitles") {
+		t.Errorf("error %q does not surface the API's message", err)
+	}
+}
+
+// TestFileIDPrefersFilesArray pins which field the id comes from.
+func TestFileIDPrefersFilesArray(t *testing.T) {
+	var r SearchResult
+	r.Attributes.SubtitleID = "999"
+	if _, ok := fileIDForResult(r); ok {
+		t.Error("returned an id with no files[]; subtitle_id is not a file id")
+	}
+
+	r.Attributes.Files = append(r.Attributes.Files, struct {
+		FileID   int    `json:"file_id"`
+		CDNumber int    `json:"cd_number"`
+		FileName string `json:"file_name"`
+	}{FileID: 4242, FileName: "s.srt"})
+
+	id, ok := fileIDForResult(r)
+	if !ok || id != 4242 {
+		t.Errorf("got (%d, %t), want (4242, true)", id, ok)
+	}
+}

--- a/pkg/providers/opensubtitles/opensubtitles.go
+++ b/pkg/providers/opensubtitles/opensubtitles.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/opensubtitles/opensubtitles.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5af27051-d855-4321-9990-c4a59eaabbd5
 // last-edited: 2026-08-04
 
@@ -111,7 +111,11 @@ type Client struct {
 	// APIURL allows overriding the REST endpoint, mainly for testing.
 	APIURL string
 	// UserAgent identifies this application to the OpenSubtitles API.
-	UserAgent  string
+	UserAgent string
+	// APIKey is sent as the Api-Key header. The v1 API requires it on every
+	// request alongside the bearer token; it was previously read from config by
+	// the CLI and then never given to the client.
+	APIKey     string
 	HTTPClient *http.Client
 
 	// Authentication
@@ -136,6 +140,7 @@ func New(_ string) *Client {
 	return &Client{
 		APIURL:     apiURL,
 		UserAgent:  ua,
+		APIKey:     viper.GetString("opensubtitles.api_key"),
 		HTTPClient: &http.Client{Timeout: 15 * time.Second},
 		username:   username,
 		password:   password,
@@ -191,13 +196,14 @@ func resolveAPIURL(configured string) string {
 // and quietly rewrites config for every other component besides.
 //
 // Empty values fall back to the same defaults New() uses.
-func NewWithCredentials(apiURL, userAgent, username, password string) *Client {
+func NewWithCredentials(apiURL, userAgent, username, password, apiKey string) *Client {
 	if userAgent == "" {
 		userAgent = "subtitle-manager v1.0"
 	}
 	return &Client{
 		APIURL:     resolveAPIURL(apiURL),
 		UserAgent:  userAgent,
+		APIKey:     apiKey,
 		HTTPClient: &http.Client{Timeout: 15 * time.Second},
 		username:   username,
 		password:   password,
@@ -227,7 +233,7 @@ func (c *Client) login(ctx context.Context) error {
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Set("Api-Key", "") // Empty API key for username/password login
+	req.Header.Set("Api-Key", c.APIKey)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -427,36 +433,33 @@ func (c *Client) SearchWithResults(ctx context.Context, mediaPath, lang string) 
 }
 
 // Fetch downloads the first matching subtitle for mediaPath in lang.
+//
+// It goes through SearchWithResults rather than Search because the download
+// step needs attributes.files[].file_id, which the []string form throws away.
 func (c *Client) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
-	urls, err := c.Search(ctx, mediaPath, lang)
+	results, err := c.SearchWithResults(ctx, mediaPath, lang)
 	if err != nil {
 		return nil, err
 	}
-	if len(urls) == 0 {
+	if len(results) == 0 {
 		return nil, fmt.Errorf("no subtitles found")
 	}
-	return c.download(ctx, urls[0])
-}
-
-// downloadURLForResult builds the download URL for a specific search result,
-// mirroring the construction used by Search. It returns "" when the result
-// carries no subtitle identifier.
-func (c *Client) downloadURLForResult(result SearchResult) string {
-	if result.Attributes.SubtitleID == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/download?file_id=%s", c.APIURL, result.Attributes.SubtitleID)
+	return c.FetchByResult(ctx, results[0])
 }
 
 // FetchByResult downloads the subtitle for a specific search result rather than
 // the first match. This is what lets a caller score candidates and then
 // download the selected best one.
 func (c *Client) FetchByResult(ctx context.Context, result SearchResult) ([]byte, error) {
-	url := c.downloadURLForResult(result)
-	if url == "" {
-		return nil, fmt.Errorf("search result has no downloadable subtitle id")
+	fileID, ok := fileIDForResult(result)
+	if !ok {
+		return nil, fmt.Errorf("search result has no downloadable file id")
 	}
-	return c.download(ctx, url)
+	link, err := c.resolveDownloadLink(ctx, fileID)
+	if err != nil {
+		return nil, err
+	}
+	return c.download(ctx, link)
 }
 
 // download performs an authenticated GET of a subtitle download URL and returns
@@ -479,4 +482,89 @@ func (c *Client) download(ctx context.Context, url string) ([]byte, error) {
 	}
 
 	return io.ReadAll(resp.Body)
+}
+
+// setAuthHeaders applies the headers every authenticated v1 request needs.
+//
+// The API requires Api-Key *and* Authorization together; the client previously
+// sent only the bearer token, and set Api-Key to the empty string on login.
+func (c *Client) setAuthHeaders(req *http.Request, token string) {
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		req.Header.Set("Api-Key", c.APIKey)
+	}
+}
+
+// fileIDForResult returns the identifier the download endpoint expects.
+//
+// It comes from attributes.files[].file_id, NOT attributes.subtitle_id — those
+// are different values, and the client used to send the latter. A subtitle can
+// span several files (multi-CD releases); the first is the one to fetch.
+func fileIDForResult(result SearchResult) (int, bool) {
+	for _, f := range result.Attributes.Files {
+		if f.FileID != 0 {
+			return f.FileID, true
+		}
+	}
+	return 0, false
+}
+
+// resolveDownloadLink exchanges a file ID for a time-limited download URL.
+//
+// This is the step that was missing entirely. The v1 API does not serve the
+// subtitle from /download: it takes POST /download with a JSON body
+// {"file_id": N} and answers with {"link": "..."} plus the caller's remaining
+// quota. The client instead issued GET /download?file_id=... and returned that
+// response body verbatim, which is the JSON envelope on a good day and an error
+// page otherwise — never a subtitle.
+//
+// Each call consumes one download from the account's daily allowance, which is
+// why the link is resolved for the single chosen result rather than for every
+// search hit.
+func (c *Client) resolveDownloadLink(ctx context.Context, fileID int) (string, error) {
+	token, err := c.getToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("authentication failed: %w", err)
+	}
+
+	payload, err := json.Marshal(map[string]int{"file_id": fileID})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.APIURL+"/download", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	c.setAuthHeaders(req, token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var dr DownloadResponse
+	if err := json.Unmarshal(body, &dr); err != nil {
+		return "", fmt.Errorf("decoding download response: %w", err)
+	}
+	if dr.Link == "" {
+		// A quota-exhausted account answers 200 with a message and no link, so
+		// this is a normal condition to report clearly rather than a parse bug.
+		if dr.Message != "" {
+			return "", fmt.Errorf("no download link returned: %s", dr.Message)
+		}
+		return "", fmt.Errorf("no download link returned")
+	}
+	return dr.Link, nil
 }

--- a/pkg/providers/opensubtitles/opensubtitles_test.go
+++ b/pkg/providers/opensubtitles/opensubtitles_test.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/opensubtitles/opensubtitles_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6bd3fcef-66ea-425f-be25-cbcea87859fe
 // last-edited: 2026-08-04
 
@@ -105,8 +105,17 @@ func TestFetchByResult(t *testing.T) {
 	c.APIURL = srv.URL
 	c.HTTPClient = srv.Client()
 
+	// The download id comes from attributes.files[].file_id. This test used to
+	// set only attributes.subtitle_id, which encoded the very assumption that
+	// was wrong — they are different values, and the API 404s on the latter.
 	var result SearchResult
 	result.Attributes.SubtitleID = "42"
+	result.Attributes.Files = append(result.Attributes.Files, struct {
+		FileID   int    `json:"file_id"`
+		CDNumber int    `json:"cd_number"`
+		FileName string `json:"file_name"`
+	}{FileID: 42, FileName: "s.srt"})
+
 	data, err := c.FetchByResult(context.Background(), result)
 	if err != nil {
 		t.Fatalf("fetch by result error: %v", err)
@@ -115,9 +124,9 @@ func TestFetchByResult(t *testing.T) {
 		t.Fatalf("unexpected data: %s", data)
 	}
 
-	// A result with no subtitle id cannot be downloaded.
+	// A result with no file id cannot be downloaded.
 	if _, err := c.FetchByResult(context.Background(), SearchResult{}); err == nil {
-		t.Fatal("expected error for result with no subtitle id")
+		t.Fatal("expected error for result with no file id")
 	}
 }
 

--- a/pkg/providers/opensubtitlescom/opensubtitlescom.go
+++ b/pkg/providers/opensubtitlescom/opensubtitlescom.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/opensubtitlescom/opensubtitlescom.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 7d3a0c58-2e91-4b46-a5f0-91c48e7d2b03
 // last-edited: 2026-08-04
 
@@ -52,6 +52,7 @@ func New() *Client {
 		pick("user_agent"),
 		pick("username"),
 		pick("password"),
+		pick("api_key"),
 	)}
 }
 


### PR DESCRIPTION
**This is the fix that makes subtitle downloading actually work.** The client
could search fine; it could never download. Three separate defects, each
confirmed against the published REST v1 contract rather than inferred from
behaviour.

## 1. The download step skipped the handshake

It issued `GET {api}/download?file_id=...` and returned that response body
verbatim. The v1 API does not serve subtitles from `/download` — it takes
`POST /download` with a JSON body `{"file_id": N}` and answers with
`{"link": "..."}`, which the caller then fetches. What reached disk was the JSON
envelope on a good day and an error page otherwise.

## 2. The wrong identifier was sent

The file id lives at `attributes.files[].file_id`. The client used
`attributes.subtitle_id`. **Those are different values** — so even a
correctly-shaped request asked for a file that does not exist. A subtitle can
also span several files (multi-CD releases), which `subtitle_id` cannot express.

## 3. The `Api-Key` header was never sent

The v1 API requires it *alongside* the bearer token.
`opensubtitles.api_key` was read by the CLI (`cmd/fetch.go`,
`cmd/fetch_scored.go`) and then never handed to the client, which set the header
to the empty string on login and omitted it everywhere else.

## Also

Quota exhaustion is now reported as an error. A depleted account answers `200`
with a message and **no link** — the old code would have written that JSON into
the media directory as if it were a subtitle.

## Why the tests didn't catch any of it

The mock served the file directly from `GET /download`, so it modelled a
protocol nothing speaks — the same vacuous-mock shape as the `opensubtitlescom`
stub in #2248. And `TestFetchByResult` set only `subtitle_id`, encoding the very
assumption that was wrong.

Both are corrected. The new mock is **strict**: it rejects a non-POST
`/download`, a missing JSON body, and a `file_id` that doesn't match the one in
`files[]` — and it deliberately returns *different* values for `subtitle_id`
(999) and `file_id` (4242) so reading the wrong field 404s.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...`, and
`go test -race ./pkg/providers/... ./pkg/scanner/` all clean.

Non-vacuity: each defect was reintroduced separately and fails with its own
distinct message —

| reverted behaviour | failure |
|---|---|
| read `subtitle_id` | `download request failed with status 404: unknown file_id` |
| skip the POST, GET the URL | `file download failed with status 405` |
| drop the `Api-Key` header | `Api-Key header = "", want the configured key` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3