### PR TITLE
fix(opensubtitles): read the credentials a Bazarr import actually writes

### DIFF
--- a/changelog.d/20260804-opensubtitles-provider-keys.md
+++ b/changelog.d/20260804-opensubtitles-provider-keys.md
@@ -1,0 +1,15 @@
+### Fixed
+
+#### Bazarr-imported OpenSubtitles credentials are actually used
+
+The Bazarr importer writes provider credentials under
+`providers.opensubtitles.username` / `.password` / `.api_key`
+(`pkg/bazarr.mapProviderSettings`), but the OpenSubtitles client only ever read
+the top-level `opensubtitles.*` spelling. Importing a Bazarr config — the
+documented way to migrate — therefore produced a config with a username and
+password sitting in it that nothing read, and the provider stayed
+unauthenticated with no indication why. Confirmed on a real imported config.
+
+The client now reads `opensubtitles.<key>` and falls back to
+`providers.opensubtitles.<key>`. The top-level spelling wins, so a config that
+already works cannot be changed by the fallback.

--- a/pkg/providers/opensubtitles/download_flow_test.go
+++ b/pkg/providers/opensubtitles/download_flow_test.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/opensubtitles/download_flow_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c02e7b3-58a1-4d96-b7e2-1a05f39c684d
 // last-edited: 2026-08-04
 
@@ -179,5 +179,43 @@ func TestFileIDPrefersFilesArray(t *testing.T) {
 	id, ok := fileIDForResult(r)
 	if !ok || id != 4242 {
 		t.Errorf("got (%d, %t), want (4242, true)", id, ok)
+	}
+}
+
+// TestBazarrImportedCredentialsAreUsed pins the fallback that makes an imported
+// config work.
+//
+// pkg/bazarr.mapProviderSettings writes credentials under
+// providers.opensubtitles.*, while this client only ever read the top-level
+// opensubtitles.* spelling. Importing a Bazarr config — the documented
+// migration path — therefore produced a config containing a username and
+// password that nothing read, leaving the provider unauthenticated with no
+// indication why. Confirmed on a real imported config before this was fixed.
+func TestBazarrImportedCredentialsAreUsed(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("providers.opensubtitles.username", "imported-user")
+	viper.Set("providers.opensubtitles.password", "imported-pass")
+	viper.Set("providers.opensubtitles.api_key", "imported-key")
+
+	c := New("")
+	if c.username != "imported-user" || c.password != "imported-pass" {
+		t.Errorf("credentials not adopted: username=%q", c.username)
+	}
+	if c.APIKey != "imported-key" {
+		t.Errorf("APIKey = %q, want the imported key", c.APIKey)
+	}
+}
+
+// TestTopLevelCredentialsWin is the control: the fallback must never override a
+// config that already works.
+func TestTopLevelCredentialsWin(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("opensubtitles.username", "primary")
+	viper.Set("providers.opensubtitles.username", "imported")
+
+	if got := New("").username; got != "primary" {
+		t.Errorf("username = %q, want the top-level value", got)
 	}
 }

--- a/pkg/providers/opensubtitles/opensubtitles.go
+++ b/pkg/providers/opensubtitles/opensubtitles.go
@@ -1,5 +1,5 @@
 // file: pkg/providers/opensubtitles/opensubtitles.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5af27051-d855-4321-9990-c4a59eaabbd5
 // last-edited: 2026-08-04
 
@@ -126,25 +126,41 @@ type Client struct {
 	tokenExp time.Time
 }
 
-// New returns a new Client configured with username/password from viper config.
+// New returns a new Client configured from viper.
+//
+// Settings are read from opensubtitles.<key>, falling back to
+// providers.opensubtitles.<key>.
+//
+// The fallback is not cosmetic: the Bazarr importer writes credentials under
+// providers.opensubtitles.* (see pkg/bazarr.mapProviderSettings), while this
+// client only ever read the top-level spelling. So importing a Bazarr config —
+// the documented way to migrate — produced a config with a username and
+// password sitting in it that nothing read, and the provider stayed
+// unauthenticated with no indication why. Confirmed on a real imported config.
 func New(_ string) *Client {
-	apiURL := resolveAPIURL(viper.GetString("opensubtitles.api_url"))
-	ua := viper.GetString("opensubtitles.user_agent")
+	ua := providerSetting("user_agent")
 	if ua == "" {
 		ua = "subtitle-manager v1.0"
 	}
 
-	username := viper.GetString("opensubtitles.username")
-	password := viper.GetString("opensubtitles.password")
-
 	return &Client{
-		APIURL:     apiURL,
+		APIURL:     resolveAPIURL(providerSetting("api_url")),
 		UserAgent:  ua,
-		APIKey:     viper.GetString("opensubtitles.api_key"),
+		APIKey:     providerSetting("api_key"),
 		HTTPClient: &http.Client{Timeout: 15 * time.Second},
-		username:   username,
-		password:   password,
+		username:   providerSetting("username"),
+		password:   providerSetting("password"),
 	}
+}
+
+// providerSetting reads opensubtitles.<key>, falling back to
+// providers.opensubtitles.<key>. The top-level spelling wins so an existing
+// working config cannot be changed by the fallback.
+func providerSetting(key string) string {
+	if v := viper.GetString("opensubtitles." + key); v != "" {
+		return v
+	}
+	return viper.GetString("providers.opensubtitles." + key)
 }
 
 // DefaultAPIURL is the OpenSubtitles.com REST v1 base this client speaks.


### PR DESCRIPTION
**This is the last thing standing between a Bazarr-imported config and working
downloads**, and it's the same "settings that nothing reads" shape as the
notifications bug and the *arr config split.

`pkg/bazarr.mapProviderSettings` writes provider credentials under:

```
providers.opensubtitles.username
providers.opensubtitles.password
providers.opensubtitles.api_key
```

The client only ever read the **top-level** `opensubtitles.*` spelling. So
importing a Bazarr config — the documented migration path — produced a config
with a username and password sitting in it that **nothing read**, and the
provider stayed unauthenticated with no indication why.

Confirmed on a real imported config: `providers.opensubtitles.username` (24
chars) and `.password` (20 chars) present and unused, while
`opensubtitles.username` did not exist at all.

## The fix

`providerSetting(key)` reads `opensubtitles.<key>` and falls back to
`providers.opensubtitles.<key>`. The top-level spelling wins, so a config that
already works cannot be changed by the fallback —
`TestTopLevelCredentialsWin` pins that.

This mirrors what #2248 did for `providers.opensubtitlescom.*`; the two
spellings now behave consistently.

## Testing

`go build ./...`, `go test ./...`, `go test -tags sqlite ./...` all clean.

Non-vacuity: dropping the fallback fails `TestBazarrImportedCredentialsAreUsed`
with `credentials not adopted: username=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159DYJ5vsZTUad1NWPwpKY3