### PR TITLE
fix(providers): report why a search failed instead of a bare "no subtitle found"

### DIFF
--- a/changelog.d/20260804-surface-provider-error.md
+++ b/changelog.d/20260804-surface-provider-error.md
@@ -1,0 +1,17 @@
+### Fixed
+
+#### Failed searches now say why
+
+`FetchFromAll` computed the last provider error, used it for the failure event,
+and then discarded it — returning a bare `no subtitle found` for every cause. A
+dead host, a malformed response and "this provider has no credentials
+configured" were indistinguishable, and the last of those is the only one an
+operator can act on.
+
+The underlying error is now wrapped, keeping the familiar prefix so anything
+matching on it still works:
+
+    no subtitle found: opensubtitles: authentication failed: ...
+
+Found while checking why a real `fetch` produced nothing: OpenSubtitles was
+entirely unconfigured, and the tool had no way of saying so.

--- a/pkg/providers/multi.go
+++ b/pkg/providers/multi.go
@@ -1,7 +1,7 @@
 // file: pkg/providers/multi.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 2f8c1a05-6d43-4b79-9e20-3a7c5d8b0164
-// last-edited: 2026-07-30
+// last-edited: 2026-08-04
 
 package providers
 
@@ -167,6 +167,15 @@ func fetchFromInstances(ctx context.Context, insts []Instance, mediaPath, lang, 
 		})
 	}
 
+	// Carry the last provider error rather than discarding it. It was already
+	// computed for the failure event two lines up and then thrown away, so the
+	// CLI and the UI reported a bare "no subtitle found" for every cause —
+	// including "this provider has no credentials configured", which is the one
+	// the operator can actually act on. The prefix is kept so existing callers
+	// and tests that match on it still do.
+	if lastError != nil {
+		return nil, "", fmt.Errorf("no subtitle found: %w", lastError)
+	}
 	return nil, "", fmt.Errorf("no subtitle found")
 }
 

--- a/pkg/providers/multi_test.go
+++ b/pkg/providers/multi_test.go
@@ -1,14 +1,16 @@
 // file: pkg/providers/multi_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 6b1e9c04-8a37-4d52-9f60-2c5d0a7b3841
-// last-edited: 2026-07-30
+// last-edited: 2026-08-04
 
 package providers
 
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -479,4 +481,37 @@ func TestSearchFailedEmissionIsUnchanged(t *testing.T) {
 				"a full library scan would fire one webhook per file", got)
 		}
 	})
+}
+
+// TestFetchFromAllSurfacesProviderError pins that the reason a fetch failed
+// reaches the caller.
+//
+// The last provider error was computed for the failure event and then discarded,
+// so every cause — a dead host, a bad response, or "this provider has no
+// credentials configured" — arrived as a bare "no subtitle found". The last of
+// those is the one an operator can act on, and it was exactly the message
+// missing when OpenSubtitles was unconfigured.
+func TestFetchFromAllSurfacesProviderError(t *testing.T) {
+	prev := ListInstances()
+	t.Cleanup(func() { SetInstances(prev) })
+
+	RegisterFactory("errtest", func() Provider { return failingProvider{} })
+	SetInstances([]Instance{{ID: "errtest", Name: "errtest", Enabled: true}})
+
+	_, _, err := FetchFromAll(context.Background(), "/media/movie.mkv", "en", "")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "no subtitle found") {
+		t.Errorf("error %q lost the familiar prefix", err)
+	}
+	if !strings.Contains(err.Error(), "credentials not configured") {
+		t.Errorf("error %q does not surface the provider's reason", err)
+	}
+}
+
+type failingProvider struct{}
+
+func (failingProvider) Fetch(ctx context.Context, mediaPath, lang string) ([]byte, error) {
+	return nil, errors.New("credentials not configured")
 }


### PR DESCRIPTION
Found while running a real `fetch` to check the download fix: it printed

```
level=fatal msg="no subtitle found"
```

when the actual cause was that OpenSubtitles had **no credentials configured at
all**. The tool had no way of saying so.

`FetchFromAll` computes `lastError`, uses it for the failure event — and then
discards it on the very next line, returning a bare `no subtitle found`. So a
dead host, a malformed response, and "this provider is unconfigured" were
indistinguishable, and the last is the only one an operator can act on.

The error is now wrapped:

```
no subtitle found: opensubtitles: authentication failed: ...
```

The prefix is kept deliberately, so the callers and tests that match on it
(`podnapisi_test.go` does) are unaffected.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...` all clean.

One new test using a provider that fails with a known reason. Non-vacuity:
discarding `lastError` again fails it with
`error "no subtitle found" does not surface the provider's reason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3